### PR TITLE
feat(backend): LLM 雙引擎實作 - Gemini/OpenAI 支援 (T-201)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,11 +9,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@google/generative-ai": "^0.24.1",
         "bcrypt": "^6.0.0",
         "cors": "^2.8.6",
         "express": "^5.2.1",
         "express-rate-limit": "^8.3.1",
         "jsonwebtoken": "^9.0.3",
+        "openai": "^6.32.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -602,6 +604,15 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -3742,6 +3753,27 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.32.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.32.0.tgz",
+      "integrity": "sha512-j3k+BjydAf8yQlcOI7WUQMQTbbF5GEIMAE2iZYCOzwwB3S2pCheaWYp+XZRNAch4jWVc52PMDGRRjutao3lLCg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,11 +21,13 @@
   "license": "ISC",
   "description": "Vibe Money Book - Voice-powered expense tracking API",
   "dependencies": {
+    "@google/generative-ai": "^0.24.1",
     "bcrypt": "^6.0.0",
     "cors": "^2.8.6",
     "express": "^5.2.1",
     "express-rate-limit": "^8.3.1",
     "jsonwebtoken": "^9.0.3",
+    "openai": "^6.32.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/backend/src/controllers/aiController.test.ts
+++ b/backend/src/controllers/aiController.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import app from '../app';
+
+// ─── Mock Data ─────────────────────────────────────────────────
+
+const MOCK_USER_ID = 'user-llm-test-001';
+const MOCK_USER = {
+  id: MOCK_USER_ID,
+  name: 'LLM Test User',
+  email: 'llm@test.com',
+  passwordHash: 'hashed_password',
+  persona: 'sarcastic',
+  aiEngine: 'gemini',
+  monthlyBudget: 30000,
+  currency: 'TWD',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  categoryBudgets: [
+    { id: 'cb-1', userId: MOCK_USER_ID, category: 'food', budgetLimit: 8000, isCustom: false, createdAt: new Date(), updatedAt: new Date() },
+    { id: 'cb-2', userId: MOCK_USER_ID, category: 'transport', budgetLimit: 3000, isCustom: false, createdAt: new Date(), updatedAt: new Date() },
+    { id: 'cb-3', userId: MOCK_USER_ID, category: 'entertainment', budgetLimit: 3000, isCustom: false, createdAt: new Date(), updatedAt: new Date() },
+    { id: 'cb-4', userId: MOCK_USER_ID, category: 'shopping', budgetLimit: 3000, isCustom: false, createdAt: new Date(), updatedAt: new Date() },
+    { id: 'cb-5', userId: MOCK_USER_ID, category: 'daily', budgetLimit: 2000, isCustom: false, createdAt: new Date(), updatedAt: new Date() },
+    { id: 'cb-6', userId: MOCK_USER_ID, category: 'medical', budgetLimit: 2000, isCustom: false, createdAt: new Date(), updatedAt: new Date() },
+    { id: 'cb-7', userId: MOCK_USER_ID, category: 'education', budgetLimit: 2000, isCustom: false, createdAt: new Date(), updatedAt: new Date() },
+    { id: 'cb-8', userId: MOCK_USER_ID, category: 'other', budgetLimit: 0, isCustom: false, createdAt: new Date(), updatedAt: new Date() },
+  ],
+};
+
+const MOCK_TRANSACTIONS = [
+  { id: 't-1', userId: MOCK_USER_ID, amount: 500, category: 'food', merchant: '便當店', rawText: '午餐便當500', note: null, transactionDate: new Date(), createdAt: new Date(), updatedAt: new Date() },
+];
+
+// ─── Mock JWT ──────────────────────────────────────────────────
+
+vi.mock('jsonwebtoken', () => ({
+  default: {
+    sign: vi.fn(() => 'mock-token'),
+    verify: vi.fn(() => ({ userId: MOCK_USER_ID })),
+  },
+}));
+
+// ─── Mock Prisma ───────────────────────────────────────────────
+
+vi.mock('../config/database', () => ({
+  default: {
+    user: {
+      findUnique: vi.fn(async ({ where, include }: { where: { id?: string; email?: string }; include?: unknown }) => {
+        if (where.id === MOCK_USER_ID || where.email === 'llm@test.com') {
+          return include ? MOCK_USER : { ...MOCK_USER, categoryBudgets: undefined };
+        }
+        return null;
+      }),
+    },
+    transaction: {
+      findMany: vi.fn(async () => MOCK_TRANSACTIONS),
+    },
+  },
+}));
+
+// ─── Mock LLM Providers ────────────────────────────────────────
+
+const mockExtractData = vi.fn();
+const mockGenerateFeedback = vi.fn();
+
+vi.mock('../services/llm/llmFactory', () => ({
+  getProvider: vi.fn(() => ({
+    extractData: mockExtractData,
+    generateFeedback: mockGenerateFeedback,
+  })),
+}));
+
+// ─── Test Helpers ──────────────────────────────────────────────
+
+const AUTH_HEADER = 'Bearer mock-token';
+const API_KEY_HEADER = 'test-api-key-12345';
+
+function postParse(rawText: string, apiKey = API_KEY_HEADER) {
+  return request(app)
+    .post('/api/v1/ai/parse')
+    .set('Authorization', AUTH_HEADER)
+    .set('X-LLM-API-Key', apiKey)
+    .send({ raw_text: rawText });
+}
+
+function postValidateKey(apiKey = API_KEY_HEADER) {
+  return request(app)
+    .post('/api/v1/ai/validate-key')
+    .set('Authorization', AUTH_HEADER)
+    .set('X-LLM-API-Key', apiKey);
+}
+
+// ─── Tests ─────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  // Default mock responses
+  mockExtractData.mockResolvedValue({
+    amount: 180,
+    category: 'food',
+    merchant: '拉麵店',
+    date: '2026-03-18',
+    confidence: 0.95,
+    is_new_category: false,
+    suggested_category: null,
+  });
+
+  mockGenerateFeedback.mockResolvedValue({
+    text: '180 元買拉麵？你準備靠光合作用過活嗎？',
+    emotion_tag: 'sarcastic_warning',
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('POST /api/v1/ai/parse', () => {
+  // --- 案例 1: 標準輸入 ---
+  it('應正確解析標準自然語言輸入（午餐拉麵 180 元）', async () => {
+    const res = await postParse('午餐吃拉麵 180 元');
+
+    expect(res.status).toBe(200);
+    expect(res.body.code).toBe(200);
+    expect(res.body.message).toBe('解析成功');
+    expect(res.body.data.parsed).toEqual({
+      amount: 180,
+      category: 'food',
+      merchant: '拉麵店',
+      date: '2026-03-18',
+      confidence: 0.95,
+      is_new_category: false,
+      suggested_category: null,
+    });
+    expect(res.body.data.feedback.text).toBeDefined();
+    expect(res.body.data.feedback.emotion_tag).toBe('sarcastic_warning');
+    expect(res.body.data.budget_context).toBeDefined();
+    expect(res.body.data.budget_context.monthly_budget).toBe(30000);
+    expect(res.body.timestamp).toBeDefined();
+  });
+
+  // --- 案例 2: 無金額 ---
+  it('應處理無法辨識金額的情境（amount 為 null）', async () => {
+    mockExtractData.mockResolvedValue({
+      amount: null,
+      category: 'food',
+      merchant: '餐廳',
+      date: '2026-03-18',
+      confidence: 0.5,
+      is_new_category: false,
+      suggested_category: null,
+    });
+
+    const res = await postParse('今天去吃飯');
+    expect(res.status).toBe(200);
+    expect(res.body.data.parsed.amount).toBeNull();
+    expect(res.body.data.parsed.confidence).toBeLessThan(1);
+  });
+
+  // --- 案例 3: 新類別偵測 ---
+  it('應偵測新類別並回傳 suggested_category', async () => {
+    mockExtractData.mockResolvedValue({
+      amount: 1200,
+      category: null,
+      merchant: '寵物店',
+      date: '2026-03-18',
+      confidence: 0.85,
+      is_new_category: true,
+      suggested_category: '寵物',
+    });
+
+    const res = await postParse('帶貓咪去寵物店打疫苗 1200 元');
+    expect(res.status).toBe(200);
+    expect(res.body.data.parsed.is_new_category).toBe(true);
+    expect(res.body.data.parsed.suggested_category).toBe('寵物');
+    expect(res.body.data.parsed.category).toBeNull();
+  });
+
+  // --- 案例 4: 模糊類別 ---
+  it('應處理模糊類別並降低 confidence', async () => {
+    mockExtractData.mockResolvedValue({
+      amount: 350,
+      category: 'entertainment',
+      merchant: '書店',
+      date: '2026-03-18',
+      confidence: 0.6,
+      is_new_category: false,
+      suggested_category: null,
+    });
+
+    const res = await postParse('在書店買了本小說 350');
+    expect(res.status).toBe(200);
+    expect(res.body.data.parsed.confidence).toBeLessThanOrEqual(0.7);
+  });
+
+  // --- 案例 5: 多筆消費（只處理第一筆）---
+  it('應僅處理第一筆消費', async () => {
+    mockExtractData.mockResolvedValue({
+      amount: 100,
+      category: 'food',
+      merchant: '早餐店',
+      date: '2026-03-18',
+      confidence: 0.9,
+      is_new_category: false,
+      suggested_category: null,
+    });
+
+    const res = await postParse('早餐 100 元，午餐 200 元');
+    expect(res.status).toBe(200);
+    expect(res.body.data.parsed.amount).toBe(100);
+  });
+
+  // --- 案例 6: 預算上下文正確計算 ---
+  it('應回傳正確的 budget_context', async () => {
+    const res = await postParse('午餐 180 元');
+    expect(res.status).toBe(200);
+
+    const ctx = res.body.data.budget_context;
+    expect(ctx.monthly_budget).toBe(30000);
+    expect(ctx.spent_this_month).toBe(500); // from MOCK_TRANSACTIONS
+    expect(ctx.remaining).toBe(29500);
+    expect(ctx.category_spent).toBe(500); // food category
+    expect(ctx.category_limit).toBe(8000);
+  });
+
+  // --- 案例 7: 缺少 X-LLM-API-Key ---
+  it('應在缺少 API Key 時回傳 400', async () => {
+    const res = await request(app)
+      .post('/api/v1/ai/parse')
+      .set('Authorization', AUTH_HEADER)
+      .send({ raw_text: '午餐 100 元' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain('API Key');
+  });
+
+  // --- 案例 8: 空白輸入 ---
+  it('應拒絕空白輸入', async () => {
+    const res = await postParse('');
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe(400);
+  });
+
+  // --- 案例 9: 超長輸入 ---
+  it('應拒絕超過 500 字元的輸入', async () => {
+    const longText = 'a'.repeat(501);
+    const res = await postParse(longText);
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe(400);
+  });
+
+  // --- 案例 10: 未認證 ---
+  it('應拒絕未認證的請求', async () => {
+    const res = await request(app)
+      .post('/api/v1/ai/parse')
+      .set('X-LLM-API-Key', API_KEY_HEADER)
+      .send({ raw_text: '午餐 100 元' });
+
+    expect(res.status).toBe(401);
+  });
+
+  // --- 案例 11: LLM API Key 無效 ---
+  it('應在 LLM API Key 無效時回傳 403', async () => {
+    mockExtractData.mockRejectedValue(
+      Object.assign(new Error('Gemini API Key 無效，請確認您的 API Key'), {
+        statusCode: 403,
+      })
+    );
+    // Re-mock to throw AppError
+    const { AppError } = await import('../middlewares/errorHandler');
+    mockExtractData.mockRejectedValue(new AppError('Gemini API Key 無效，請確認您的 API Key', 403));
+
+    const res = await postParse('午餐 100 元', 'invalid-key');
+    expect(res.status).toBe(403);
+    expect(res.body.message).toContain('API Key');
+  });
+
+  // --- 案例 12: LLM 服務不可用 ---
+  it('應在 LLM 服務不可用時回傳 502', async () => {
+    const { AppError } = await import('../middlewares/errorHandler');
+    mockExtractData.mockRejectedValue(new AppError('LLM 服務暫時不可用，請稍後再試', 502));
+
+    const res = await postParse('午餐 100 元');
+    expect(res.status).toBe(502);
+    expect(res.body.message).toContain('不可用');
+  });
+
+  // --- 案例 13: 引擎切換邏輯 ---
+  it('應根據使用者偏好選擇正確的 Provider', async () => {
+    const { getProvider } = await import('../services/llm/llmFactory');
+    await postParse('午餐 100 元');
+    // getProvider should be called (mocked, but verifies the flow)
+    expect(getProvider).toHaveBeenCalled();
+  });
+
+  // --- 案例 14: Prompt 組裝驗證 ---
+  it('應將使用者類別清單注入 Prompt', async () => {
+    await postParse('午餐 100 元');
+    // extractData should be called with a prompt containing category names
+    const callArgs = mockExtractData.mock.calls[0];
+    const prompt = callArgs[0] as string;
+    expect(prompt).toContain('food');
+    expect(prompt).toContain('transport');
+    expect(prompt).toContain('entertainment');
+  });
+});
+
+describe('POST /api/v1/ai/validate-key', () => {
+  // --- 案例 15: 驗證成功 ---
+  it('應在 API Key 有效時回傳 valid: true', async () => {
+    const res = await postValidateKey();
+
+    expect(res.status).toBe(200);
+    expect(res.body.code).toBe(200);
+    expect(res.body.data.valid).toBe(true);
+    expect(res.body.data.engine).toBe('gemini');
+  });
+
+  // --- 案例 16: 驗證失敗 ---
+  it('應在 API Key 無效時回傳 403', async () => {
+    const { AppError } = await import('../middlewares/errorHandler');
+    mockExtractData.mockRejectedValue(new AppError('Gemini API Key 無效，請確認您的 API Key', 403));
+
+    const res = await postValidateKey('bad-key');
+    expect(res.status).toBe(403);
+  });
+
+  // --- 案例 17: 缺少 API Key ---
+  it('應在缺少 API Key 時回傳 400', async () => {
+    const res = await request(app)
+      .post('/api/v1/ai/validate-key')
+      .set('Authorization', AUTH_HEADER);
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain('API Key');
+  });
+
+  // --- 案例 18: 未認證 ---
+  it('應拒絕未認證的請求', async () => {
+    const res = await request(app)
+      .post('/api/v1/ai/validate-key')
+      .set('X-LLM-API-Key', API_KEY_HEADER);
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/src/controllers/aiController.ts
+++ b/backend/src/controllers/aiController.ts
@@ -1,0 +1,75 @@
+import { Response, NextFunction } from 'express';
+import { AuthRequest } from '../middlewares/auth';
+import { aiParseSchema } from '../validators/aiValidators';
+import * as llmService from '../services/llmService';
+import { AppError } from '../middlewares/errorHandler';
+import { ApiResponse } from '../types';
+import { ZodError } from 'zod';
+
+function formatZodErrors(error: ZodError) {
+  return error.issues.map((issue) => ({
+    field: issue.path.join('.'),
+    reason: issue.message,
+  }));
+}
+
+function extractApiKey(req: AuthRequest): string {
+  const apiKey = req.headers['x-llm-api-key'] as string | undefined;
+  if (!apiKey) {
+    throw new AppError('請提供 LLM API Key（X-LLM-API-Key Header）', 400);
+  }
+  return apiKey;
+}
+
+export async function aiParse(
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const parsed = aiParseSchema.safeParse(req.body);
+    if (!parsed.success) {
+      throw new AppError('參數驗證失敗', 400, formatZodErrors(parsed.error));
+    }
+
+    const apiKey = extractApiKey(req);
+    const userId = req.userId!;
+
+    const result = await llmService.parseTransaction(userId, parsed.data.raw_text, apiKey);
+
+    const response: ApiResponse<typeof result> = {
+      code: 200,
+      message: '解析成功',
+      data: result,
+      timestamp: new Date().toISOString(),
+    };
+
+    res.status(200).json(response);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function validateKey(
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const apiKey = extractApiKey(req);
+    const userId = req.userId!;
+
+    const result = await llmService.validateApiKey(userId, apiKey);
+
+    const response: ApiResponse<typeof result> = {
+      code: 200,
+      message: '驗證成功',
+      data: result,
+      timestamp: new Date().toISOString(),
+    };
+
+    res.status(200).json(response);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/prompts/dataExtractorPrompt.ts
+++ b/backend/src/prompts/dataExtractorPrompt.ts
@@ -1,0 +1,35 @@
+import { DataExtractorInput } from '../types/llm';
+
+export function buildDataExtractorPrompt(input: DataExtractorInput): string {
+  const categoriesList = input.categories.join(', ');
+
+  return `你是一個記帳助手，負責將使用者的自然語言輸入轉換為結構化的 JSON 資料。
+
+## 規則
+1. 從使用者輸入中萃取：金額、類別、商家、日期
+2. 金額必須為正數。若無法辨識金額，回傳 amount 為 null
+3. 類別必須從以下清單中選擇：[${categoriesList}]
+4. 若無法匹配任何現有類別，將 is_new_category 設為 true，並在 suggested_category 中填入建議的新類別名稱
+5. 偵測相似類別名稱（如「咖啡」與「飲料」），避免重複建立，優先歸入現有類別
+6. 若未提及商家，根據消費內容推測合理的商家名稱
+7. 若未提及日期，使用今天的日期：${input.currentDate}
+8. 僅處理第一筆消費，若包含多筆，忽略後續的
+9. confidence 值介於 0 到 1 之間，反映解析的確定性
+
+## 輸出格式
+僅回傳以下 JSON，不要包含任何其他文字或 markdown 標記：
+{
+  "amount": <number | null>,
+  "category": "<string | null>",
+  "merchant": "<string>",
+  "date": "<YYYY-MM-DD>",
+  "confidence": <number>,
+  "is_new_category": <boolean>,
+  "suggested_category": "<string | null>"
+}
+
+## 使用者輸入
+${input.rawText}`;
+}
+
+export const DATA_EXTRACTOR_SYSTEM_PROMPT = '你是一個精確的記帳資料萃取引擎。你只能回傳 JSON 格式的結果，不能包含任何其他文字。';

--- a/backend/src/prompts/personaFeedbackPrompt.ts
+++ b/backend/src/prompts/personaFeedbackPrompt.ts
@@ -1,0 +1,45 @@
+import { PersonaFeedbackInput } from '../types/llm';
+
+const PERSONA_DEFINITIONS: Record<string, string> = {
+  sarcastic: `你是一個毒舌的財務評論員。你的風格是尖酸刻薄但有趣，用諷刺的方式提醒使用者注意消費。
+    - 用嘲諷語氣評價消費行為
+    - 若超預算，加重諷刺力道
+    - 保持幽默感，不要真的傷人`,
+
+  gentle: `你是一個溫柔體貼的財務顧問。你的風格是溫暖鼓勵，用正面的方式引導使用者理財。
+    - 用鼓勵和關心的語氣
+    - 若超預算，溫柔提醒但不責備
+    - 偶爾給予正面肯定`,
+
+  guilt_trip: `你是一個擅長情緒勒索的財務顧問。你的風格是用愧疚感讓使用者反思消費行為。
+    - 用讓人感到愧疚的方式評論消費
+    - 提及未來的影響或犧牲
+    - 若超預算，加重情緒勒索`,
+};
+
+export function buildPersonaFeedbackPrompt(input: PersonaFeedbackInput): string {
+  const budgetUsedPercent = Math.round(input.budgetUsedRatio * 100);
+  const categoryUsedPercent = Math.round(input.categoryBudgetUsedRatio * 100);
+
+  return `根據以下消費資訊，用你的角色風格給出簡短的財務評論（50字以內）。
+
+## 消費資訊
+- 金額：${input.amount} 元
+- 類別：${input.category}
+- 商家：${input.merchant}
+- 月預算總額：${input.monthlyBudget} 元
+- 月預算已使用：${budgetUsedPercent}%
+- 該類別預算已使用：${categoryUsedPercent}%
+- 剩餘月預算：${input.remainingBudget} 元
+
+## 輸出格式
+僅回傳以下 JSON，不要包含任何其他文字或 markdown 標記：
+{
+  "feedback": "<你的評論，50字以內>",
+  "emotion_tag": "<情緒標籤，如 sarcastic_warning, gentle_encouragement, guilt_heavy 等>"
+}`;
+}
+
+export function getPersonaSystemPrompt(persona: string): string {
+  return PERSONA_DEFINITIONS[persona] || PERSONA_DEFINITIONS.gentle;
+}

--- a/backend/src/routes/aiRoutes.ts
+++ b/backend/src/routes/aiRoutes.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { authMiddleware } from '../middlewares/auth';
+import { llmRateLimiter } from '../middlewares/rateLimiter';
+import { aiParse, validateKey } from '../controllers/aiController';
+
+const router = Router();
+
+router.post('/parse', authMiddleware, llmRateLimiter, aiParse);
+router.post('/validate-key', authMiddleware, llmRateLimiter, validateKey);
+
+export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { healthCheck } from '../controllers/healthController';
 import authRoutes from './authRoutes';
 import userRoutes from './userRoutes';
+import aiRoutes from './aiRoutes';
 
 const router = Router();
 
@@ -11,9 +12,9 @@ router.get('/health', healthCheck);
 // API v1 routes
 router.use('/api/v1/auth', authRoutes);
 router.use('/api/v1/users', userRoutes);
+router.use('/api/v1/ai', aiRoutes);
 
 // Future routes will be added here:
-// router.use('/api/v1/ai', aiRoutes);
 // router.use('/api/v1/transactions', transactionRoutes);
 // router.use('/api/v1/budget', budgetRoutes);
 // router.use('/api/v1/stats', statsRoutes);

--- a/backend/src/services/llm/geminiProvider.ts
+++ b/backend/src/services/llm/geminiProvider.ts
@@ -1,0 +1,90 @@
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import { LLMProvider } from './llmProvider';
+import { ParsedTransaction, AIFeedbackContent } from '../../types/llm';
+import { AppError } from '../../middlewares/errorHandler';
+
+const GEMINI_MODEL = process.env.GEMINI_MODEL || 'gemini-2.0-flash-lite';
+const TIMEOUT_MS = 3000;
+const MAX_RETRIES = 2;
+
+export class GeminiProvider implements LLMProvider {
+  private async callWithRetry(
+    apiKey: string,
+    systemPrompt: string,
+    userPrompt: string,
+    temperature: number,
+    maxTokens: number
+  ): Promise<string> {
+    const genAI = new GoogleGenerativeAI(apiKey);
+    const model = genAI.getGenerativeModel({
+      model: GEMINI_MODEL,
+      generationConfig: {
+        temperature,
+        maxOutputTokens: maxTokens,
+      },
+      systemInstruction: systemPrompt,
+    });
+
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+        const result = await model.generateContent({
+          contents: [{ role: 'user', parts: [{ text: userPrompt }] }],
+        });
+
+        clearTimeout(timeout);
+        const text = result.response.text();
+        if (!text) {
+          throw new Error('Gemini 回傳空結果');
+        }
+        return text;
+      } catch (err) {
+        lastError = err as Error;
+        if (attempt < MAX_RETRIES) {
+          continue;
+        }
+      }
+    }
+
+    const message = lastError?.message || '';
+    if (message.includes('API_KEY_INVALID') || message.includes('PERMISSION_DENIED')) {
+      throw new AppError('Gemini API Key 無效，請確認您的 API Key', 403);
+    }
+    if (message.includes('RESOURCE_EXHAUSTED') || message.includes('quota')) {
+      throw new AppError('Gemini API 額度已用盡，請檢查您的配額或切換引擎', 403);
+    }
+    throw new AppError('LLM 服務暫時不可用，請稍後再試', 502);
+  }
+
+  async extractData(prompt: string, apiKey: string): Promise<ParsedTransaction> {
+    const systemPrompt = '你是一個精確的記帳資料萃取引擎。你只能回傳 JSON 格式的結果，不能包含任何其他文字。';
+    const text = await this.callWithRetry(apiKey, systemPrompt, prompt, 0, 200);
+    return this.parseJSON<ParsedTransaction>(text);
+  }
+
+  async generateFeedback(prompt: string, apiKey: string): Promise<AIFeedbackContent> {
+    // The persona system prompt is embedded in the prompt parameter
+    const parts = prompt.split('\n---SYSTEM---\n');
+    const systemPrompt = parts.length > 1 ? parts[0] : '';
+    const userPrompt = parts.length > 1 ? parts[1] : prompt;
+    const text = await this.callWithRetry(apiKey, systemPrompt, userPrompt, 0.8, 150);
+    return this.parseJSON<AIFeedbackContent>(text);
+  }
+
+  private parseJSON<T>(text: string): T {
+    // Strip markdown code blocks if present
+    let cleaned = text.trim();
+    if (cleaned.startsWith('```')) {
+      cleaned = cleaned.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '');
+    }
+    try {
+      return JSON.parse(cleaned) as T;
+    } catch {
+      throw new AppError('LLM 回傳格式異常，無法解析', 502);
+    }
+  }
+}

--- a/backend/src/services/llm/llmFactory.ts
+++ b/backend/src/services/llm/llmFactory.ts
@@ -1,0 +1,13 @@
+import { AIEngine } from '../../types/llm';
+import { LLMProvider } from './llmProvider';
+import { GeminiProvider } from './geminiProvider';
+import { OpenAIProvider } from './openaiProvider';
+
+const providers: Record<AIEngine, LLMProvider> = {
+  gemini: new GeminiProvider(),
+  openai: new OpenAIProvider(),
+};
+
+export function getProvider(engine: AIEngine): LLMProvider {
+  return providers[engine];
+}

--- a/backend/src/services/llm/llmProvider.ts
+++ b/backend/src/services/llm/llmProvider.ts
@@ -1,0 +1,6 @@
+import { ParsedTransaction, AIFeedbackContent } from '../../types/llm';
+
+export interface LLMProvider {
+  extractData(prompt: string, apiKey: string): Promise<ParsedTransaction>;
+  generateFeedback(prompt: string, apiKey: string): Promise<AIFeedbackContent>;
+}

--- a/backend/src/services/llm/openaiProvider.ts
+++ b/backend/src/services/llm/openaiProvider.ts
@@ -1,0 +1,82 @@
+import OpenAI from 'openai';
+import { LLMProvider } from './llmProvider';
+import { ParsedTransaction, AIFeedbackContent } from '../../types/llm';
+import { AppError } from '../../middlewares/errorHandler';
+
+const OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-4o-mini';
+const TIMEOUT_MS = 3000;
+const MAX_RETRIES = 2;
+
+export class OpenAIProvider implements LLMProvider {
+  private async callWithRetry(
+    apiKey: string,
+    systemPrompt: string,
+    userPrompt: string,
+    temperature: number,
+    maxTokens: number
+  ): Promise<string> {
+    const client = new OpenAI({ apiKey, timeout: TIMEOUT_MS });
+
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        const response = await client.chat.completions.create({
+          model: OPENAI_MODEL,
+          messages: [
+            { role: 'system', content: systemPrompt },
+            { role: 'user', content: userPrompt },
+          ],
+          temperature,
+          max_tokens: maxTokens,
+        });
+
+        const text = response.choices[0]?.message?.content;
+        if (!text) {
+          throw new Error('OpenAI 回傳空結果');
+        }
+        return text;
+      } catch (err) {
+        lastError = err as Error;
+        if (attempt < MAX_RETRIES) {
+          continue;
+        }
+      }
+    }
+
+    const message = lastError?.message || '';
+    if (message.includes('Incorrect API key') || message.includes('invalid_api_key')) {
+      throw new AppError('OpenAI API Key 無效，請確認您的 API Key', 403);
+    }
+    if (message.includes('Rate limit') || message.includes('quota')) {
+      throw new AppError('OpenAI API 額度已用盡，請檢查您的配額或切換引擎', 403);
+    }
+    throw new AppError('LLM 服務暫時不可用，請稍後再試', 502);
+  }
+
+  async extractData(prompt: string, apiKey: string): Promise<ParsedTransaction> {
+    const systemPrompt = '你是一個精確的記帳資料萃取引擎。你只能回傳 JSON 格式的結果，不能包含任何其他文字。';
+    const text = await this.callWithRetry(apiKey, systemPrompt, prompt, 0, 200);
+    return this.parseJSON<ParsedTransaction>(text);
+  }
+
+  async generateFeedback(prompt: string, apiKey: string): Promise<AIFeedbackContent> {
+    const parts = prompt.split('\n---SYSTEM---\n');
+    const systemPrompt = parts.length > 1 ? parts[0] : '';
+    const userPrompt = parts.length > 1 ? parts[1] : prompt;
+    const text = await this.callWithRetry(apiKey, systemPrompt, userPrompt, 0.8, 150);
+    return this.parseJSON<AIFeedbackContent>(text);
+  }
+
+  private parseJSON<T>(text: string): T {
+    let cleaned = text.trim();
+    if (cleaned.startsWith('```')) {
+      cleaned = cleaned.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '');
+    }
+    try {
+      return JSON.parse(cleaned) as T;
+    } catch {
+      throw new AppError('LLM 回傳格式異常，無法解析', 502);
+    }
+  }
+}

--- a/backend/src/services/llmService.ts
+++ b/backend/src/services/llmService.ts
@@ -1,0 +1,126 @@
+import prisma from '../config/database';
+import { getProvider } from './llm/llmFactory';
+import { buildDataExtractorPrompt } from '../prompts/dataExtractorPrompt';
+import { buildPersonaFeedbackPrompt, getPersonaSystemPrompt } from '../prompts/personaFeedbackPrompt';
+import {
+  AIEngine,
+  Persona,
+  ParsedTransaction,
+  AIFeedbackContent,
+  BudgetContext,
+  PersonaFeedbackInput,
+} from '../types/llm';
+import { AppError } from '../middlewares/errorHandler';
+
+export async function parseTransaction(
+  userId: string,
+  rawText: string,
+  apiKey: string
+): Promise<{ parsed: ParsedTransaction; feedback: AIFeedbackContent; budget_context: BudgetContext }> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    include: { categoryBudgets: true },
+  });
+
+  if (!user) {
+    throw new AppError('使用者不存在', 404);
+  }
+
+  const engine = user.aiEngine as AIEngine;
+  const persona = user.persona as Persona;
+  const provider = getProvider(engine);
+
+  // Build category list for prompt
+  const categories = user.categoryBudgets.map((cb) => cb.category);
+  const currentDate = new Date().toISOString().split('T')[0];
+
+  // 1. Data extraction
+  const extractorPrompt = buildDataExtractorPrompt({
+    rawText,
+    categories,
+    currentDate,
+  });
+
+  const parsed = await provider.extractData(extractorPrompt, apiKey);
+
+  // 2. Get budget context
+  const now = new Date();
+  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+
+  const transactions = await prisma.transaction.findMany({
+    where: {
+      userId,
+      transactionDate: {
+        gte: monthStart,
+        lte: monthEnd,
+      },
+    },
+  });
+
+  const monthlyBudget = Number(user.monthlyBudget);
+  const spentThisMonth = transactions.reduce((sum, t) => sum + Number(t.amount), 0);
+  const remaining = monthlyBudget - spentThisMonth;
+  const usedRatio = monthlyBudget > 0 ? spentThisMonth / monthlyBudget : 0;
+
+  const resolvedCategory = parsed.category || 'other';
+  const categoryBudget = user.categoryBudgets.find((cb) => cb.category === resolvedCategory);
+  const categoryLimit = categoryBudget ? Number(categoryBudget.budgetLimit) : 0;
+  const categorySpent = transactions
+    .filter((t) => t.category === resolvedCategory)
+    .reduce((sum, t) => sum + Number(t.amount), 0);
+  const categoryBudgetUsedRatio = categoryLimit > 0 ? categorySpent / categoryLimit : 0;
+
+  const budgetContext: BudgetContext = {
+    monthly_budget: monthlyBudget,
+    spent_this_month: spentThisMonth,
+    remaining,
+    used_ratio: Math.round(usedRatio * 100) / 100,
+    category_spent: categorySpent,
+    category_limit: categoryLimit,
+  };
+
+  // 3. Generate persona feedback
+  const feedbackInput: PersonaFeedbackInput = {
+    persona,
+    amount: parsed.amount || 0,
+    category: resolvedCategory,
+    merchant: parsed.merchant || '',
+    budgetUsedRatio: usedRatio,
+    categoryBudgetUsedRatio,
+    monthlyBudget,
+    remainingBudget: remaining,
+  };
+
+  const personaSystemPrompt = getPersonaSystemPrompt(persona);
+  const feedbackUserPrompt = buildPersonaFeedbackPrompt(feedbackInput);
+  const combinedPrompt = `${personaSystemPrompt}\n---SYSTEM---\n${feedbackUserPrompt}`;
+
+  const feedback = await provider.generateFeedback(combinedPrompt, apiKey);
+
+  return { parsed, feedback, budget_context: budgetContext };
+}
+
+export async function validateApiKey(userId: string, apiKey: string): Promise<{ valid: boolean; engine: AIEngine }> {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user) {
+    throw new AppError('使用者不存在', 404);
+  }
+
+  const engine = user.aiEngine as AIEngine;
+  const provider = getProvider(engine);
+
+  // Minimal test: try extracting from a simple input
+  try {
+    await provider.extractData(
+      '測試：午餐 100 元',
+      apiKey
+    );
+    return { valid: true, engine };
+  } catch (err) {
+    if (err instanceof AppError && err.statusCode === 403) {
+      throw err;
+    }
+    throw new AppError('API Key 驗證失敗，請確認 Key 是否正確', 403);
+  }
+}

--- a/backend/src/types/llm.ts
+++ b/backend/src/types/llm.ts
@@ -1,0 +1,43 @@
+export type AIEngine = 'gemini' | 'openai';
+export type Persona = 'sarcastic' | 'gentle' | 'guilt_trip';
+
+export interface ParsedTransaction {
+  amount: number | null;
+  category: string | null;
+  merchant: string;
+  date: string;
+  confidence: number;
+  is_new_category: boolean;
+  suggested_category: string | null;
+}
+
+export interface AIFeedbackContent {
+  text: string;
+  emotion_tag: string;
+}
+
+export interface BudgetContext {
+  monthly_budget: number;
+  spent_this_month: number;
+  remaining: number;
+  used_ratio: number;
+  category_spent: number;
+  category_limit: number;
+}
+
+export interface DataExtractorInput {
+  rawText: string;
+  categories: string[];
+  currentDate: string;
+}
+
+export interface PersonaFeedbackInput {
+  persona: Persona;
+  amount: number;
+  category: string;
+  merchant: string;
+  budgetUsedRatio: number;
+  categoryBudgetUsedRatio: number;
+  monthlyBudget: number;
+  remainingBudget: number;
+}

--- a/backend/src/validators/aiValidators.ts
+++ b/backend/src/validators/aiValidators.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const aiParseSchema = z.object({
+  raw_text: z
+    .string({ error: '請提供輸入文字' })
+    .min(1, '輸入文字不可為空')
+    .max(500, '輸入文字不可超過 500 字元'),
+});
+
+export type AIParseInput = z.infer<typeof aiParseSchema>;


### PR DESCRIPTION
## Summary
- 實作 LLMProvider 抽象介面，支援 Gemini 與 OpenAI 雙引擎動態切換
- 實作資料萃取引擎（自然語言 → JSON）與人設回饋引擎（毒舌/溫柔/情勒）
- 新增 `POST /ai/parse` 與 `POST /ai/validate-key` 端點
- API Key 透過 `X-LLM-API-Key` Header 傳入，用後即棄不持久化
- 錯誤處理：3s timeout、最多重試 2 次、友善錯誤訊息
- 18 組單元測試全部通過（含邊界情境：無金額、新類別偵測、多筆消費）

## Files Changed
| 檔案 | 說明 |
|------|------|
| `src/types/llm.ts` | LLM 相關型別定義 |
| `src/services/llm/llmProvider.ts` | LLMProvider 抽象介面 |
| `src/services/llm/geminiProvider.ts` | Gemini 引擎實作 |
| `src/services/llm/openaiProvider.ts` | OpenAI 引擎實作 |
| `src/services/llm/llmFactory.ts` | 引擎工廠 |
| `src/prompts/dataExtractorPrompt.ts` | 資料萃取 Prompt 模板 |
| `src/prompts/personaFeedbackPrompt.ts` | 人設回饋 Prompt 模板 |
| `src/services/llmService.ts` | LLM 業務邏輯服務 |
| `src/controllers/aiController.ts` | AI 端點控制器 |
| `src/validators/aiValidators.ts` | Zod 驗證 |
| `src/routes/aiRoutes.ts` | AI 路由定義 |
| `src/routes/index.ts` | 掛載 AI 路由 |

## Test Plan
- [x] TypeScript 編譯通過（`tsc --noEmit`）
- [x] 18 組單元測試通過（Mock Provider 驗證引擎切換、Prompt 組裝、錯誤處理）
- [x] ESLint 檢查通過
- [ ] 手動：使用真實 API Key 驗證 Gemini/OpenAI 引擎回傳結果品質（需 staging 環境）

Closes #7