### PR TITLE
feat(backend): 交易 CRUD API 實作 (T-202)

### DIFF
--- a/backend/src/controllers/transactionController.test.ts
+++ b/backend/src/controllers/transactionController.test.ts
@@ -1,0 +1,412 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import app from '../app';
+
+// ─── Mock Data ─────────────────────────────────────────────────
+
+const MOCK_USER_ID = 'user-txn-test-001';
+const OTHER_USER_ID = 'user-txn-test-002';
+
+const now = new Date();
+const mockTransactions: Record<string, {
+  id: string;
+  userId: string;
+  amount: number;
+  category: string;
+  merchant: string | null;
+  rawText: string;
+  note: string | null;
+  transactionDate: Date;
+  createdAt: Date;
+  updatedAt: Date;
+  aiFeedback?: {
+    id: string;
+    feedbackText: string;
+    emotionTag: string;
+    personaUsed: string;
+    createdAt: Date;
+  } | null;
+}> = {};
+
+let txnCounter = 0;
+
+// ─── Mock JWT ──────────────────────────────────────────────────
+
+vi.mock('jsonwebtoken', () => ({
+  default: {
+    sign: vi.fn(() => 'mock-token'),
+    verify: vi.fn(() => ({ userId: MOCK_USER_ID })),
+  },
+}));
+
+// ─── Mock Prisma ───────────────────────────────────────────────
+
+vi.mock('../config/database', () => ({
+  default: {
+    user: {
+      findUnique: vi.fn(async () => null),
+      create: vi.fn(async () => null),
+    },
+    transaction: {
+      create: vi.fn(async ({ data, include: _include }: { data: Record<string, unknown>; include?: unknown }) => {
+        txnCounter++;
+        const id = `txn-${txnCounter}`;
+        const feedbackData = data.aiFeedback as { create: Record<string, unknown> } | undefined;
+        const txn = {
+          id,
+          userId: data.userId as string,
+          amount: data.amount as number,
+          category: data.category as string,
+          merchant: (data.merchant as string) || null,
+          rawText: data.rawText as string,
+          note: (data.note as string) || null,
+          transactionDate: data.transactionDate as Date,
+          createdAt: now,
+          updatedAt: now,
+          aiFeedback: feedbackData
+            ? {
+                id: `fb-${txnCounter}`,
+                feedbackText: feedbackData.create.feedbackText as string,
+                emotionTag: feedbackData.create.emotionTag as string,
+                personaUsed: feedbackData.create.personaUsed as string,
+                createdAt: now,
+              }
+            : null,
+        };
+        mockTransactions[id] = txn;
+        return txn;
+      }),
+      findMany: vi.fn(async ({ where, orderBy, skip, take }: {
+        where: Record<string, unknown>;
+        orderBy?: Record<string, string>;
+        skip?: number;
+        take?: number;
+      }) => {
+        let items = Object.values(mockTransactions).filter((t) => t.userId === where.userId);
+
+        if (where.category) {
+          items = items.filter((t) => t.category === where.category);
+        }
+        if (where.transactionDate) {
+          const dateFilter = where.transactionDate as { gte?: Date; lte?: Date };
+          if (dateFilter.gte) items = items.filter((t) => t.transactionDate >= dateFilter.gte!);
+          if (dateFilter.lte) items = items.filter((t) => t.transactionDate <= dateFilter.lte!);
+        }
+
+        // Sort
+        if (orderBy?.transactionDate === 'desc') {
+          items.sort((a, b) => b.transactionDate.getTime() - a.transactionDate.getTime());
+        } else {
+          items.sort((a, b) => a.transactionDate.getTime() - b.transactionDate.getTime());
+        }
+
+        if (skip !== undefined) items = items.slice(skip);
+        if (take !== undefined) items = items.slice(0, take);
+
+        return items;
+      }),
+      findUnique: vi.fn(async ({ where, include: _include }: { where: { id: string }; include?: unknown }) => {
+        const txn = mockTransactions[where.id] || null;
+        return txn;
+      }),
+      count: vi.fn(async ({ where }: { where: Record<string, unknown> }) => {
+        let items = Object.values(mockTransactions).filter((t) => t.userId === where.userId);
+        if (where.category) items = items.filter((t) => t.category === where.category);
+        return items.length;
+      }),
+      delete: vi.fn(async ({ where }: { where: { id: string } }) => {
+        const txn = mockTransactions[where.id];
+        delete mockTransactions[where.id];
+        return txn;
+      }),
+    },
+  },
+}));
+
+// ─── Test Helpers ──────────────────────────────────────────────
+
+const AUTH_HEADER = 'Bearer mock-token';
+
+function createTxnPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    amount: 180,
+    category: 'food',
+    merchant: '拉麵店',
+    raw_text: '午餐吃拉麵 180 元',
+    transaction_date: '2026-03-18',
+    ...overrides,
+  };
+}
+
+// ─── Tests ─────────────────────────────────────────────────────
+
+beforeEach(() => {
+  // Clear mock transactions
+  Object.keys(mockTransactions).forEach((key) => delete mockTransactions[key]);
+  txnCounter = 0;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('POST /api/v1/transactions', () => {
+  it('應成功建立交易記錄', async () => {
+    const res = await request(app)
+      .post('/api/v1/transactions')
+      .set('Authorization', AUTH_HEADER)
+      .send(createTxnPayload());
+
+    expect(res.status).toBe(201);
+    expect(res.body.code).toBe(201);
+    expect(res.body.message).toBe('交易建立成功');
+    expect(res.body.data.transaction.amount).toBe(180);
+    expect(res.body.data.transaction.category).toBe('food');
+    expect(res.body.data.transaction.merchant).toBe('拉麵店');
+    expect(res.body.data.transaction.transaction_date).toBe('2026-03-18');
+    expect(res.body.data.feedback).toBeNull();
+  });
+
+  it('應同時建立交易與 AI 回饋記錄', async () => {
+    const res = await request(app)
+      .post('/api/v1/transactions')
+      .set('Authorization', AUTH_HEADER)
+      .send(createTxnPayload({
+        feedback: {
+          text: '又吃拉麵？你準備靠光合作用過活嗎？',
+          emotion_tag: 'sarcastic_warning',
+          persona_used: 'sarcastic',
+        },
+      }));
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.feedback).not.toBeNull();
+    expect(res.body.data.feedback.feedback_text).toBe('又吃拉麵？你準備靠光合作用過活嗎？');
+    expect(res.body.data.feedback.persona_used).toBe('sarcastic');
+  });
+
+  it('應拒絕金額為負數的交易', async () => {
+    const res = await request(app)
+      .post('/api/v1/transactions')
+      .set('Authorization', AUTH_HEADER)
+      .send(createTxnPayload({ amount: -100 }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe(400);
+  });
+
+  it('應拒絕缺少必填欄位的請求', async () => {
+    const res = await request(app)
+      .post('/api/v1/transactions')
+      .set('Authorization', AUTH_HEADER)
+      .send({ amount: 100 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toBeDefined();
+  });
+
+  it('應拒絕無效的日期格式', async () => {
+    const res = await request(app)
+      .post('/api/v1/transactions')
+      .set('Authorization', AUTH_HEADER)
+      .send(createTxnPayload({ transaction_date: '2026/03/18' }));
+
+    expect(res.status).toBe(400);
+  });
+
+  it('應拒絕超過 500 字元的 raw_text', async () => {
+    const res = await request(app)
+      .post('/api/v1/transactions')
+      .set('Authorization', AUTH_HEADER)
+      .send(createTxnPayload({ raw_text: 'a'.repeat(501) }));
+
+    expect(res.status).toBe(400);
+  });
+
+  it('應拒絕未認證的請求', async () => {
+    const res = await request(app)
+      .post('/api/v1/transactions')
+      .send(createTxnPayload());
+
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/v1/transactions', () => {
+  beforeEach(async () => {
+    // Seed some transactions
+    for (let i = 1; i <= 3; i++) {
+      await request(app)
+        .post('/api/v1/transactions')
+        .set('Authorization', AUTH_HEADER)
+        .send(createTxnPayload({
+          amount: i * 100,
+          category: i === 3 ? 'transport' : 'food',
+          transaction_date: `2026-03-${String(15 + i).padStart(2, '0')}`,
+        }));
+    }
+  });
+
+  it('應回傳分頁交易列表', async () => {
+    const res = await request(app)
+      .get('/api/v1/transactions')
+      .set('Authorization', AUTH_HEADER);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.items).toHaveLength(3);
+    expect(res.body.data.pagination.total).toBe(3);
+    expect(res.body.data.pagination.page).toBe(1);
+  });
+
+  it('應支援分頁查詢（limit=1）', async () => {
+    const res = await request(app)
+      .get('/api/v1/transactions?limit=1&page=1')
+      .set('Authorization', AUTH_HEADER);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.items).toHaveLength(1);
+    expect(res.body.data.pagination.pages).toBe(3);
+  });
+
+  it('應支援按類別篩選', async () => {
+    const res = await request(app)
+      .get('/api/v1/transactions?category=transport')
+      .set('Authorization', AUTH_HEADER);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.items).toHaveLength(1);
+    expect(res.body.data.items[0].category).toBe('transport');
+  });
+
+  it('應支援按日期範圍篩選', async () => {
+    const res = await request(app)
+      .get('/api/v1/transactions?start_date=2026-03-17&end_date=2026-03-18')
+      .set('Authorization', AUTH_HEADER);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.items.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('應在無結果時回傳空陣列', async () => {
+    const res = await request(app)
+      .get('/api/v1/transactions?category=nonexistent')
+      .set('Authorization', AUTH_HEADER);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.items).toHaveLength(0);
+    expect(res.body.data.pagination.total).toBe(0);
+  });
+
+  it('應拒絕未認證的請求', async () => {
+    const res = await request(app)
+      .get('/api/v1/transactions');
+
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/v1/transactions/:id', () => {
+  it('應回傳單筆交易詳情', async () => {
+    // Create a transaction first
+    const createRes = await request(app)
+      .post('/api/v1/transactions')
+      .set('Authorization', AUTH_HEADER)
+      .send(createTxnPayload());
+
+    const txnId = createRes.body.data.transaction.id;
+
+    const res = await request(app)
+      .get(`/api/v1/transactions/${txnId}`)
+      .set('Authorization', AUTH_HEADER);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.id).toBe(txnId);
+    expect(res.body.data.amount).toBe(180);
+    expect(res.body.data.raw_text).toBe('午餐吃拉麵 180 元');
+  });
+
+  it('應在交易不存在時回傳 404', async () => {
+    const res = await request(app)
+      .get('/api/v1/transactions/nonexistent-id')
+      .set('Authorization', AUTH_HEADER);
+
+    expect(res.status).toBe(404);
+  });
+
+  it('應拒絕存取其他使用者的交易', async () => {
+    // Create a transaction owned by another user
+    const otherId = `txn-other-${Date.now()}`;
+    mockTransactions[otherId] = {
+      id: otherId,
+      userId: OTHER_USER_ID,
+      amount: 999,
+      category: 'food',
+      merchant: '別人的店',
+      rawText: '別人的交易',
+      note: null,
+      transactionDate: now,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    const res = await request(app)
+      .get(`/api/v1/transactions/${otherId}`)
+      .set('Authorization', AUTH_HEADER);
+
+    expect(res.status).toBe(404); // 404 not 403 for security
+  });
+});
+
+describe('DELETE /api/v1/transactions/:id', () => {
+  it('應成功刪除交易', async () => {
+    const createRes = await request(app)
+      .post('/api/v1/transactions')
+      .set('Authorization', AUTH_HEADER)
+      .send(createTxnPayload());
+
+    const txnId = createRes.body.data.transaction.id;
+
+    const res = await request(app)
+      .delete(`/api/v1/transactions/${txnId}`)
+      .set('Authorization', AUTH_HEADER);
+
+    expect(res.status).toBe(204);
+  });
+
+  it('應在交易不存在時回傳 404', async () => {
+    const res = await request(app)
+      .delete('/api/v1/transactions/nonexistent-id')
+      .set('Authorization', AUTH_HEADER);
+
+    expect(res.status).toBe(404);
+  });
+
+  it('應拒絕刪除其他使用者的交易', async () => {
+    const otherId = `txn-other-del-${Date.now()}`;
+    mockTransactions[otherId] = {
+      id: otherId,
+      userId: OTHER_USER_ID,
+      amount: 500,
+      category: 'food',
+      merchant: '別人的店',
+      rawText: '別人的交易',
+      note: null,
+      transactionDate: now,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    const res = await request(app)
+      .delete(`/api/v1/transactions/${otherId}`)
+      .set('Authorization', AUTH_HEADER);
+
+    expect(res.status).toBe(404);
+  });
+
+  it('應拒絕未認證的請求', async () => {
+    const res = await request(app)
+      .delete('/api/v1/transactions/some-id');
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/src/controllers/transactionController.ts
+++ b/backend/src/controllers/transactionController.ts
@@ -1,0 +1,102 @@
+import { Response, NextFunction } from 'express';
+import { AuthRequest } from '../middlewares/auth';
+import { createTransactionSchema, listTransactionsSchema } from '../validators/transactionValidators';
+import * as transactionService from '../services/transactionService';
+import { AppError } from '../middlewares/errorHandler';
+import { ApiResponse } from '../types';
+import { ZodError } from 'zod';
+
+function formatZodErrors(error: ZodError) {
+  return error.issues.map((issue) => ({
+    field: issue.path.join('.'),
+    reason: issue.message,
+  }));
+}
+
+export async function createTransaction(
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const parsed = createTransactionSchema.safeParse(req.body);
+    if (!parsed.success) {
+      throw new AppError('參數驗證失敗', 400, formatZodErrors(parsed.error));
+    }
+
+    const result = await transactionService.createTransaction(req.userId!, parsed.data);
+
+    const response: ApiResponse<typeof result> = {
+      code: 201,
+      message: '交易建立成功',
+      data: result,
+      timestamp: new Date().toISOString(),
+    };
+
+    res.status(201).json(response);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function listTransactions(
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const parsed = listTransactionsSchema.safeParse(req.query);
+    if (!parsed.success) {
+      throw new AppError('參數驗證失敗', 400, formatZodErrors(parsed.error));
+    }
+
+    const result = await transactionService.listTransactions(req.userId!, parsed.data);
+
+    const response: ApiResponse<typeof result> = {
+      code: 200,
+      message: 'success',
+      data: result,
+      timestamp: new Date().toISOString(),
+    };
+
+    res.status(200).json(response);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getTransaction(
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const id = req.params.id as string;
+    const result = await transactionService.getTransaction(req.userId!, id);
+
+    const response: ApiResponse<typeof result> = {
+      code: 200,
+      message: 'success',
+      data: result,
+      timestamp: new Date().toISOString(),
+    };
+
+    res.status(200).json(response);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function deleteTransaction(
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const id = req.params.id as string;
+    await transactionService.deleteTransaction(req.userId!, id);
+    res.status(204).send();
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -3,6 +3,7 @@ import { healthCheck } from '../controllers/healthController';
 import authRoutes from './authRoutes';
 import userRoutes from './userRoutes';
 import aiRoutes from './aiRoutes';
+import transactionRoutes from './transactionRoutes';
 
 const router = Router();
 
@@ -13,9 +14,9 @@ router.get('/health', healthCheck);
 router.use('/api/v1/auth', authRoutes);
 router.use('/api/v1/users', userRoutes);
 router.use('/api/v1/ai', aiRoutes);
+router.use('/api/v1/transactions', transactionRoutes);
 
 // Future routes will be added here:
-// router.use('/api/v1/transactions', transactionRoutes);
 // router.use('/api/v1/budget', budgetRoutes);
 // router.use('/api/v1/stats', statsRoutes);
 

--- a/backend/src/routes/transactionRoutes.ts
+++ b/backend/src/routes/transactionRoutes.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import { authMiddleware } from '../middlewares/auth';
+import {
+  createTransaction,
+  listTransactions,
+  getTransaction,
+  deleteTransaction,
+} from '../controllers/transactionController';
+
+const router = Router();
+
+router.post('/', authMiddleware, createTransaction);
+router.get('/', authMiddleware, listTransactions);
+router.get('/:id', authMiddleware, getTransaction);
+router.delete('/:id', authMiddleware, deleteTransaction);
+
+export default router;

--- a/backend/src/services/transactionService.ts
+++ b/backend/src/services/transactionService.ts
@@ -1,0 +1,214 @@
+import prisma from '../config/database';
+import { AppError } from '../middlewares/errorHandler';
+import { CreateTransactionInput, ListTransactionsInput } from '../validators/transactionValidators';
+
+export async function createTransaction(userId: string, input: CreateTransactionInput) {
+  const transactionData: {
+    userId: string;
+    amount: number;
+    category: string;
+    merchant: string | undefined;
+    rawText: string;
+    note: string | undefined;
+    transactionDate: Date;
+    aiFeedback?: {
+      create: {
+        userId: string;
+        feedbackText: string;
+        emotionTag: string;
+        personaUsed: string;
+      };
+    };
+  } = {
+    userId,
+    amount: input.amount,
+    category: input.category,
+    merchant: input.merchant || undefined,
+    rawText: input.raw_text,
+    note: input.note || undefined,
+    transactionDate: new Date(input.transaction_date),
+  };
+
+  // If feedback is provided, create AIFeedback record alongside
+  if (input.feedback) {
+    transactionData.aiFeedback = {
+      create: {
+        userId,
+        feedbackText: input.feedback.text,
+        emotionTag: input.feedback.emotion_tag,
+        personaUsed: input.feedback.persona_used,
+      },
+    };
+  }
+
+  const transaction = await prisma.transaction.create({
+    data: transactionData,
+    include: { aiFeedback: true },
+  });
+
+  return formatTransaction(transaction);
+}
+
+export async function listTransactions(userId: string, input: ListTransactionsInput) {
+  const where: Record<string, unknown> = { userId };
+
+  if (input.category) {
+    where.category = input.category;
+  }
+
+  if (input.start_date || input.end_date) {
+    const dateFilter: Record<string, Date> = {};
+    if (input.start_date) dateFilter.gte = new Date(input.start_date);
+    if (input.end_date) dateFilter.lte = new Date(input.end_date);
+    where.transactionDate = dateFilter;
+  }
+
+  const [total, items] = await Promise.all([
+    prisma.transaction.count({ where }),
+    prisma.transaction.findMany({
+      where,
+      orderBy: { transactionDate: input.sort },
+      skip: (input.page - 1) * input.limit,
+      take: input.limit,
+    }),
+  ]);
+
+  return {
+    items: items.map(formatTransactionListItem),
+    pagination: {
+      total,
+      page: input.page,
+      limit: input.limit,
+      pages: Math.ceil(total / input.limit),
+    },
+  };
+}
+
+export async function getTransaction(userId: string, id: string) {
+  const transaction = await prisma.transaction.findUnique({
+    where: { id },
+    include: { aiFeedback: true },
+  });
+
+  if (!transaction) {
+    throw new AppError('交易記錄不存在', 404);
+  }
+
+  if (transaction.userId !== userId) {
+    throw new AppError('交易記錄不存在', 404);
+  }
+
+  return formatTransactionDetail(transaction);
+}
+
+export async function deleteTransaction(userId: string, id: string) {
+  const transaction = await prisma.transaction.findUnique({
+    where: { id },
+  });
+
+  if (!transaction) {
+    throw new AppError('交易記錄不存在', 404);
+  }
+
+  if (transaction.userId !== userId) {
+    throw new AppError('交易記錄不存在', 404);
+  }
+
+  await prisma.transaction.delete({ where: { id } });
+}
+
+// ─── Formatters ────────────────────────────────────────────────
+
+function formatTransaction(t: {
+  id: string;
+  amount: unknown;
+  category: string;
+  merchant: string | null;
+  rawText: string;
+  note: string | null;
+  transactionDate: Date;
+  createdAt: Date;
+  updatedAt: Date;
+  aiFeedback?: {
+    id: string;
+    feedbackText: string;
+    emotionTag: string | null;
+    personaUsed: string;
+    createdAt: Date;
+  } | null;
+}) {
+  return {
+    transaction: {
+      id: t.id,
+      amount: Number(t.amount),
+      category: t.category,
+      merchant: t.merchant,
+      raw_text: t.rawText,
+      note: t.note,
+      transaction_date: t.transactionDate.toISOString().split('T')[0],
+      created_at: t.createdAt.toISOString(),
+      updated_at: t.updatedAt.toISOString(),
+    },
+    feedback: t.aiFeedback
+      ? {
+          id: t.aiFeedback.id,
+          feedback_text: t.aiFeedback.feedbackText,
+          emotion_tag: t.aiFeedback.emotionTag,
+          persona_used: t.aiFeedback.personaUsed,
+          created_at: t.aiFeedback.createdAt.toISOString(),
+        }
+      : null,
+  };
+}
+
+function formatTransactionListItem(t: {
+  id: string;
+  amount: unknown;
+  category: string;
+  merchant: string | null;
+  transactionDate: Date;
+  createdAt: Date;
+}) {
+  return {
+    id: t.id,
+    amount: Number(t.amount),
+    category: t.category,
+    merchant: t.merchant,
+    transaction_date: t.transactionDate.toISOString().split('T')[0],
+    created_at: t.createdAt.toISOString(),
+  };
+}
+
+function formatTransactionDetail(t: {
+  id: string;
+  amount: unknown;
+  category: string;
+  merchant: string | null;
+  rawText: string;
+  note: string | null;
+  transactionDate: Date;
+  createdAt: Date;
+  aiFeedback?: {
+    feedbackText: string;
+    emotionTag: string | null;
+    personaUsed: string;
+  } | null;
+}) {
+  return {
+    id: t.id,
+    amount: Number(t.amount),
+    category: t.category,
+    merchant: t.merchant,
+    raw_text: t.rawText,
+    note: t.note,
+    transaction_date: t.transactionDate.toISOString().split('T')[0],
+    created_at: t.createdAt.toISOString(),
+    feedback: t.aiFeedback
+      ? {
+          feedback_text: t.aiFeedback.feedbackText,
+          emotion_tag: t.aiFeedback.emotionTag,
+          persona_used: t.aiFeedback.personaUsed,
+        }
+      : null,
+  };
+}

--- a/backend/src/validators/transactionValidators.ts
+++ b/backend/src/validators/transactionValidators.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+
+export const createTransactionSchema = z.object({
+  amount: z
+    .number({ error: '金額為必填' })
+    .positive('金額必須為正數'),
+  category: z
+    .string({ error: '類別為必填' })
+    .min(1, '類別不可為空'),
+  merchant: z
+    .string()
+    .max(100, '商家名稱最多 100 個字元')
+    .optional(),
+  raw_text: z
+    .string({ error: '原始文字為必填' })
+    .min(1, '原始文字不可為空')
+    .max(500, '原始文字不可超過 500 字元'),
+  transaction_date: z
+    .string({ error: '交易日期為必填' })
+    .regex(/^\d{4}-\d{2}-\d{2}$/, '日期格式須為 YYYY-MM-DD'),
+  note: z
+    .string()
+    .max(500, '備註不可超過 500 字元')
+    .optional(),
+  feedback: z
+    .object({
+      text: z.string(),
+      emotion_tag: z.string(),
+      persona_used: z.enum(['sarcastic', 'gentle', 'guilt_trip']),
+    })
+    .optional(),
+});
+
+export const listTransactionsSchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  category: z.string().optional(),
+  start_date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, '日期格式須為 YYYY-MM-DD')
+    .optional(),
+  end_date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, '日期格式須為 YYYY-MM-DD')
+    .optional(),
+  sort: z.enum(['asc', 'desc']).default('desc'),
+});
+
+export type CreateTransactionInput = z.infer<typeof createTransactionSchema>;
+export type ListTransactionsInput = z.infer<typeof listTransactionsSchema>;


### PR DESCRIPTION
## Summary
- 實作完整的交易 RESTful API：建立、列表查詢、單筆詳情、刪除
- 建立交易時可同時關聯儲存 AI 回饋記錄
- 支援分頁（offset/limit）、按類別篩選、按日期範圍篩選
- 所有端點使用 Zod 驗證輸入
- 所有權驗證：使用者只能存取自己的交易記錄
- 20 組單元測試全部通過

## Files Changed
| 檔案 | 說明 |
|------|------|
| `src/validators/transactionValidators.ts` | 交易請求 Zod 驗證 Schema |
| `src/services/transactionService.ts` | 交易業務邏輯（CRUD + 分頁 + 篩選）|
| `src/controllers/transactionController.ts` | 交易端點控制器 |
| `src/routes/transactionRoutes.ts` | 交易路由定義 |
| `src/routes/index.ts` | 掛載交易路由 |
| `src/controllers/transactionController.test.ts` | 20 組單元測試 |

## Test Plan
- [x] TypeScript 編譯通過
- [x] 20 組單元測試通過（CRUD 完整路徑、分頁邊界、權限驗證）
- [x] ESLint 檢查通過

Closes #8