### PR TITLE
feat(backend): Auth & User Profile API (T-105)

### DIFF
--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -1,0 +1,7 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient({
+  log: process.env.NODE_ENV === 'development' ? ['query', 'warn', 'error'] : ['error'],
+});
+
+export default prisma;

--- a/backend/src/config/jwt.ts
+++ b/backend/src/config/jwt.ts
@@ -1,0 +1,9 @@
+import type { SignOptions } from 'jsonwebtoken';
+
+export const jwtConfig: {
+  secret: string;
+  expiresIn: SignOptions['expiresIn'];
+} = {
+  secret: process.env.JWT_SECRET || 'dev-secret-do-not-use-in-production',
+  expiresIn: '7d',
+};

--- a/backend/src/controllers/authController.test.ts
+++ b/backend/src/controllers/authController.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import app from '../app';
+
+// Mock Prisma
+vi.mock('../config/database', () => {
+  const users: Record<string, {
+    id: string;
+    name: string;
+    email: string;
+    passwordHash: string;
+    persona: string;
+    aiEngine: string;
+    monthlyBudget: number;
+    currency: string;
+    createdAt: Date;
+    updatedAt: Date;
+  }> = {};
+
+  return {
+    default: {
+      user: {
+        findUnique: vi.fn(async ({ where }: { where: { email?: string; id?: string } }) => {
+          if (where.email) {
+            return Object.values(users).find((u) => u.email === where.email) || null;
+          }
+          if (where.id) {
+            return users[where.id] || null;
+          }
+          return null;
+        }),
+        create: vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
+          const id = `user-${Date.now()}-${Math.random().toString(36).substr(2, 5)}`;
+          const user = {
+            id,
+            name: data.name as string,
+            email: data.email as string,
+            passwordHash: data.passwordHash as string,
+            persona: 'gentle',
+            aiEngine: 'gemini',
+            monthlyBudget: 30000,
+            currency: 'TWD',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          };
+          users[id] = user;
+          return user;
+        }),
+      },
+      // Store reference so tests can clear it
+      _users: users,
+    },
+  };
+});
+
+// Mock bcrypt
+vi.mock('bcrypt', () => ({
+  default: {
+    hash: vi.fn(async (password: string) => `hashed_${password}`),
+    compare: vi.fn(async (password: string, hash: string) => hash === `hashed_${password}`),
+  },
+}));
+
+beforeEach(() => {
+  // Clear user store before each test (access via dynamic import)
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('POST /api/v1/auth/register', () => {
+  it('should register a new user successfully', async () => {
+    const res = await request(app)
+      .post('/api/v1/auth/register')
+      .send({
+        name: 'Test User',
+        email: `test-${Date.now()}@example.com`,
+        password: 'password123',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.code).toBe(201);
+    expect(res.body.message).toBe('註冊成功');
+    expect(res.body.data.user).toBeDefined();
+    expect(res.body.data.user.name).toBe('Test User');
+    expect(res.body.data.user.persona).toBe('gentle');
+    expect(res.body.data.user.ai_engine).toBe('gemini');
+    expect(res.body.data.user.monthly_budget).toBe(30000);
+    expect(res.body.data.token).toBeDefined();
+    expect(res.body.data.user.password_hash).toBeUndefined();
+    expect(res.body.timestamp).toBeDefined();
+  });
+
+  it('should return 409 for duplicate email', async () => {
+    const email = `dup-${Date.now()}@example.com`;
+
+    // First registration
+    await request(app)
+      .post('/api/v1/auth/register')
+      .send({ name: 'User 1', email, password: 'password123' });
+
+    // Second registration with same email
+    const res = await request(app)
+      .post('/api/v1/auth/register')
+      .send({ name: 'User 2', email, password: 'password456' });
+
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe(409);
+    expect(res.body.message).toBe('此 Email 已被註冊');
+  });
+
+  it('should return 400 for invalid email format', async () => {
+    const res = await request(app)
+      .post('/api/v1/auth/register')
+      .send({ name: 'Test', email: 'not-an-email', password: 'password123' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe(400);
+    expect(res.body.errors).toBeDefined();
+  });
+
+  it('should return 400 for short password', async () => {
+    const res = await request(app)
+      .post('/api/v1/auth/register')
+      .send({ name: 'Test', email: 'test@example.com', password: '123' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe(400);
+  });
+
+  it('should return 400 for missing fields', async () => {
+    const res = await request(app)
+      .post('/api/v1/auth/register')
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe(400);
+  });
+});
+
+describe('POST /api/v1/auth/login', () => {
+  const testEmail = `login-test-${Date.now()}@example.com`;
+
+  beforeEach(async () => {
+    // Register a user first
+    await request(app)
+      .post('/api/v1/auth/register')
+      .send({ name: 'Login User', email: testEmail, password: 'password123' });
+  });
+
+  it('should login successfully with correct credentials', async () => {
+    const res = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email: testEmail, password: 'password123' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.code).toBe(200);
+    expect(res.body.message).toBe('登入成功');
+    expect(res.body.data.user).toBeDefined();
+    expect(res.body.data.user.email).toBe(testEmail);
+    expect(res.body.data.token).toBeDefined();
+  });
+
+  it('should return 401 for wrong password', async () => {
+    const res = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email: testEmail, password: 'wrongpassword' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe(401);
+    expect(res.body.message).toBe('Email 或密碼錯誤');
+  });
+
+  it('should return 401 for non-existent email', async () => {
+    const res = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email: 'nonexistent@example.com', password: 'password123' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe(401);
+  });
+
+  it('should return 400 for invalid email format', async () => {
+    const res = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email: 'not-email', password: 'password123' });
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -1,0 +1,65 @@
+import { Request, Response, NextFunction } from 'express';
+import { registerSchema, loginSchema } from '../validators/authValidators';
+import * as authService from '../services/authService';
+import { AppError } from '../middlewares/errorHandler';
+import { ApiResponse } from '../types';
+import { ZodError } from 'zod';
+
+function formatZodErrors(error: ZodError) {
+  return error.issues.map((issue) => ({
+    field: issue.path.join('.'),
+    reason: issue.message,
+  }));
+}
+
+export async function register(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const parsed = registerSchema.safeParse(req.body);
+    if (!parsed.success) {
+      throw new AppError('參數驗證失敗', 400, formatZodErrors(parsed.error));
+    }
+
+    const result = await authService.register(parsed.data);
+
+    const response: ApiResponse<typeof result> = {
+      code: 201,
+      message: '註冊成功',
+      data: result,
+      timestamp: new Date().toISOString(),
+    };
+
+    res.status(201).json(response);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function login(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const parsed = loginSchema.safeParse(req.body);
+    if (!parsed.success) {
+      throw new AppError('參數驗證失敗', 400, formatZodErrors(parsed.error));
+    }
+
+    const result = await authService.login(parsed.data);
+
+    const response: ApiResponse<typeof result> = {
+      code: 200,
+      message: '登入成功',
+      data: result,
+      timestamp: new Date().toISOString(),
+    };
+
+    res.status(200).json(response);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/controllers/userController.test.ts
+++ b/backend/src/controllers/userController.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import app from '../app';
+import { jwtConfig } from '../config/jwt';
+
+const TEST_USER_ID = 'user-profile-test';
+
+function makeTestUser() {
+  return {
+    id: TEST_USER_ID,
+    name: 'Profile User',
+    email: 'profile@example.com',
+    passwordHash: 'hashed_password',
+    persona: 'gentle',
+    aiEngine: 'gemini',
+    monthlyBudget: 30000,
+    currency: 'TWD',
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+  };
+}
+
+// Mock Prisma - factory must not reference outer variables
+vi.mock('../config/database', () => {
+  let currentUser: Record<string, unknown> | null = null;
+
+  return {
+    default: {
+      user: {
+        findUnique: vi.fn(async ({ where }: { where: { id?: string; email?: string } }) => {
+          if (!currentUser) return null;
+          if (where.id && where.id === currentUser.id) return { ...currentUser };
+          if (where.email && where.email === currentUser.email) return { ...currentUser };
+          return null;
+        }),
+        update: vi.fn(async ({ where, data }: { where: { id: string }; data: Record<string, unknown> }) => {
+          if (currentUser && where.id === currentUser.id) {
+            currentUser = { ...currentUser, ...data, updatedAt: new Date() };
+            return { ...currentUser };
+          }
+          throw new Error('User not found');
+        }),
+        create: vi.fn(),
+      },
+      _setUser: (user: Record<string, unknown> | null) => {
+        currentUser = user ? { ...user } : null;
+      },
+    },
+  };
+});
+
+function getToken(userId: string = TEST_USER_ID): string {
+  return jwt.sign({ userId }, jwtConfig.secret, { expiresIn: '1h' });
+}
+
+beforeEach(async () => {
+  const prisma = (await import('../config/database')).default;
+  (prisma as unknown as { _setUser: (u: Record<string, unknown>) => void })._setUser(makeTestUser());
+});
+
+describe('GET /api/v1/users/profile', () => {
+  it('should return user profile', async () => {
+    const res = await request(app)
+      .get('/api/v1/users/profile')
+      .set('Authorization', `Bearer ${getToken()}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.code).toBe(200);
+    expect(res.body.data.id).toBe(TEST_USER_ID);
+    expect(res.body.data.name).toBe('Profile User');
+    expect(res.body.data.email).toBe('profile@example.com');
+    expect(res.body.data.persona).toBe('gentle');
+    expect(res.body.data.ai_engine).toBe('gemini');
+    expect(res.body.data.monthly_budget).toBe(30000);
+    expect(res.body.data.currency).toBe('TWD');
+    expect(res.body.data.created_at).toBeDefined();
+    // Should not expose password
+    expect(res.body.data.password_hash).toBeUndefined();
+    expect(res.body.data.passwordHash).toBeUndefined();
+  });
+
+  it('should return 401 without token', async () => {
+    const res = await request(app).get('/api/v1/users/profile');
+
+    expect(res.status).toBe(401);
+  });
+
+  it('should return 404 for non-existent user', async () => {
+    const token = jwt.sign({ userId: 'non-existent' }, jwtConfig.secret, {
+      expiresIn: '1h',
+    });
+
+    const res = await request(app)
+      .get('/api/v1/users/profile')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('PUT /api/v1/users/profile', () => {
+  it('should update name', async () => {
+    const res = await request(app)
+      .put('/api/v1/users/profile')
+      .set('Authorization', `Bearer ${getToken()}`)
+      .send({ name: 'New Name' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.code).toBe(200);
+    expect(res.body.data.name).toBe('New Name');
+  });
+
+  it('should update persona', async () => {
+    const res = await request(app)
+      .put('/api/v1/users/profile')
+      .set('Authorization', `Bearer ${getToken()}`)
+      .send({ persona: 'sarcastic' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.persona).toBe('sarcastic');
+  });
+
+  it('should update ai_engine', async () => {
+    const res = await request(app)
+      .put('/api/v1/users/profile')
+      .set('Authorization', `Bearer ${getToken()}`)
+      .send({ ai_engine: 'openai' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.ai_engine).toBe('openai');
+  });
+
+  it('should update monthly_budget', async () => {
+    const res = await request(app)
+      .put('/api/v1/users/profile')
+      .set('Authorization', `Bearer ${getToken()}`)
+      .send({ monthly_budget: 50000 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.monthly_budget).toBe(50000);
+  });
+
+  it('should return 400 for invalid persona', async () => {
+    const res = await request(app)
+      .put('/api/v1/users/profile')
+      .set('Authorization', `Bearer ${getToken()}`)
+      .send({ persona: 'invalid_persona' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 400 for invalid ai_engine', async () => {
+    const res = await request(app)
+      .put('/api/v1/users/profile')
+      .set('Authorization', `Bearer ${getToken()}`)
+      .send({ ai_engine: 'invalid_engine' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 400 for empty body', async () => {
+    const res = await request(app)
+      .put('/api/v1/users/profile')
+      .set('Authorization', `Bearer ${getToken()}`)
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 400 for negative monthly_budget', async () => {
+    const res = await request(app)
+      .put('/api/v1/users/profile')
+      .set('Authorization', `Bearer ${getToken()}`)
+      .send({ monthly_budget: -1000 });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 401 without token', async () => {
+    const res = await request(app)
+      .put('/api/v1/users/profile')
+      .send({ name: 'New Name' });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -1,0 +1,64 @@
+import { Response, NextFunction } from 'express';
+import { AuthRequest } from '../middlewares/auth';
+import { updateProfileSchema } from '../validators/userValidators';
+import * as userService from '../services/userService';
+import { AppError } from '../middlewares/errorHandler';
+import { ApiResponse } from '../types';
+import { ZodError } from 'zod';
+
+function formatZodErrors(error: ZodError) {
+  return error.issues.map((issue) => ({
+    field: issue.path.join('.'),
+    reason: issue.message,
+  }));
+}
+
+export async function getProfile(
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const userId = req.userId!;
+    const user = await userService.getProfile(userId);
+
+    const response: ApiResponse<typeof user> = {
+      code: 200,
+      message: 'success',
+      data: user,
+      timestamp: new Date().toISOString(),
+    };
+
+    res.status(200).json(response);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function updateProfile(
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const userId = req.userId!;
+
+    const parsed = updateProfileSchema.safeParse(req.body);
+    if (!parsed.success) {
+      throw new AppError('參數驗證失敗', 400, formatZodErrors(parsed.error));
+    }
+
+    const user = await userService.updateProfile(userId, parsed.data);
+
+    const response: ApiResponse<typeof user> = {
+      code: 200,
+      message: '更新成功',
+      data: user,
+      timestamp: new Date().toISOString(),
+    };
+
+    res.status(200).json(response);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/middlewares/auth.test.ts
+++ b/backend/src/middlewares/auth.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import { authMiddleware, AuthRequest } from './auth';
+import { errorHandler } from './errorHandler';
+import { jwtConfig } from '../config/jwt';
+
+// Create a small test app for middleware testing
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+
+  app.get('/test', authMiddleware, (req: AuthRequest, res) => {
+    res.json({ userId: req.userId });
+  });
+
+  app.use(errorHandler);
+  return app;
+}
+
+describe('Auth Middleware', () => {
+  const testApp = createTestApp();
+
+  it('should pass with a valid token and inject userId', async () => {
+    const token = jwt.sign({ userId: 'test-user-id' }, jwtConfig.secret, {
+      expiresIn: '1h',
+    });
+
+    const res = await request(testApp)
+      .get('/test')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.userId).toBe('test-user-id');
+  });
+
+  it('should return 401 when no Authorization header', async () => {
+    const res = await request(testApp).get('/test');
+
+    expect(res.status).toBe(401);
+    expect(res.body.message).toBe('未提供認證 Token');
+  });
+
+  it('should return 401 when Authorization header does not start with Bearer', async () => {
+    const res = await request(testApp)
+      .get('/test')
+      .set('Authorization', 'Basic some-token');
+
+    expect(res.status).toBe(401);
+    expect(res.body.message).toBe('未提供認證 Token');
+  });
+
+  it('should return 401 for an invalid token', async () => {
+    const res = await request(testApp)
+      .get('/test')
+      .set('Authorization', 'Bearer invalid-token');
+
+    expect(res.status).toBe(401);
+    expect(res.body.message).toBe('Token 無效');
+  });
+
+  it('should return 401 for an expired token', async () => {
+    const token = jwt.sign({ userId: 'test-user-id' }, jwtConfig.secret, {
+      expiresIn: '0s',
+    });
+
+    // Wait a tiny bit to ensure expiration
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const res = await request(testApp)
+      .get('/test')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(401);
+    expect(res.body.message).toBe('Token 已過期');
+  });
+
+  it('should return 401 for a token signed with wrong secret', async () => {
+    const token = jwt.sign({ userId: 'test-user-id' }, 'wrong-secret', {
+      expiresIn: '1h',
+    });
+
+    const res = await request(testApp)
+      .get('/test')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(401);
+    expect(res.body.message).toBe('Token 無效');
+  });
+});

--- a/backend/src/middlewares/auth.ts
+++ b/backend/src/middlewares/auth.ts
@@ -1,0 +1,37 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import { jwtConfig } from '../config/jwt';
+import { AppError } from './errorHandler';
+
+export interface AuthRequest extends Request {
+  userId?: string;
+}
+
+interface JwtPayload {
+  userId: string;
+}
+
+export function authMiddleware(
+  req: AuthRequest,
+  _res: Response,
+  next: NextFunction
+): void {
+  const authHeader = req.headers.authorization;
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    throw new AppError('未提供認證 Token', 401);
+  }
+
+  const token = authHeader.substring(7);
+
+  try {
+    const decoded = jwt.verify(token, jwtConfig.secret) as JwtPayload;
+    req.userId = decoded.userId;
+    next();
+  } catch (err) {
+    if (err instanceof jwt.TokenExpiredError) {
+      throw new AppError('Token 已過期', 401);
+    }
+    throw new AppError('Token 無效', 401);
+  }
+}

--- a/backend/src/middlewares/rateLimiter.ts
+++ b/backend/src/middlewares/rateLimiter.ts
@@ -1,11 +1,15 @@
 import rateLimit from 'express-rate-limit';
 
+const isTest = process.env.NODE_ENV === 'test';
+const skipInTest = () => isTest;
+
 // General API rate limiter: 100 req/min
 export const apiRateLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
   max: parseInt(process.env.RATE_LIMIT_API_PER_MIN || '100', 10),
   standardHeaders: true,
   legacyHeaders: false,
+  skip: skipInTest,
   message: {
     code: 429,
     message: '請求過於頻繁，請稍後再試',
@@ -19,6 +23,7 @@ export const llmRateLimiter = rateLimit({
   max: parseInt(process.env.RATE_LIMIT_LLM_PER_MIN || '20', 10),
   standardHeaders: true,
   legacyHeaders: false,
+  skip: skipInTest,
   message: {
     code: 429,
     message: 'LLM 請求過於頻繁，請稍後再試',
@@ -32,6 +37,7 @@ export const authRateLimiter = rateLimit({
   max: 10,
   standardHeaders: true,
   legacyHeaders: false,
+  skip: skipInTest,
   message: {
     code: 429,
     message: '認證請求過於頻繁，請稍後再試',

--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { register, login } from '../controllers/authController';
+import { authRateLimiter } from '../middlewares/rateLimiter';
+
+const router = Router();
+
+router.post('/register', authRateLimiter, register);
+router.post('/login', authRateLimiter, login);
+
+export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,14 +1,18 @@
 import { Router } from 'express';
 import { healthCheck } from '../controllers/healthController';
+import authRoutes from './authRoutes';
+import userRoutes from './userRoutes';
 
 const router = Router();
 
 // Health check endpoint
 router.get('/health', healthCheck);
 
+// API v1 routes
+router.use('/api/v1/auth', authRoutes);
+router.use('/api/v1/users', userRoutes);
+
 // Future routes will be added here:
-// router.use('/api/v1/auth', authRoutes);
-// router.use('/api/v1/users', userRoutes);
 // router.use('/api/v1/ai', aiRoutes);
 // router.use('/api/v1/transactions', transactionRoutes);
 // router.use('/api/v1/budget', budgetRoutes);

--- a/backend/src/routes/userRoutes.ts
+++ b/backend/src/routes/userRoutes.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { getProfile, updateProfile } from '../controllers/userController';
+import { authMiddleware } from '../middlewares/auth';
+
+const router = Router();
+
+router.get('/profile', authMiddleware, getProfile);
+router.put('/profile', authMiddleware, updateProfile);
+
+export default router;

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -1,0 +1,93 @@
+import bcrypt from 'bcrypt';
+import jwt, { SignOptions } from 'jsonwebtoken';
+import prisma from '../config/database';
+import { jwtConfig } from '../config/jwt';
+import { AppError } from '../middlewares/errorHandler';
+import { RegisterInput, LoginInput } from '../validators/authValidators';
+
+const BCRYPT_ROUNDS = 10;
+
+/** SRD SS3.4 - 8 default category budgets */
+const DEFAULT_CATEGORY_BUDGETS = [
+  { category: 'food', budgetLimit: 8000, isCustom: false },
+  { category: 'transport', budgetLimit: 3000, isCustom: false },
+  { category: 'entertainment', budgetLimit: 3000, isCustom: false },
+  { category: 'shopping', budgetLimit: 3000, isCustom: false },
+  { category: 'daily', budgetLimit: 2000, isCustom: false },
+  { category: 'medical', budgetLimit: 2000, isCustom: false },
+  { category: 'education', budgetLimit: 2000, isCustom: false },
+  { category: 'other', budgetLimit: 0, isCustom: false },
+];
+
+function generateToken(userId: string): string {
+  const options: SignOptions = {
+    expiresIn: jwtConfig.expiresIn,
+  };
+  return jwt.sign({ userId }, jwtConfig.secret, options);
+}
+
+export function formatUserResponse(user: {
+  id: string;
+  name: string;
+  email: string;
+  persona: string;
+  aiEngine: string;
+  monthlyBudget: unknown;
+  currency: string;
+  createdAt: Date;
+}) {
+  return {
+    id: user.id,
+    name: user.name,
+    email: user.email,
+    persona: user.persona,
+    ai_engine: user.aiEngine,
+    monthly_budget: Number(user.monthlyBudget),
+    currency: user.currency,
+    created_at: user.createdAt.toISOString(),
+  };
+}
+
+export async function register(input: RegisterInput) {
+  // Check if email already exists
+  const existing = await prisma.user.findUnique({
+    where: { email: input.email },
+  });
+  if (existing) {
+    throw new AppError('此 Email 已被註冊', 409);
+  }
+
+  const passwordHash = await bcrypt.hash(input.password, BCRYPT_ROUNDS);
+
+  // Create user and default category budgets in a transaction
+  const user = await prisma.user.create({
+    data: {
+      name: input.name,
+      email: input.email,
+      passwordHash,
+      categoryBudgets: {
+        create: DEFAULT_CATEGORY_BUDGETS,
+      },
+    },
+  });
+
+  const token = generateToken(user.id);
+  return { user: formatUserResponse(user), token };
+}
+
+export async function login(input: LoginInput) {
+  const user = await prisma.user.findUnique({
+    where: { email: input.email },
+  });
+  if (!user) {
+    throw new AppError('Email 或密碼錯誤', 401);
+  }
+
+  const isPasswordValid = await bcrypt.compare(input.password, user.passwordHash);
+  if (!isPasswordValid) {
+    throw new AppError('Email 或密碼錯誤', 401);
+  }
+
+  const token = generateToken(user.id);
+  return { user: formatUserResponse(user), token };
+}

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -1,0 +1,32 @@
+import prisma from '../config/database';
+import { AppError } from '../middlewares/errorHandler';
+import { formatUserResponse } from './authService';
+import { UpdateProfileInput } from '../validators/userValidators';
+
+export async function getProfile(userId: string) {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+  });
+
+  if (!user) {
+    throw new AppError('使用者不存在', 404);
+  }
+
+  return formatUserResponse(user);
+}
+
+export async function updateProfile(userId: string, input: UpdateProfileInput) {
+  // Build update data, mapping snake_case input to camelCase Prisma fields
+  const updateData: Record<string, unknown> = {};
+  if (input.name !== undefined) updateData.name = input.name;
+  if (input.persona !== undefined) updateData.persona = input.persona;
+  if (input.ai_engine !== undefined) updateData.aiEngine = input.ai_engine;
+  if (input.monthly_budget !== undefined) updateData.monthlyBudget = input.monthly_budget;
+
+  const user = await prisma.user.update({
+    where: { id: userId },
+    data: updateData,
+  });
+
+  return formatUserResponse(user);
+}

--- a/backend/src/validators/authValidators.ts
+++ b/backend/src/validators/authValidators.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+export const registerSchema = z.object({
+  name: z
+    .string({ error: '名稱為必填' })
+    .min(2, '名稱至少 2 個字元')
+    .max(50, '名稱最多 50 個字元'),
+  email: z
+    .string({ error: 'Email 為必填' })
+    .email('Email 格式不正確'),
+  password: z
+    .string({ error: '密碼為必填' })
+    .min(8, '密碼至少 8 個字元')
+    .max(100, '密碼最多 100 個字元'),
+});
+
+export const loginSchema = z.object({
+  email: z
+    .string({ error: 'Email 為必填' })
+    .email('Email 格式不正確'),
+  password: z
+    .string({ error: '密碼為必填' }),
+});
+
+export type RegisterInput = z.infer<typeof registerSchema>;
+export type LoginInput = z.infer<typeof loginSchema>;

--- a/backend/src/validators/userValidators.ts
+++ b/backend/src/validators/userValidators.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+export const updateProfileSchema = z.object({
+  name: z
+    .string()
+    .min(2, '名稱至少 2 個字元')
+    .max(50, '名稱最多 50 個字元')
+    .optional(),
+  persona: z
+    .enum(['sarcastic', 'gentle', 'guilt_trip'], {
+      error: '人設必須為 sarcastic、gentle 或 guilt_trip',
+    })
+    .optional(),
+  ai_engine: z
+    .enum(['gemini', 'openai'], {
+      error: 'AI 引擎必須為 gemini 或 openai',
+    })
+    .optional(),
+  monthly_budget: z
+    .number()
+    .min(0, '月預算不可為負數')
+    .max(10000000, '月預算不可超過 10,000,000')
+    .optional(),
+}).refine(
+  (data) => Object.keys(data).length > 0,
+  { message: '至少需提供一個欄位進行更新' }
+);
+
+export type UpdateProfileInput = z.infer<typeof updateProfileSchema>;

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['src/**/*.test.ts'],
+    env: {
+      NODE_ENV: 'test',
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary
- 實作完整認證模組：`POST /auth/register`（含自動初始化 8 個預設類別預算）、`POST /auth/login`（JWT 生成）
- 實作 JWT Auth Middleware：驗證 Bearer Token、注入 `req.userId`
- 實作 User Profile API：`GET /users/profile`、`PUT /users/profile`（含人設、預算、AI 引擎偏好更新）
- 使用 Zod 定義請求驗證 Schema（email 格式、密碼長度、persona/ai_engine enum）
- 撰寫完整單元測試：Auth Controller、User Controller、Auth Middleware

## Related Issue
Closes #5

## Test plan
- [ ] `npm test` 單元測試全數通過
- [ ] CI Pipeline (lint + tsc + vitest + build) 全綠
- [ ] 註冊成功後自動建立 8 個預設類別預算
- [ ] 登入回傳有效 JWT Token
- [ ] Auth Middleware 正確攔截未認證請求