### PR TITLE
feat(frontend): Login/Register Pages & Auth (T-106)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,23 @@
+import { useEffect } from 'react'
 import { Routes, Route, useLocation } from 'react-router-dom'
 import Layout from './components/Layout.tsx'
+import ProtectedRoute from './components/ProtectedRoute.tsx'
 import DashboardPage from './pages/DashboardPage.tsx'
 import StatsPage from './pages/StatsPage.tsx'
 import HistoryPage from './pages/HistoryPage.tsx'
 import SettingsPage from './pages/SettingsPage.tsx'
 import LoginPage from './pages/LoginPage.tsx'
 import RegisterPage from './pages/RegisterPage.tsx'
+import { useAuthStore } from './stores/authStore.ts'
 
 function App() {
   const location = useLocation()
   const hideTabBar = ['/login', '/register'].includes(location.pathname)
+  const restoreSession = useAuthStore((state) => state.restoreSession)
+
+  useEffect(() => {
+    restoreSession()
+  }, [restoreSession])
 
   return (
     <Routes>
@@ -19,7 +27,13 @@ function App() {
           <Route path="/register" element={<RegisterPage />} />
         </>
       ) : (
-        <Route element={<Layout />}>
+        <Route
+          element={
+            <ProtectedRoute>
+              <Layout />
+            </ProtectedRoute>
+          }
+        >
           <Route path="/" element={<DashboardPage />} />
           <Route path="/stats" element={<StatsPage />} />
           <Route path="/history" element={<HistoryPage />} />

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,23 @@
+import { Navigate, useLocation } from 'react-router-dom'
+import { useAuthStore } from '../stores/authStore.ts'
+
+interface ProtectedRouteProps {
+  children: React.ReactNode
+}
+
+/**
+ * 保護路由元件：未認證使用者自動導向 /login
+ * 保留原始目標路徑，登入後可跳轉回去
+ */
+function ProtectedRoute({ children }: ProtectedRouteProps) {
+  const token = useAuthStore((state) => state.token)
+  const location = useLocation()
+
+  if (!token) {
+    return <Navigate to="/login" state={{ from: location.pathname }} replace />
+  }
+
+  return <>{children}</>
+}
+
+export default ProtectedRoute

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -24,6 +24,7 @@ api.interceptors.response.use(
     // 401 時可導向登入頁
     if (error.response?.status === 401) {
       localStorage.removeItem('auth_token')
+      localStorage.removeItem('auth_user')
       window.location.href = '/login'
     }
     return Promise.reject(error)

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,6 +1,55 @@
-import { Link } from 'react-router-dom'
+import { useState } from 'react'
+import { Link, useNavigate, useLocation } from 'react-router-dom'
+import { useAuthStore } from '../stores/authStore.ts'
+
+/** Email 格式驗證 */
+function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+}
 
 function LoginPage() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [validationErrors, setValidationErrors] = useState<Record<string, string>>({})
+
+  const login = useAuthStore((state) => state.login)
+  const loading = useAuthStore((state) => state.loading)
+  const error = useAuthStore((state) => state.error)
+  const clearError = useAuthStore((state) => state.clearError)
+
+  const navigate = useNavigate()
+  const location = useLocation()
+  const from = (location.state as { from?: string })?.from ?? '/'
+
+  function validate(): boolean {
+    const errors: Record<string, string> = {}
+    if (!email.trim()) {
+      errors.email = '請輸入 Email'
+    } else if (!isValidEmail(email)) {
+      errors.email = 'Email 格式不正確'
+    }
+    if (!password) {
+      errors.password = '請輸入密碼'
+    } else if (password.length < 8) {
+      errors.password = '密碼長度至少 8 個字元'
+    }
+    setValidationErrors(errors)
+    return Object.keys(errors).length === 0
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    clearError()
+    if (!validate()) return
+
+    try {
+      await login(email, password)
+      navigate(from, { replace: true })
+    } catch {
+      // error is already set in store
+    }
+  }
+
   return (
     <div className="min-h-svh flex flex-col items-center justify-center p-2xl bg-bg">
       <div className="w-16 h-16 bg-primary rounded-lg flex items-center justify-center text-3xl mb-lg">
@@ -13,21 +62,84 @@ function LoginPage() {
         語音記帳教練
       </p>
 
-      <div className="w-full max-w-sm">
-        <input
-          type="email"
-          placeholder="Email"
-          className="w-full h-12 rounded-md border border-border bg-surface px-lg text-[var(--font-size-body)] mb-md outline-none focus:border-primary transition-colors"
-          aria-label="Email"
-        />
-        <input
-          type="password"
-          placeholder="密碼"
-          className="w-full h-12 rounded-md border border-border bg-surface px-lg text-[var(--font-size-body)] mb-xl outline-none focus:border-primary transition-colors"
-          aria-label="密碼"
-        />
-        <button className="w-full h-12 bg-primary text-surface rounded-md font-semibold text-[var(--font-size-body)] hover:bg-primary-dark transition-colors">
-          登入
+      <form onSubmit={handleSubmit} className="w-full max-w-sm" noValidate>
+        {error && (
+          <div
+            className="mb-lg p-md rounded-md bg-danger-light text-danger text-[var(--font-size-caption)] text-center"
+            role="alert"
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="mb-md">
+          <input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => {
+              setEmail(e.target.value)
+              if (validationErrors.email) {
+                setValidationErrors((prev) => {
+                  const next = { ...prev }
+                  delete next.email
+                  return next
+                })
+              }
+            }}
+            className={`w-full h-12 rounded-md border bg-surface px-lg text-[var(--font-size-body)] outline-none transition-colors ${
+              validationErrors.email
+                ? 'border-danger focus:border-danger'
+                : 'border-border focus:border-primary'
+            }`}
+            aria-label="Email"
+            aria-invalid={!!validationErrors.email}
+            autoComplete="email"
+          />
+          {validationErrors.email && (
+            <p className="mt-xs text-[var(--font-size-small)] text-danger" role="alert">
+              {validationErrors.email}
+            </p>
+          )}
+        </div>
+
+        <div className="mb-xl">
+          <input
+            type="password"
+            placeholder="密碼"
+            value={password}
+            onChange={(e) => {
+              setPassword(e.target.value)
+              if (validationErrors.password) {
+                setValidationErrors((prev) => {
+                  const next = { ...prev }
+                  delete next.password
+                  return next
+                })
+              }
+            }}
+            className={`w-full h-12 rounded-md border bg-surface px-lg text-[var(--font-size-body)] outline-none transition-colors ${
+              validationErrors.password
+                ? 'border-danger focus:border-danger'
+                : 'border-border focus:border-primary'
+            }`}
+            aria-label="密碼"
+            aria-invalid={!!validationErrors.password}
+            autoComplete="current-password"
+          />
+          {validationErrors.password && (
+            <p className="mt-xs text-[var(--font-size-small)] text-danger" role="alert">
+              {validationErrors.password}
+            </p>
+          )}
+        </div>
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full h-12 bg-primary text-surface rounded-md font-semibold text-[var(--font-size-body)] hover:bg-primary-dark transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          {loading ? '登入中...' : '登入'}
         </button>
 
         <p className="text-center mt-xl text-[var(--font-size-caption)]">
@@ -36,7 +148,7 @@ function LoginPage() {
             立即註冊
           </Link>
         </p>
-      </div>
+      </form>
     </div>
   )
 }

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,6 +1,75 @@
-import { Link } from 'react-router-dom'
+import { useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { useAuthStore } from '../stores/authStore.ts'
+
+/** Email 格式驗證 */
+function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+}
 
 function RegisterPage() {
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [validationErrors, setValidationErrors] = useState<Record<string, string>>({})
+
+  const register = useAuthStore((state) => state.register)
+  const loading = useAuthStore((state) => state.loading)
+  const error = useAuthStore((state) => state.error)
+  const clearError = useAuthStore((state) => state.clearError)
+
+  const navigate = useNavigate()
+
+  function validate(): boolean {
+    const errors: Record<string, string> = {}
+    if (!name.trim()) {
+      errors.name = '請輸入使用者名稱'
+    } else if (name.trim().length < 2) {
+      errors.name = '使用者名稱至少 2 個字元'
+    }
+    if (!email.trim()) {
+      errors.email = '請輸入 Email'
+    } else if (!isValidEmail(email)) {
+      errors.email = 'Email 格式不正確'
+    }
+    if (!password) {
+      errors.password = '請輸入密碼'
+    } else if (password.length < 8) {
+      errors.password = '密碼長度至少 8 個字元'
+    }
+    if (!confirmPassword) {
+      errors.confirmPassword = '請再次輸入密碼'
+    } else if (password !== confirmPassword) {
+      errors.confirmPassword = '兩次輸入的密碼不一致'
+    }
+    setValidationErrors(errors)
+    return Object.keys(errors).length === 0
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    clearError()
+    if (!validate()) return
+
+    try {
+      await register(name.trim(), email, password)
+      navigate('/', { replace: true })
+    } catch {
+      // error is already set in store
+    }
+  }
+
+  function clearFieldError(field: string) {
+    if (validationErrors[field]) {
+      setValidationErrors((prev) => {
+        const next = { ...prev }
+        delete next[field]
+        return next
+      })
+    }
+  }
+
   return (
     <div className="min-h-svh flex flex-col items-center justify-center p-2xl bg-bg">
       <div className="w-16 h-16 bg-primary rounded-lg flex items-center justify-center text-3xl mb-lg">
@@ -13,27 +82,122 @@ function RegisterPage() {
         語音記帳教練
       </p>
 
-      <div className="w-full max-w-sm">
-        <input
-          type="text"
-          placeholder="使用者名稱"
-          className="w-full h-12 rounded-md border border-border bg-surface px-lg text-[var(--font-size-body)] mb-md outline-none focus:border-primary transition-colors"
-          aria-label="使用者名稱"
-        />
-        <input
-          type="email"
-          placeholder="Email"
-          className="w-full h-12 rounded-md border border-border bg-surface px-lg text-[var(--font-size-body)] mb-md outline-none focus:border-primary transition-colors"
-          aria-label="Email"
-        />
-        <input
-          type="password"
-          placeholder="密碼"
-          className="w-full h-12 rounded-md border border-border bg-surface px-lg text-[var(--font-size-body)] mb-xl outline-none focus:border-primary transition-colors"
-          aria-label="密碼"
-        />
-        <button className="w-full h-12 bg-primary text-surface rounded-md font-semibold text-[var(--font-size-body)] hover:bg-primary-dark transition-colors">
-          註冊
+      <form onSubmit={handleSubmit} className="w-full max-w-sm" noValidate>
+        {error && (
+          <div
+            className="mb-lg p-md rounded-md bg-danger-light text-danger text-[var(--font-size-caption)] text-center"
+            role="alert"
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="mb-md">
+          <input
+            type="text"
+            placeholder="使用者名稱"
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value)
+              clearFieldError('name')
+            }}
+            className={`w-full h-12 rounded-md border bg-surface px-lg text-[var(--font-size-body)] outline-none transition-colors ${
+              validationErrors.name
+                ? 'border-danger focus:border-danger'
+                : 'border-border focus:border-primary'
+            }`}
+            aria-label="使用者名稱"
+            aria-invalid={!!validationErrors.name}
+            autoComplete="name"
+          />
+          {validationErrors.name && (
+            <p className="mt-xs text-[var(--font-size-small)] text-danger" role="alert">
+              {validationErrors.name}
+            </p>
+          )}
+        </div>
+
+        <div className="mb-md">
+          <input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => {
+              setEmail(e.target.value)
+              clearFieldError('email')
+            }}
+            className={`w-full h-12 rounded-md border bg-surface px-lg text-[var(--font-size-body)] outline-none transition-colors ${
+              validationErrors.email
+                ? 'border-danger focus:border-danger'
+                : 'border-border focus:border-primary'
+            }`}
+            aria-label="Email"
+            aria-invalid={!!validationErrors.email}
+            autoComplete="email"
+          />
+          {validationErrors.email && (
+            <p className="mt-xs text-[var(--font-size-small)] text-danger" role="alert">
+              {validationErrors.email}
+            </p>
+          )}
+        </div>
+
+        <div className="mb-md">
+          <input
+            type="password"
+            placeholder="密碼"
+            value={password}
+            onChange={(e) => {
+              setPassword(e.target.value)
+              clearFieldError('password')
+            }}
+            className={`w-full h-12 rounded-md border bg-surface px-lg text-[var(--font-size-body)] outline-none transition-colors ${
+              validationErrors.password
+                ? 'border-danger focus:border-danger'
+                : 'border-border focus:border-primary'
+            }`}
+            aria-label="密碼"
+            aria-invalid={!!validationErrors.password}
+            autoComplete="new-password"
+          />
+          {validationErrors.password && (
+            <p className="mt-xs text-[var(--font-size-small)] text-danger" role="alert">
+              {validationErrors.password}
+            </p>
+          )}
+        </div>
+
+        <div className="mb-xl">
+          <input
+            type="password"
+            placeholder="確認密碼"
+            value={confirmPassword}
+            onChange={(e) => {
+              setConfirmPassword(e.target.value)
+              clearFieldError('confirmPassword')
+            }}
+            className={`w-full h-12 rounded-md border bg-surface px-lg text-[var(--font-size-body)] outline-none transition-colors ${
+              validationErrors.confirmPassword
+                ? 'border-danger focus:border-danger'
+                : 'border-border focus:border-primary'
+            }`}
+            aria-label="確認密碼"
+            aria-invalid={!!validationErrors.confirmPassword}
+            autoComplete="new-password"
+          />
+          {validationErrors.confirmPassword && (
+            <p className="mt-xs text-[var(--font-size-small)] text-danger" role="alert">
+              {validationErrors.confirmPassword}
+            </p>
+          )}
+        </div>
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full h-12 bg-primary text-surface rounded-md font-semibold text-[var(--font-size-body)] hover:bg-primary-dark transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          {loading ? '註冊中...' : '註冊'}
         </button>
 
         <p className="text-center mt-xl text-[var(--font-size-caption)]">
@@ -42,7 +206,7 @@ function RegisterPage() {
             返回登入
           </Link>
         </p>
-      </div>
+      </form>
     </div>
   )
 }

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -1,0 +1,117 @@
+import { create } from 'zustand'
+import type { User } from '../types/index.ts'
+import api from '../lib/api.ts'
+
+/** Auth API 回應資料結構 */
+interface AuthResponseData {
+  user: User
+  token: string
+}
+
+interface AuthState {
+  /** 當前使用者 */
+  user: User | null
+  /** JWT Token */
+  token: string | null
+  /** 是否正在載入（登入/註冊中） */
+  loading: boolean
+  /** 錯誤訊息 */
+  error: string | null
+
+  /** 登入 */
+  login: (email: string, password: string) => Promise<void>
+  /** 註冊 */
+  register: (name: string, email: string, password: string) => Promise<void>
+  /** 登出 */
+  logout: () => void
+  /** 從 localStorage 恢復登入狀態 */
+  restoreSession: () => void
+  /** 清除錯誤訊息 */
+  clearError: () => void
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  user: null,
+  token: null,
+  loading: false,
+  error: null,
+
+  login: async (email: string, password: string) => {
+    set({ loading: true, error: null })
+    try {
+      const response = await api.post<{ data: AuthResponseData }>('/auth/login', {
+        email,
+        password,
+      })
+      const { user, token } = response.data.data
+      localStorage.setItem('auth_token', token)
+      localStorage.setItem('auth_user', JSON.stringify(user))
+      set({ user, token, loading: false, error: null })
+    } catch (err: unknown) {
+      const message = extractErrorMessage(err, '登入失敗，請檢查帳號密碼')
+      set({ loading: false, error: message })
+      throw new Error(message)
+    }
+  },
+
+  register: async (name: string, email: string, password: string) => {
+    set({ loading: true, error: null })
+    try {
+      const response = await api.post<{ data: AuthResponseData }>('/auth/register', {
+        name,
+        email,
+        password,
+      })
+      const { user, token } = response.data.data
+      localStorage.setItem('auth_token', token)
+      localStorage.setItem('auth_user', JSON.stringify(user))
+      set({ user, token, loading: false, error: null })
+    } catch (err: unknown) {
+      const message = extractErrorMessage(err, '註冊失敗，請稍後再試')
+      set({ loading: false, error: message })
+      throw new Error(message)
+    }
+  },
+
+  logout: () => {
+    localStorage.removeItem('auth_token')
+    localStorage.removeItem('auth_user')
+    set({ user: null, token: null, error: null })
+  },
+
+  restoreSession: () => {
+    const token = localStorage.getItem('auth_token')
+    const userJson = localStorage.getItem('auth_user')
+    if (token && userJson) {
+      try {
+        const user = JSON.parse(userJson) as User
+        set({ user, token })
+      } catch {
+        localStorage.removeItem('auth_token')
+        localStorage.removeItem('auth_user')
+      }
+    }
+  },
+
+  clearError: () => {
+    set({ error: null })
+  },
+}))
+
+/** 從 axios error 中提取錯誤訊息 */
+function extractErrorMessage(err: unknown, fallback: string): string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const response = (err as { response?: { data?: { message?: string }; status?: number } })
+      .response
+    if (response?.data?.message) {
+      return response.data.message
+    }
+    if (response?.status === 409) {
+      return 'Email 已被註冊'
+    }
+    if (response?.status === 401) {
+      return '帳號或密碼錯誤'
+    }
+  }
+  return fallback
+}

--- a/frontend/src/test/App.test.tsx
+++ b/frontend/src/test/App.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import App from '../App'
+import { useAuthStore } from '../stores/authStore.ts'
 
 function renderWithRouter(initialRoute = '/') {
   return render(
@@ -11,56 +12,104 @@ function renderWithRouter(initialRoute = '/') {
   )
 }
 
+/** 設定已認證狀態 */
+function setAuthenticated() {
+  useAuthStore.setState({
+    token: 'test-token',
+    user: {
+      id: '1',
+      name: 'Test',
+      email: 'test@example.com',
+      persona: 'gentle',
+      aiEngine: 'gemini',
+      monthlyBudget: 20000,
+      currency: 'TWD',
+      createdAt: '2026-01-01',
+      updatedAt: '2026-01-01',
+    },
+  })
+}
+
 describe('App Routing', () => {
-  it('renders dashboard page at /', () => {
-    renderWithRouter('/')
-    expect(screen.getByText('Vibe Money Book')).toBeInTheDocument()
-    expect(screen.getByText('語音記帳教練')).toBeInTheDocument()
+  beforeEach(() => {
+    useAuthStore.setState({
+      user: null,
+      token: null,
+      loading: false,
+      error: null,
+    })
+    localStorage.clear()
   })
 
-  it('renders stats page at /stats', () => {
-    renderWithRouter('/stats')
-    expect(screen.getByText('📊 統計')).toBeInTheDocument()
+  describe('authenticated routes', () => {
+    beforeEach(() => {
+      setAuthenticated()
+    })
+
+    it('renders dashboard page at /', () => {
+      renderWithRouter('/')
+      expect(screen.getByText('Vibe Money Book')).toBeInTheDocument()
+      expect(screen.getByText('語音記帳教練')).toBeInTheDocument()
+    })
+
+    it('renders stats page at /stats', () => {
+      renderWithRouter('/stats')
+      expect(screen.getByText('📊 統計')).toBeInTheDocument()
+    })
+
+    it('renders history page at /history', () => {
+      renderWithRouter('/history')
+      expect(screen.getByText('📋 記錄')).toBeInTheDocument()
+    })
+
+    it('renders settings page at /settings', () => {
+      renderWithRouter('/settings')
+      expect(screen.getByText('⚙️ 設定')).toBeInTheDocument()
+    })
+
+    it('shows tab bar on main pages', () => {
+      renderWithRouter('/')
+      expect(screen.getByLabelText('主選單')).toBeInTheDocument()
+      expect(screen.getByText('首頁')).toBeInTheDocument()
+      expect(screen.getByText('統計')).toBeInTheDocument()
+      expect(screen.getByText('記錄')).toBeInTheDocument()
+      expect(screen.getByText('設定')).toBeInTheDocument()
+    })
   })
 
-  it('renders history page at /history', () => {
-    renderWithRouter('/history')
-    expect(screen.getByText('📋 記錄')).toBeInTheDocument()
+  describe('public routes', () => {
+    it('renders login page at /login', () => {
+      renderWithRouter('/login')
+      expect(screen.getByRole('button', { name: '登入' })).toBeInTheDocument()
+      expect(screen.getByText('立即註冊')).toBeInTheDocument()
+    })
+
+    it('renders register page at /register', () => {
+      renderWithRouter('/register')
+      expect(screen.getByRole('button', { name: '註冊' })).toBeInTheDocument()
+      expect(screen.getByText('返回登入')).toBeInTheDocument()
+    })
+
+    it('hides tab bar on login page', () => {
+      renderWithRouter('/login')
+      expect(screen.queryByLabelText('主選單')).not.toBeInTheDocument()
+    })
+
+    it('hides tab bar on register page', () => {
+      renderWithRouter('/register')
+      expect(screen.queryByLabelText('主選單')).not.toBeInTheDocument()
+    })
   })
 
-  it('renders settings page at /settings', () => {
-    renderWithRouter('/settings')
-    expect(screen.getByText('⚙️ 設定')).toBeInTheDocument()
-  })
+  describe('route protection', () => {
+    it('redirects unauthenticated user from / to /login', () => {
+      renderWithRouter('/')
+      expect(screen.getByRole('button', { name: '登入' })).toBeInTheDocument()
+    })
 
-  it('renders login page at /login', () => {
-    renderWithRouter('/login')
-    expect(screen.getByText('登入')).toBeInTheDocument()
-    expect(screen.getByText('立即註冊')).toBeInTheDocument()
-  })
-
-  it('renders register page at /register', () => {
-    renderWithRouter('/register')
-    expect(screen.getByText('註冊')).toBeInTheDocument()
-    expect(screen.getByText('返回登入')).toBeInTheDocument()
-  })
-
-  it('shows tab bar on main pages', () => {
-    renderWithRouter('/')
-    expect(screen.getByLabelText('主選單')).toBeInTheDocument()
-    expect(screen.getByText('首頁')).toBeInTheDocument()
-    expect(screen.getByText('統計')).toBeInTheDocument()
-    expect(screen.getByText('記錄')).toBeInTheDocument()
-    expect(screen.getByText('設定')).toBeInTheDocument()
-  })
-
-  it('hides tab bar on login page', () => {
-    renderWithRouter('/login')
-    expect(screen.queryByLabelText('主選單')).not.toBeInTheDocument()
-  })
-
-  it('hides tab bar on register page', () => {
-    renderWithRouter('/register')
-    expect(screen.queryByLabelText('主選單')).not.toBeInTheDocument()
+    it('redirects unauthenticated user from /settings to /login', () => {
+      renderWithRouter('/settings')
+      expect(screen.getByRole('button', { name: '登入' })).toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/test/ProtectedRoute.test.tsx
+++ b/frontend/src/test/ProtectedRoute.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { describe, it, expect, beforeEach } from 'vitest'
+import ProtectedRoute from '../components/ProtectedRoute.tsx'
+import { useAuthStore } from '../stores/authStore.ts'
+
+function renderWithRouter(initialRoute: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialRoute]}>
+      <Routes>
+        <Route
+          path="/dashboard"
+          element={
+            <ProtectedRoute>
+              <div>Dashboard Content</div>
+            </ProtectedRoute>
+          }
+        />
+        <Route path="/login" element={<div>Login Page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('ProtectedRoute', () => {
+  beforeEach(() => {
+    useAuthStore.setState({
+      user: null,
+      token: null,
+      loading: false,
+      error: null,
+    })
+  })
+
+  it('redirects to /login when user is not authenticated', () => {
+    renderWithRouter('/dashboard')
+    expect(screen.getByText('Login Page')).toBeInTheDocument()
+    expect(screen.queryByText('Dashboard Content')).not.toBeInTheDocument()
+  })
+
+  it('renders children when user is authenticated', () => {
+    useAuthStore.setState({
+      token: 'valid-token',
+      user: {
+        id: '1',
+        name: 'Test',
+        email: 'test@example.com',
+        persona: 'gentle',
+        aiEngine: 'gemini',
+        monthlyBudget: 20000,
+        currency: 'TWD',
+        createdAt: '2026-01-01',
+        updatedAt: '2026-01-01',
+      },
+    })
+
+    renderWithRouter('/dashboard')
+    expect(screen.getByText('Dashboard Content')).toBeInTheDocument()
+    expect(screen.queryByText('Login Page')).not.toBeInTheDocument()
+  })
+
+  it('redirects to login when token is null even if user exists', () => {
+    useAuthStore.setState({
+      token: null,
+      user: {
+        id: '1',
+        name: 'Test',
+        email: 'test@example.com',
+        persona: 'gentle',
+        aiEngine: 'gemini',
+        monthlyBudget: 20000,
+        currency: 'TWD',
+        createdAt: '2026-01-01',
+        updatedAt: '2026-01-01',
+      },
+    })
+
+    renderWithRouter('/dashboard')
+    expect(screen.getByText('Login Page')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/authStore.test.ts
+++ b/frontend/src/test/authStore.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useAuthStore } from '../stores/authStore.ts'
+
+// Mock the api module
+vi.mock('../lib/api.ts', () => {
+  return {
+    default: {
+      post: vi.fn(),
+    },
+  }
+})
+
+// Helper to get a fresh api mock
+async function getApiMock() {
+  const mod = await import('../lib/api.ts')
+  return mod.default as unknown as { post: ReturnType<typeof vi.fn> }
+}
+
+describe('Auth Store', () => {
+  beforeEach(() => {
+    // Reset store state
+    useAuthStore.setState({
+      user: null,
+      token: null,
+      loading: false,
+      error: null,
+    })
+    // Clear localStorage
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  describe('initial state', () => {
+    it('starts with null user and token', () => {
+      const state = useAuthStore.getState()
+      expect(state.user).toBeNull()
+      expect(state.token).toBeNull()
+      expect(state.loading).toBe(false)
+      expect(state.error).toBeNull()
+    })
+  })
+
+  describe('login', () => {
+    it('sets user and token on successful login', async () => {
+      const mockUser = {
+        id: '1',
+        name: 'Test',
+        email: 'test@example.com',
+        persona: 'gentle' as const,
+        aiEngine: 'gemini' as const,
+        monthlyBudget: 20000,
+        currency: 'TWD',
+        createdAt: '2026-01-01',
+        updatedAt: '2026-01-01',
+      }
+      const mockToken = 'jwt-token-123'
+
+      const api = await getApiMock()
+      api.post.mockResolvedValueOnce({
+        data: { data: { user: mockUser, token: mockToken } },
+      })
+
+      await useAuthStore.getState().login('test@example.com', 'password123')
+
+      const state = useAuthStore.getState()
+      expect(state.user).toEqual(mockUser)
+      expect(state.token).toBe(mockToken)
+      expect(state.loading).toBe(false)
+      expect(state.error).toBeNull()
+      expect(localStorage.getItem('auth_token')).toBe(mockToken)
+      expect(localStorage.getItem('auth_user')).toBe(JSON.stringify(mockUser))
+    })
+
+    it('sets error on failed login', async () => {
+      const api = await getApiMock()
+      api.post.mockRejectedValueOnce({
+        response: { status: 401, data: { message: '帳號或密碼錯誤' } },
+      })
+
+      await expect(
+        useAuthStore.getState().login('wrong@example.com', 'wrongpass'),
+      ).rejects.toThrow('帳號或密碼錯誤')
+
+      const state = useAuthStore.getState()
+      expect(state.user).toBeNull()
+      expect(state.token).toBeNull()
+      expect(state.loading).toBe(false)
+      expect(state.error).toBe('帳號或密碼錯誤')
+    })
+
+    it('sets loading during login', async () => {
+      const api = await getApiMock()
+      let resolvePromise: (value: unknown) => void
+      api.post.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolvePromise = resolve
+        }),
+      )
+
+      const loginPromise = useAuthStore.getState().login('test@example.com', 'password123')
+      expect(useAuthStore.getState().loading).toBe(true)
+
+      resolvePromise!({
+        data: {
+          data: {
+            user: { id: '1', name: 'Test', email: 'test@example.com' },
+            token: 'token',
+          },
+        },
+      })
+      await loginPromise
+      expect(useAuthStore.getState().loading).toBe(false)
+    })
+  })
+
+  describe('register', () => {
+    it('sets user and token on successful registration', async () => {
+      const mockUser = {
+        id: '2',
+        name: 'New User',
+        email: 'new@example.com',
+        persona: 'gentle' as const,
+        aiEngine: 'gemini' as const,
+        monthlyBudget: 0,
+        currency: 'TWD',
+        createdAt: '2026-01-01',
+        updatedAt: '2026-01-01',
+      }
+      const mockToken = 'jwt-token-456'
+
+      const api = await getApiMock()
+      api.post.mockResolvedValueOnce({
+        data: { data: { user: mockUser, token: mockToken } },
+      })
+
+      await useAuthStore.getState().register('New User', 'new@example.com', 'password123')
+
+      const state = useAuthStore.getState()
+      expect(state.user).toEqual(mockUser)
+      expect(state.token).toBe(mockToken)
+      expect(state.loading).toBe(false)
+      expect(localStorage.getItem('auth_token')).toBe(mockToken)
+    })
+
+    it('sets error on failed registration (409 conflict)', async () => {
+      const api = await getApiMock()
+      api.post.mockRejectedValueOnce({
+        response: { status: 409, data: {} },
+      })
+
+      await expect(
+        useAuthStore.getState().register('User', 'exists@example.com', 'password123'),
+      ).rejects.toThrow('Email 已被註冊')
+
+      expect(useAuthStore.getState().error).toBe('Email 已被註冊')
+    })
+  })
+
+  describe('logout', () => {
+    it('clears user, token, and localStorage', () => {
+      useAuthStore.setState({
+        user: { id: '1', name: 'Test', email: 'test@example.com' } as never,
+        token: 'token-123',
+      })
+      localStorage.setItem('auth_token', 'token-123')
+      localStorage.setItem('auth_user', '{}')
+
+      useAuthStore.getState().logout()
+
+      const state = useAuthStore.getState()
+      expect(state.user).toBeNull()
+      expect(state.token).toBeNull()
+      expect(localStorage.getItem('auth_token')).toBeNull()
+      expect(localStorage.getItem('auth_user')).toBeNull()
+    })
+  })
+
+  describe('restoreSession', () => {
+    it('restores user and token from localStorage', () => {
+      const mockUser = {
+        id: '1',
+        name: 'Test',
+        email: 'test@example.com',
+        persona: 'gentle',
+        aiEngine: 'gemini',
+        monthlyBudget: 20000,
+        currency: 'TWD',
+        createdAt: '2026-01-01',
+        updatedAt: '2026-01-01',
+      }
+      localStorage.setItem('auth_token', 'saved-token')
+      localStorage.setItem('auth_user', JSON.stringify(mockUser))
+
+      useAuthStore.getState().restoreSession()
+
+      const state = useAuthStore.getState()
+      expect(state.token).toBe('saved-token')
+      expect(state.user).toEqual(mockUser)
+    })
+
+    it('does nothing if no stored session', () => {
+      useAuthStore.getState().restoreSession()
+
+      const state = useAuthStore.getState()
+      expect(state.token).toBeNull()
+      expect(state.user).toBeNull()
+    })
+
+    it('clears invalid JSON from localStorage', () => {
+      localStorage.setItem('auth_token', 'some-token')
+      localStorage.setItem('auth_user', 'invalid-json')
+
+      useAuthStore.getState().restoreSession()
+
+      expect(useAuthStore.getState().user).toBeNull()
+      expect(localStorage.getItem('auth_token')).toBeNull()
+      expect(localStorage.getItem('auth_user')).toBeNull()
+    })
+  })
+
+  describe('clearError', () => {
+    it('clears the error message', () => {
+      useAuthStore.setState({ error: 'some error' })
+      useAuthStore.getState().clearError()
+      expect(useAuthStore.getState().error).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- 實作 Login/Register 頁面：表單驗證、錯誤提示、登入後跳轉首頁
- 實作 Auth Store (Zustand)：管理 token/user 狀態、login/logout/register actions
- 實作 ProtectedRoute 組件：未認證使用者自動導向 `/login`
- 實作 Token 持久化：localStorage 存儲、頁面重整後自動恢復登入狀態
- 實作 API Client Auth 攔截器：自動附加 Bearer Token
- 撰寫完整單元測試：Auth Store、ProtectedRoute、App 路由

## Related Issue
Closes #6

## Test plan
- [ ] `npm test` 單元測試全數通過
- [ ] CI Pipeline (lint + tsc + vitest + build) 全綠
- [ ] 登入/註冊表單驗證正確（email 格式、密碼長度、密碼確認）
- [ ] 登入後正確跳轉首頁、Token 存入 localStorage
- [ ] 未認證使用者訪問受保護頁面時重導至 `/login`