### PR TITLE
feat(frontend): T-204 儀表板式記帳介面

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -20,4 +20,10 @@ export default defineConfig([
       globals: globals.browser,
     },
   },
+  {
+    files: ['src/types/**/*.d.ts'],
+    rules: {
+      'no-var': 'off',
+    },
+  },
 ])

--- a/frontend/src/components/AIFeedbackCard.tsx
+++ b/frontend/src/components/AIFeedbackCard.tsx
@@ -1,0 +1,40 @@
+import type { Persona } from '../stores/index'
+
+interface AIFeedbackCardProps {
+  feedbackText: string
+  persona: Persona
+}
+
+const personaConfig: Record<
+  Persona,
+  { name: string; emoji: string; icon: string }
+> = {
+  gentle: { name: '溫柔管家', emoji: '💖', icon: '💬' },
+  sarcastic: { name: '毒舌教練', emoji: '🔥', icon: '🔥' },
+  guilt_trip: { name: '心疼天使', emoji: '🥺', icon: '❤️' },
+}
+
+function AIFeedbackCard({ feedbackText, persona }: AIFeedbackCardProps) {
+  const config = personaConfig[persona]
+
+  return (
+    <section
+      className="bg-primary-light rounded-lg p-lg mx-2xl mb-xl"
+      aria-label="AI 回饋"
+    >
+      <div className="flex items-center gap-sm mb-xs">
+        <div className="w-9 h-9 rounded-full bg-primary flex items-center justify-center text-surface text-lg">
+          {config.icon}
+        </div>
+        <p className="text-[var(--font-size-caption)] text-text-secondary">
+          {config.name} {config.emoji} 的即時回饋
+        </p>
+      </div>
+      <p className="text-[var(--font-size-body)] text-primary-dark">
+        「{feedbackText}」
+      </p>
+    </section>
+  )
+}
+
+export default AIFeedbackCard

--- a/frontend/src/components/BudgetCard.tsx
+++ b/frontend/src/components/BudgetCard.tsx
@@ -1,0 +1,108 @@
+import type { BudgetSummary } from '../stores/dashboardStore'
+
+interface BudgetCardProps {
+  summary: BudgetSummary | null
+}
+
+function BudgetCard({ summary }: BudgetCardProps) {
+  if (!summary || summary.monthlyBudget <= 0) {
+    return (
+      <section
+        className="bg-surface rounded-lg shadow-card p-lg mx-2xl mb-xl"
+        aria-label="預算概覽"
+      >
+        <h2 className="text-[var(--font-size-caption)] text-text-secondary mb-sm">
+          預算剩餘
+        </h2>
+        <p className="text-[var(--font-size-display)] font-bold text-text-primary">
+          --
+        </p>
+        <p className="text-[var(--font-size-caption)] text-text-secondary mt-sm">
+          尚未設定預算
+        </p>
+      </section>
+    )
+  }
+
+  const { monthlyBudget, totalSpent, remaining, usedRatio } = summary
+  const remainingRatio = Math.max(0, 1 - usedRatio)
+  const remainingPercent = Math.round(remainingRatio * 100)
+  const progressPercent = Math.min(usedRatio * 100, 100)
+
+  const isOverBudget = remaining <= 0
+  const isLow = remainingRatio < 0.2
+  const isMedium = remainingRatio >= 0.2 && remainingRatio < 0.5
+
+  const getProgressColor = () => {
+    if (isLow) return 'bg-danger'
+    if (isMedium) return 'bg-warning'
+    return 'bg-success'
+  }
+
+  const getPercentColor = () => {
+    if (isLow) return 'text-danger'
+    if (isMedium) return 'text-warning'
+    return 'text-text-primary'
+  }
+
+  const formatMoney = (n: number) =>
+    `$${n.toLocaleString('zh-TW', { maximumFractionDigits: 0 })}`
+
+  return (
+    <section
+      className="bg-surface rounded-lg shadow-card p-lg mx-2xl mb-xl"
+      aria-label="預算概覽"
+    >
+      <div className="flex justify-between items-start mb-sm">
+        <div>
+          <p className="text-[var(--font-size-caption)] text-text-secondary">
+            預算剩餘
+          </p>
+          <p
+            className={`text-[var(--font-size-display)] font-bold ${getPercentColor()}`}
+            aria-live="polite"
+          >
+            {isOverBudget ? '超支' : `${remainingPercent}%`}
+          </p>
+        </div>
+        <div className="text-right">
+          <p className="text-[var(--font-size-caption)] text-text-secondary">
+            本月支出
+          </p>
+          <p
+            className="text-[var(--font-size-headline)] font-bold text-danger"
+            aria-live="polite"
+          >
+            {formatMoney(totalSpent)}
+          </p>
+        </div>
+      </div>
+
+      {/* Progress bar */}
+      <div className="h-2 rounded-full bg-border overflow-hidden mb-xs">
+        <div
+          className={`h-full rounded-full transition-all duration-[var(--transition-normal)] ${getProgressColor()} ${
+            isLow ? 'animate-budget-pulse' : ''
+          }`}
+          style={{ width: `${progressPercent}%` }}
+          role="progressbar"
+          aria-valuenow={progressPercent}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`已使用 ${Math.round(usedRatio * 100)}% 預算`}
+        />
+      </div>
+
+      <div className="flex justify-between">
+        <span className="text-[var(--font-size-small)] text-text-secondary">
+          $0
+        </span>
+        <span className="text-[var(--font-size-small)] text-text-secondary">
+          目標：{formatMoney(monthlyBudget)}
+        </span>
+      </div>
+    </section>
+  )
+}
+
+export default BudgetCard

--- a/frontend/src/components/NewCategoryDialog.tsx
+++ b/frontend/src/components/NewCategoryDialog.tsx
@@ -1,0 +1,190 @@
+import { useState } from 'react'
+import type { Persona } from '../stores/index'
+
+interface NewCategoryDialogProps {
+  suggestedCategory: string
+  persona: Persona
+  existingCategories: string[]
+  onConfirm: (categoryName: string) => void
+  onSelectExisting: (category: string) => void
+}
+
+const personaConfig: Record<Persona, { emoji: string }> = {
+  gentle: { emoji: '💖' },
+  sarcastic: { emoji: '🔥' },
+  guilt_trip: { emoji: '🥺' },
+}
+
+const categoryNames: Record<string, string> = {
+  food: '飲食',
+  transport: '交通',
+  entertainment: '娛樂',
+  shopping: '購物',
+  daily: '日用品',
+  medical: '醫療',
+  education: '教育',
+  other: '其他',
+}
+
+const categoryIcons: Record<string, string> = {
+  food: '🍽️',
+  transport: '🚌',
+  entertainment: '🎬',
+  shopping: '🛍️',
+  daily: '🧴',
+  medical: '🏥',
+  education: '📚',
+  other: '📦',
+}
+
+type DialogMode = 'main' | 'rename' | 'select'
+
+function NewCategoryDialog({
+  suggestedCategory,
+  persona,
+  existingCategories,
+  onConfirm,
+  onSelectExisting,
+}: NewCategoryDialogProps) {
+  const [mode, setMode] = useState<DialogMode>('main')
+  const [customName, setCustomName] = useState(suggestedCategory)
+  const config = personaConfig[persona]
+
+  const isNameValid = customName.trim().length >= 2 && customName.trim().length <= 50
+
+  if (mode === 'rename') {
+    return (
+      <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/30">
+        <div
+          className="w-full max-w-lg bg-surface rounded-t-xl p-lg animate-slide-up"
+          role="dialog"
+          aria-label="修改類別名稱"
+        >
+          <h3 className="text-[var(--font-size-title)] font-semibold text-text-primary mb-md">
+            修改類別名稱
+          </h3>
+          <input
+            type="text"
+            value={customName}
+            onChange={(e) => setCustomName(e.target.value)}
+            className="w-full h-[44px] rounded-md border border-border px-lg text-[var(--font-size-body)] mb-xs"
+            maxLength={50}
+            autoFocus
+            aria-label="類別名稱"
+          />
+          <p className="text-[var(--font-size-small)] text-text-tertiary mb-lg">
+            ⚠️ 類別名稱 2–50 字元
+          </p>
+          <div className="flex gap-sm">
+            <button
+              type="button"
+              onClick={() => setMode('main')}
+              className="flex-1 h-10 rounded-sm border border-border text-text-secondary"
+            >
+              取消
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                if (isNameValid) onConfirm(customName.trim())
+              }}
+              disabled={!isNameValid}
+              className="flex-1 h-10 rounded-sm bg-primary text-surface font-semibold disabled:opacity-40"
+            >
+              確認新增
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (mode === 'select') {
+    return (
+      <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/30">
+        <div
+          className="w-full max-w-lg bg-surface rounded-t-xl p-lg animate-slide-up"
+          role="dialog"
+          aria-label="選擇類別"
+        >
+          <h3 className="text-[var(--font-size-title)] font-semibold text-text-primary mb-md">
+            選擇類別
+          </h3>
+          <div className="flex flex-wrap gap-sm mb-lg">
+            {existingCategories.map((cat) => (
+              <button
+                key={cat}
+                type="button"
+                onClick={() => onSelectExisting(cat)}
+                className="px-lg py-sm rounded-sm bg-bg text-[var(--font-size-body)] text-text-primary hover:bg-border transition-colors"
+              >
+                {categoryIcons[cat] ?? '📦'}{' '}
+                {categoryNames[cat] ?? cat}
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={() => setMode('main')}
+            className="w-full h-10 rounded-sm border border-border text-text-secondary"
+          >
+            取消
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  // Main mode - AI suggestion bubble
+  return (
+    <div className="mx-2xl mb-md">
+      <div
+        className="max-w-[85%] bg-primary-light rounded-xl p-lg"
+        role="dialog"
+        aria-label="新類別建議"
+      >
+        <div className="flex items-start gap-sm mb-md">
+          <div className="w-7 h-7 rounded-full bg-primary flex items-center justify-center text-surface text-sm shrink-0">
+            {config.emoji}
+          </div>
+          <p className="text-[var(--font-size-body)] text-text-primary">
+            我覺得這筆消費屬於「
+            <span className="font-semibold bg-primary/20 rounded-sm px-1.5 py-0.5">
+              {suggestedCategory}
+            </span>
+            」，但你的類別中沒有這項。
+            <br />
+            <br />
+            要新增「{suggestedCategory}」類別嗎？
+          </p>
+        </div>
+
+        <div className="flex gap-sm">
+          <button
+            type="button"
+            onClick={() => onConfirm(suggestedCategory)}
+            className="h-9 px-lg rounded-sm bg-primary text-surface text-[var(--font-size-body)] font-medium"
+          >
+            確認
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode('rename')}
+            className="h-9 px-lg rounded-sm border border-primary text-primary text-[var(--font-size-body)]"
+          >
+            修改名稱
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode('select')}
+            className="h-9 px-lg rounded-sm border border-border text-text-secondary text-[var(--font-size-body)]"
+          >
+            選現有
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default NewCategoryDialog

--- a/frontend/src/components/ParsedResultCard.tsx
+++ b/frontend/src/components/ParsedResultCard.tsx
@@ -1,0 +1,172 @@
+import { useState } from 'react'
+import type { ParsedResult } from '../stores/dashboardStore'
+
+interface ParsedResultCardProps {
+  result: ParsedResult
+  onConfirm: (data: {
+    amount: number
+    category: string
+    merchant: string
+    date: string
+  }) => void
+  onCancel: () => void
+  categories: string[]
+}
+
+const categoryNames: Record<string, string> = {
+  food: '飲食',
+  transport: '交通',
+  entertainment: '娛樂',
+  shopping: '購物',
+  daily: '日用品',
+  medical: '醫療',
+  education: '教育',
+  other: '其他',
+}
+
+function ParsedResultCard({
+  result,
+  onConfirm,
+  onCancel,
+  categories,
+}: ParsedResultCardProps) {
+  const [isEditing, setIsEditing] = useState(false)
+  const [amount, setAmount] = useState(result.amount?.toString() ?? '')
+  const [category, setCategory] = useState(result.category ?? 'other')
+  const [merchant, setMerchant] = useState(result.merchant ?? '')
+  const [date, setDate] = useState(result.date ?? new Date().toISOString().split('T')[0])
+
+  const handleConfirm = () => {
+    const parsedAmount = parseFloat(amount)
+    if (isNaN(parsedAmount) || parsedAmount <= 0) return
+    onConfirm({
+      amount: parsedAmount,
+      category,
+      merchant,
+      date,
+    })
+  }
+
+  return (
+    <div
+      className="bg-surface rounded-lg shadow-card border-l-4 border-l-primary p-lg mx-2xl mb-md"
+      role="region"
+      aria-label="AI 解析結果"
+    >
+      <h3 className="text-[var(--font-size-body)] font-semibold text-text-primary mb-md">
+        ✨ AI 幫你整理好了
+      </h3>
+
+      <div className="space-y-sm mb-lg">
+        <div className="flex items-center gap-md">
+          <span className="text-[var(--font-size-caption)] text-text-secondary w-[60px] shrink-0">
+            金額
+          </span>
+          {isEditing ? (
+            <input
+              type="number"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              className="flex-1 h-9 rounded-md border border-border px-sm text-[var(--font-size-body)] text-danger font-semibold"
+              min="0.01"
+              step="1"
+              aria-label="金額"
+            />
+          ) : (
+            <span className="text-[var(--font-size-body)] text-danger font-semibold">
+              ${result.amount?.toLocaleString() ?? '--'}
+            </span>
+          )}
+        </div>
+
+        <div className="flex items-center gap-md">
+          <span className="text-[var(--font-size-caption)] text-text-secondary w-[60px] shrink-0">
+            類別
+          </span>
+          {isEditing ? (
+            <select
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              className="flex-1 h-9 rounded-md border border-border px-sm text-[var(--font-size-body)]"
+              aria-label="類別"
+            >
+              {categories.map((cat) => (
+                <option key={cat} value={cat}>
+                  {categoryNames[cat] ?? cat}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <span className="text-[var(--font-size-body)] text-text-primary">
+              {categoryNames[result.category ?? ''] ?? result.category ?? '--'}
+            </span>
+          )}
+        </div>
+
+        <div className="flex items-center gap-md">
+          <span className="text-[var(--font-size-caption)] text-text-secondary w-[60px] shrink-0">
+            商家
+          </span>
+          {isEditing ? (
+            <input
+              type="text"
+              value={merchant}
+              onChange={(e) => setMerchant(e.target.value)}
+              className="flex-1 h-9 rounded-md border border-border px-sm text-[var(--font-size-body)]"
+              aria-label="商家"
+            />
+          ) : (
+            <span className="text-[var(--font-size-body)] text-text-primary">
+              {result.merchant || '--'}
+            </span>
+          )}
+        </div>
+
+        <div className="flex items-center gap-md">
+          <span className="text-[var(--font-size-caption)] text-text-secondary w-[60px] shrink-0">
+            日期
+          </span>
+          {isEditing ? (
+            <input
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              className="flex-1 h-9 rounded-md border border-border px-sm text-[var(--font-size-body)]"
+              aria-label="日期"
+            />
+          ) : (
+            <span className="text-[var(--font-size-body)] text-text-primary">
+              {result.date ?? '--'}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="flex gap-sm">
+        <button
+          type="button"
+          onClick={() => {
+            if (isEditing) {
+              onCancel()
+              setIsEditing(false)
+            } else {
+              setIsEditing(true)
+            }
+          }}
+          className="flex-1 h-10 rounded-sm border border-border text-text-secondary text-[var(--font-size-body)] transition-colors duration-[var(--transition-fast)] hover:bg-bg"
+        >
+          {isEditing ? '取消' : '修改'}
+        </button>
+        <button
+          type="button"
+          onClick={handleConfirm}
+          className="flex-1 h-10 rounded-sm bg-primary text-surface font-semibold text-[var(--font-size-body)] transition-opacity duration-[var(--transition-fast)] hover:opacity-90"
+        >
+          ✓ 確認記帳
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default ParsedResultCard

--- a/frontend/src/components/RecentTransactions.tsx
+++ b/frontend/src/components/RecentTransactions.tsx
@@ -1,0 +1,83 @@
+import type { Transaction } from '../stores/index'
+
+interface RecentTransactionsProps {
+  transactions: Transaction[]
+}
+
+const categoryIcons: Record<string, string> = {
+  food: '🍽️',
+  transport: '🚌',
+  entertainment: '🎬',
+  shopping: '🛍️',
+  daily: '🧴',
+  medical: '🏥',
+  education: '📚',
+  other: '📦',
+}
+
+function formatTime(dateStr: string): string {
+  const date = new Date(dateStr)
+  const hours = date.getHours()
+  const minutes = date.getMinutes().toString().padStart(2, '0')
+  const period = hours < 12 ? '上午' : '下午'
+  const displayHour = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours
+  return `${period}${displayHour.toString().padStart(2, '0')}:${minutes}`
+}
+
+const categoryNames: Record<string, string> = {
+  food: '飲食',
+  transport: '交通',
+  entertainment: '娛樂',
+  shopping: '購物',
+  daily: '日用品',
+  medical: '醫療',
+  education: '教育',
+  other: '其他',
+}
+
+function RecentTransactions({ transactions }: RecentTransactionsProps) {
+  return (
+    <section className="px-2xl" aria-label="最近帳目">
+      <h2 className="text-[var(--font-size-title)] font-semibold text-text-primary mb-md">
+        🕐 最近帳目
+      </h2>
+
+      {transactions.length === 0 ? (
+        <p className="text-[var(--font-size-body)] text-text-tertiary text-center py-3xl">
+          還沒有記帳紀錄，開始記帳吧！
+        </p>
+      ) : (
+        <div>
+          {transactions.map((tx) => (
+            <div
+              key={tx.id}
+              className="flex items-center gap-md py-md border-b border-border last:border-b-0"
+            >
+              <div className="w-10 h-10 rounded-md bg-danger-light flex items-center justify-center text-lg shrink-0">
+                {categoryIcons[tx.category] ?? '📦'}
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-[var(--font-size-body)] font-semibold text-text-primary truncate">
+                  {tx.merchant || tx.category}
+                </p>
+                <div className="flex items-center gap-xs">
+                  <span className="text-[var(--font-size-small)] text-text-secondary bg-[#F0F0F0] rounded-sm px-2 py-0.5">
+                    {categoryNames[tx.category] ?? tx.category}
+                  </span>
+                  <span className="text-[var(--font-size-small)] text-text-secondary">
+                    · {formatTime(tx.createdAt)}
+                  </span>
+                </div>
+              </div>
+              <p className="text-[var(--font-size-title)] font-semibold text-danger shrink-0">
+                -${tx.amount.toLocaleString()}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+export default RecentTransactions

--- a/frontend/src/components/VoiceInput.tsx
+++ b/frontend/src/components/VoiceInput.tsx
@@ -1,0 +1,186 @@
+import { useState, useRef, useCallback, useEffect } from 'react'
+import {
+  useVoiceRecognition,
+  isSpeechRecognitionSupported,
+} from '../hooks/useVoiceRecognition'
+
+interface VoiceInputProps {
+  onSubmit: (text: string) => void
+  disabled?: boolean
+}
+
+function VoiceInput({ onSubmit, disabled = false }: VoiceInputProps) {
+  const [inputText, setInputText] = useState('')
+  const [showError, setShowError] = useState(false)
+  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const isSupported = isSpeechRecognitionSupported()
+
+  const handleVoiceResult = useCallback((transcript: string) => {
+    setInputText(transcript)
+  }, [])
+
+  const handleVoiceInterim = useCallback((interim: string) => {
+    setInputText(interim)
+  }, [])
+
+  const handleVoiceError = useCallback((error: string) => {
+    if (!error) return
+    setShowError(true)
+    errorTimerRef.current = setTimeout(() => setShowError(false), 3000)
+  }, [])
+
+  const { status, errorMessage, startRecording, stopRecording } =
+    useVoiceRecognition({
+      lang: 'zh-TW',
+      onResult: handleVoiceResult,
+      onInterimResult: handleVoiceInterim,
+      onError: handleVoiceError,
+    })
+
+  // Cleanup error timer on unmount
+  useEffect(() => {
+    return () => {
+      if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
+    }
+  }, [])
+
+  const isRecording = status === 'recording'
+  const isRecognizing = status === 'recognizing'
+  const isActive = isRecording || isRecognizing
+
+  const handleSubmit = useCallback(() => {
+    const text = inputText.trim()
+    if (!text || disabled) return
+    onSubmit(text)
+    setInputText('')
+  }, [inputText, onSubmit, disabled])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+        e.preventDefault()
+        handleSubmit()
+      }
+    },
+    [handleSubmit]
+  )
+
+  const handleMicPointerDown = useCallback(() => {
+    if (disabled) return
+    startRecording()
+  }, [startRecording, disabled])
+
+  const handleMicPointerUp = useCallback(() => {
+    stopRecording()
+  }, [stopRecording])
+
+  const getPlaceholder = () => {
+    if (isRecording) return '正在聆聽...'
+    if (isRecognizing) return '辨識中...'
+    return '例如：中午吃拉麵 280 元'
+  }
+
+  return (
+    <div
+      className="fixed left-0 right-0 bg-surface px-2xl py-md z-40"
+      style={{
+        bottom: 'calc(56px + env(safe-area-inset-bottom, 0px))',
+        boxShadow: '0 -2px 8px rgba(0,0,0,0.06)',
+      }}
+    >
+      {/* Error message */}
+      {showError && errorMessage && (
+        <div
+          className="mb-sm px-lg py-sm rounded-md text-[var(--font-size-small)] text-danger bg-danger-light text-center"
+          role="alert"
+        >
+          {errorMessage}
+        </div>
+      )}
+
+      <div className="flex items-center gap-sm">
+        {/* Text input */}
+        <input
+          type="text"
+          value={inputText}
+          onChange={(e) => setInputText(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={getPlaceholder()}
+          disabled={disabled || isActive}
+          className={`flex-1 h-[44px] rounded-xl px-lg text-[var(--font-size-body)] border outline-none transition-colors duration-[var(--transition-fast)] ${
+            isActive
+              ? 'bg-primary-light border-primary'
+              : 'bg-bg border-border focus:border-primary'
+          }`}
+          aria-label="消費描述輸入"
+        />
+
+        {/* Mic button - only shown when supported */}
+        {isSupported && (
+          <button
+            type="button"
+            onPointerDown={handleMicPointerDown}
+            onPointerUp={handleMicPointerUp}
+            onPointerLeave={handleMicPointerUp}
+            disabled={disabled}
+            className={`relative w-9 h-9 flex items-center justify-center rounded-full transition-colors duration-[var(--transition-fast)] select-none touch-none ${
+              isActive ? 'text-primary' : 'text-text-secondary'
+            } disabled:opacity-40`}
+            aria-label="語音輸入"
+            aria-pressed={isActive}
+          >
+            {/* Pulse rings animation */}
+            {isRecording && (
+              <>
+                <span className="voice-pulse-ring voice-pulse-ring-1" />
+                <span className="voice-pulse-ring voice-pulse-ring-2" />
+              </>
+            )}
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="relative z-10"
+              aria-hidden="true"
+            >
+              <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
+              <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+              <line x1="12" x2="12" y1="19" y2="22" />
+            </svg>
+          </button>
+        )}
+
+        {/* Send button */}
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={disabled || !inputText.trim()}
+          className="w-10 h-10 rounded-full bg-primary flex items-center justify-center shadow-fab transition-opacity duration-[var(--transition-fast)] disabled:opacity-40"
+          aria-label="送出"
+        >
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="white"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <line x1="22" x2="11" y1="2" y2="13" />
+            <polygon points="22 2 15 22 11 13 2 9 22 2" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default VoiceInput

--- a/frontend/src/hooks/useVoiceRecognition.ts
+++ b/frontend/src/hooks/useVoiceRecognition.ts
@@ -1,0 +1,158 @@
+import { useState, useCallback, useRef, useEffect } from 'react'
+
+export type VoiceStatus = 'idle' | 'recording' | 'recognizing' | 'error'
+
+interface UseVoiceRecognitionOptions {
+  lang?: string
+  onResult?: (transcript: string) => void
+  onInterimResult?: (transcript: string) => void
+  onError?: (error: string) => void
+}
+
+interface UseVoiceRecognitionReturn {
+  isSupported: boolean
+  status: VoiceStatus
+  transcript: string
+  interimTranscript: string
+  errorMessage: string
+  startRecording: () => void
+  stopRecording: () => void
+}
+
+// Feature Detection: check SpeechRecognition support
+function getSpeechRecognition(): (new () => SpeechRecognition) | null {
+  if (typeof window === 'undefined') return null
+  return window.SpeechRecognition ?? window.webkitSpeechRecognition ?? null
+}
+
+export function isSpeechRecognitionSupported(): boolean {
+  return getSpeechRecognition() !== null
+}
+
+export function useVoiceRecognition(
+  options: UseVoiceRecognitionOptions = {}
+): UseVoiceRecognitionReturn {
+  const { lang = 'zh-TW', onResult, onInterimResult, onError } = options
+
+  const [isSupported] = useState(() => isSpeechRecognitionSupported())
+  const [status, setStatus] = useState<VoiceStatus>('idle')
+  const [transcript, setTranscript] = useState('')
+  const [interimTranscript, setInterimTranscript] = useState('')
+  const [errorMessage, setErrorMessage] = useState('')
+
+  const recognitionRef = useRef<SpeechRecognition | null>(null)
+  const callbacksRef = useRef({ onResult, onInterimResult, onError })
+
+  // Keep callbacks ref updated
+  useEffect(() => {
+    callbacksRef.current = { onResult, onInterimResult, onError }
+  }, [onResult, onInterimResult, onError])
+
+  const startRecording = useCallback(() => {
+    const SpeechRecognitionClass = getSpeechRecognition()
+    if (!SpeechRecognitionClass) return
+
+    // Stop any existing recognition
+    if (recognitionRef.current) {
+      recognitionRef.current.abort()
+      recognitionRef.current = null
+    }
+
+    const recognition = new SpeechRecognitionClass()
+    recognition.lang = lang
+    recognition.interimResults = true
+    recognition.continuous = false
+    recognition.maxAlternatives = 1
+
+    recognition.onstart = () => {
+      setStatus('recording')
+      setErrorMessage('')
+      setTranscript('')
+      setInterimTranscript('')
+    }
+
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      let finalTranscript = ''
+      let interim = ''
+
+      for (let i = 0; i < event.results.length; i++) {
+        const result = event.results[i]
+        if (result.isFinal) {
+          finalTranscript += result[0].transcript
+        } else {
+          interim += result[0].transcript
+        }
+      }
+
+      if (interim) {
+        setInterimTranscript(interim)
+        setStatus('recognizing')
+        callbacksRef.current.onInterimResult?.(interim)
+      }
+
+      if (finalTranscript) {
+        setTranscript(finalTranscript)
+        setInterimTranscript('')
+        callbacksRef.current.onResult?.(finalTranscript)
+      }
+    }
+
+    recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+      const message = getErrorMessage(event.error)
+      setErrorMessage(message)
+      setStatus('error')
+      callbacksRef.current.onError?.(message)
+    }
+
+    recognition.onend = () => {
+      setStatus((prev) => (prev === 'error' ? 'error' : 'idle'))
+      recognitionRef.current = null
+    }
+
+    recognitionRef.current = recognition
+    recognition.start()
+  }, [lang])
+
+  const stopRecording = useCallback(() => {
+    if (recognitionRef.current) {
+      recognitionRef.current.stop()
+    }
+  }, [])
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (recognitionRef.current) {
+        recognitionRef.current.abort()
+        recognitionRef.current = null
+      }
+    }
+  }, [])
+
+  return {
+    isSupported,
+    status,
+    transcript,
+    interimTranscript,
+    errorMessage,
+    startRecording,
+    stopRecording,
+  }
+}
+
+function getErrorMessage(error: string): string {
+  switch (error) {
+    case 'not-allowed':
+      return '麥克風權限被拒絕，請在瀏覽器設定中允許麥克風存取'
+    case 'no-speech':
+      return '未偵測到語音，請再試一次'
+    case 'audio-capture':
+      return '找不到麥克風裝置'
+    case 'network':
+      return '網路連線異常，請檢查網路後重試'
+    case 'aborted':
+      return ''
+    default:
+      return '語音辨識失敗，請重試或改用文字輸入'
+  }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -76,6 +76,32 @@ body {
   flex-direction: column;
 }
 
+/* ===== Voice Input Pulse Animation ===== */
+
+.voice-pulse-ring {
+  position: absolute;
+  inset: -4px;
+  border-radius: 50%;
+  border: 2px solid var(--color-primary);
+  opacity: 0;
+  animation: voice-pulse 0.8s ease-out infinite;
+}
+
+.voice-pulse-ring-2 {
+  animation-delay: 0.4s;
+}
+
+@keyframes voice-pulse {
+  0% {
+    transform: scale(1);
+    opacity: 0.6;
+  }
+  100% {
+    transform: scale(1.8);
+    opacity: 0;
+  }
+}
+
 /* Respect reduced motion preferences */
 @media (prefers-reduced-motion: reduce) {
   *,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -102,6 +102,36 @@ body {
   }
 }
 
+/* ===== Budget Pulse Animation ===== */
+
+@keyframes budget-pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.6;
+  }
+}
+
+.animate-budget-pulse {
+  animation: budget-pulse 1.5s ease-in-out infinite;
+}
+
+/* ===== Slide-up Animation ===== */
+
+@keyframes slide-up {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+.animate-slide-up {
+  animation: slide-up 300ms ease-out;
+}
+
 /* Respect reduced motion preferences */
 @media (prefers-reduced-motion: reduce) {
   *,

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,58 +1,70 @@
+import { useCallback } from 'react'
+import VoiceInput from '../components/VoiceInput'
+
 function DashboardPage() {
+  const handleSubmit = useCallback((text: string) => {
+    // TODO: integrate with AI parse API in future issues
+    console.log('Submit:', text)
+  }, [])
+
   return (
-    <div className="p-2xl">
-      <header className="flex items-center justify-between h-14 mb-lg">
-        <div className="flex items-center gap-sm">
-          <div className="w-8 h-8 bg-primary rounded-sm flex items-center justify-center text-surface text-lg">
-            💰
+    <>
+      <div className="p-2xl pb-[120px]">
+        <header className="flex items-center justify-between h-14 mb-lg">
+          <div className="flex items-center gap-sm">
+            <div className="w-8 h-8 bg-primary rounded-sm flex items-center justify-center text-surface text-lg">
+              💰
+            </div>
+            <div>
+              <h1 className="text-[var(--font-size-title)] font-semibold text-text-primary leading-tight">
+                Vibe Money Book
+              </h1>
+              <p className="text-[var(--font-size-small)] text-text-secondary tracking-[2px]">
+                語音記帳教練
+              </p>
+            </div>
           </div>
-          <div>
-            <h1 className="text-[var(--font-size-title)] font-semibold text-text-primary leading-tight">
-              Vibe Money Book
-            </h1>
-            <p className="text-[var(--font-size-small)] text-text-secondary tracking-[2px]">
-              語音記帳教練
-            </p>
-          </div>
-        </div>
-      </header>
+        </header>
 
-      <section
-        className="bg-surface rounded-lg shadow-card p-lg mb-xl"
-        aria-label="預算概覽"
-      >
-        <h2 className="text-[var(--font-size-caption)] text-text-secondary mb-sm">
-          預算剩餘
-        </h2>
-        <p className="text-[var(--font-size-display)] font-bold text-text-primary">
-          --
-        </p>
-        <p className="text-[var(--font-size-caption)] text-text-secondary mt-sm">
-          尚未設定預算
-        </p>
-      </section>
+        <section
+          className="bg-surface rounded-lg shadow-card p-lg mb-xl"
+          aria-label="預算概覽"
+        >
+          <h2 className="text-[var(--font-size-caption)] text-text-secondary mb-sm">
+            預算剩餘
+          </h2>
+          <p className="text-[var(--font-size-display)] font-bold text-text-primary">
+            --
+          </p>
+          <p className="text-[var(--font-size-caption)] text-text-secondary mt-sm">
+            尚未設定預算
+          </p>
+        </section>
 
-      <section
-        className="bg-primary-light rounded-lg p-lg mb-xl"
-        aria-label="AI 回饋"
-      >
-        <p className="text-[var(--font-size-caption)] text-text-secondary mb-xs">
-          溫柔管家 💖 的即時回饋
-        </p>
-        <p className="text-[var(--font-size-body)] text-primary-dark">
-          「歡迎使用 Vibe Money Book！開始記錄你的第一筆消費吧～」
-        </p>
-      </section>
+        <section
+          className="bg-primary-light rounded-lg p-lg mb-xl"
+          aria-label="AI 回饋"
+        >
+          <p className="text-[var(--font-size-caption)] text-text-secondary mb-xs">
+            溫柔管家 💖 的即時回饋
+          </p>
+          <p className="text-[var(--font-size-body)] text-primary-dark">
+            「歡迎使用 Vibe Money Book！開始記錄你的第一筆消費吧～」
+          </p>
+        </section>
 
-      <section aria-label="最近帳目">
-        <h2 className="text-[var(--font-size-title)] font-semibold text-text-primary mb-md">
-          🕐 最近帳目
-        </h2>
-        <p className="text-[var(--font-size-body)] text-text-tertiary text-center py-3xl">
-          還沒有記帳紀錄，開始記帳吧！
-        </p>
-      </section>
-    </div>
+        <section aria-label="最近帳目">
+          <h2 className="text-[var(--font-size-title)] font-semibold text-text-primary mb-md">
+            🕐 最近帳目
+          </h2>
+          <p className="text-[var(--font-size-body)] text-text-tertiary text-center py-3xl">
+            還沒有記帳紀錄，開始記帳吧！
+          </p>
+        </section>
+      </div>
+
+      <VoiceInput onSubmit={handleSubmit} />
+    </>
   )
 }
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,16 +1,135 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAppStore } from '../stores/index'
+import { useDashboardStore } from '../stores/dashboardStore'
 import VoiceInput from '../components/VoiceInput'
+import BudgetCard from '../components/BudgetCard'
+import AIFeedbackCard from '../components/AIFeedbackCard'
+import RecentTransactions from '../components/RecentTransactions'
+import ParsedResultCard from '../components/ParsedResultCard'
+import NewCategoryDialog from '../components/NewCategoryDialog'
+
+const DEFAULT_CATEGORIES = [
+  'food',
+  'transport',
+  'entertainment',
+  'shopping',
+  'daily',
+  'medical',
+  'education',
+  'other',
+]
 
 function DashboardPage() {
-  const handleSubmit = useCallback((text: string) => {
-    // TODO: integrate with AI parse API in future issues
-    console.log('Submit:', text)
-  }, [])
+  const navigate = useNavigate()
+  const settings = useAppStore((s) => s.settings)
+
+  const {
+    status,
+    parsedResult,
+    aiFeedback,
+    budgetSummary,
+    recentTransactions,
+    errorMessage,
+    lastFeedbackText,
+    parseInput,
+    confirmTransaction,
+    createCategory,
+    fetchBudgetSummary,
+    fetchRecentTransactions,
+    resetParsedResult,
+  } = useDashboardStore()
+
+  useEffect(() => {
+    fetchBudgetSummary()
+    fetchRecentTransactions()
+  }, [fetchBudgetSummary, fetchRecentTransactions])
+
+  const handleSubmit = useCallback(
+    (text: string) => {
+      parseInput(text)
+    },
+    [parseInput]
+  )
+
+  const handleConfirmTransaction = useCallback(
+    async (data: {
+      amount: number
+      category: string
+      merchant: string
+      date: string
+    }) => {
+      await confirmTransaction({
+        ...data,
+        rawText: parsedResult?.merchant ?? data.merchant,
+        feedback: aiFeedback ?? undefined,
+      })
+      fetchBudgetSummary()
+    },
+    [confirmTransaction, parsedResult, aiFeedback, fetchBudgetSummary]
+  )
+
+  const handleNewCategoryConfirm = useCallback(
+    async (categoryName: string) => {
+      try {
+        await createCategory(categoryName)
+        if (parsedResult) {
+          await confirmTransaction({
+            amount: parsedResult.amount ?? 0,
+            category: categoryName,
+            merchant: parsedResult.merchant,
+            date: parsedResult.date,
+            rawText: parsedResult.merchant,
+            feedback: aiFeedback ?? undefined,
+          })
+          fetchBudgetSummary()
+        }
+      } catch {
+        // Error handled by store
+      }
+    },
+    [
+      createCategory,
+      confirmTransaction,
+      parsedResult,
+      aiFeedback,
+      fetchBudgetSummary,
+    ]
+  )
+
+  const handleSelectExistingCategory = useCallback(
+    async (category: string) => {
+      if (parsedResult) {
+        await confirmTransaction({
+          amount: parsedResult.amount ?? 0,
+          category,
+          merchant: parsedResult.merchant,
+          date: parsedResult.date,
+          rawText: parsedResult.merchant,
+          feedback: aiFeedback ?? undefined,
+        })
+        fetchBudgetSummary()
+      }
+    },
+    [confirmTransaction, parsedResult, aiFeedback, fetchBudgetSummary]
+  )
+
+  const isParsing = status === 'parsing'
+  const isSaving = status === 'saving'
+  const showParsedResult =
+    status === 'parsed' && parsedResult && !parsedResult.isNewCategory
+  const showNewCategoryDialog =
+    status === 'parsed' && parsedResult?.isNewCategory
+
+  const feedbackText =
+    lastFeedbackText ||
+    '歡迎使用 Vibe Money Book！開始記錄你的第一筆消費吧～'
 
   return (
     <>
-      <div className="p-2xl pb-[120px]">
-        <header className="flex items-center justify-between h-14 mb-lg">
+      <div className="pt-2xl pb-[120px]">
+        {/* Header */}
+        <header className="flex items-center justify-between h-14 px-2xl mb-lg">
           <div className="flex items-center gap-sm">
             <div className="w-8 h-8 bg-primary rounded-sm flex items-center justify-center text-surface text-lg">
               💰
@@ -24,46 +143,81 @@ function DashboardPage() {
               </p>
             </div>
           </div>
+          <button
+            type="button"
+            onClick={() => navigate('/settings')}
+            className="w-6 h-6 text-text-secondary"
+            aria-label="設定"
+          >
+            ⚙️
+          </button>
         </header>
 
-        <section
-          className="bg-surface rounded-lg shadow-card p-lg mb-xl"
-          aria-label="預算概覽"
-        >
-          <h2 className="text-[var(--font-size-caption)] text-text-secondary mb-sm">
-            預算剩餘
-          </h2>
-          <p className="text-[var(--font-size-display)] font-bold text-text-primary">
-            --
-          </p>
-          <p className="text-[var(--font-size-caption)] text-text-secondary mt-sm">
-            尚未設定預算
-          </p>
-        </section>
+        {/* Budget Card */}
+        <BudgetCard summary={budgetSummary} />
 
-        <section
-          className="bg-primary-light rounded-lg p-lg mb-xl"
-          aria-label="AI 回饋"
-        >
-          <p className="text-[var(--font-size-caption)] text-text-secondary mb-xs">
-            溫柔管家 💖 的即時回饋
-          </p>
-          <p className="text-[var(--font-size-body)] text-primary-dark">
-            「歡迎使用 Vibe Money Book！開始記錄你的第一筆消費吧～」
-          </p>
-        </section>
+        {/* AI Feedback Card */}
+        <AIFeedbackCard
+          feedbackText={
+            isParsing ? 'AI 正在分析...' : feedbackText
+          }
+          persona={settings.persona}
+        />
 
-        <section aria-label="最近帳目">
-          <h2 className="text-[var(--font-size-title)] font-semibold text-text-primary mb-md">
-            🕐 最近帳目
-          </h2>
-          <p className="text-[var(--font-size-body)] text-text-tertiary text-center py-3xl">
-            還沒有記帳紀錄，開始記帳吧！
+        {/* Error toast */}
+        {status === 'error' && errorMessage && (
+          <div
+            className="mx-2xl mb-md px-lg py-sm rounded-md bg-danger text-surface text-[var(--font-size-body)] text-center"
+            role="alert"
+          >
+            {errorMessage}
+          </div>
+        )}
+
+        {/* Skeleton loading */}
+        {isParsing && (
+          <div className="mx-2xl mb-md">
+            <div className="bg-surface rounded-lg shadow-card p-lg animate-pulse">
+              <div className="h-4 bg-border rounded w-1/3 mb-md" />
+              <div className="h-4 bg-border rounded w-2/3 mb-sm" />
+              <div className="h-4 bg-border rounded w-1/2" />
+            </div>
+          </div>
+        )}
+
+        {/* Parsed Result Card */}
+        {showParsedResult && (
+          <ParsedResultCard
+            result={parsedResult}
+            onConfirm={handleConfirmTransaction}
+            onCancel={resetParsedResult}
+            categories={DEFAULT_CATEGORIES}
+          />
+        )}
+
+        {/* New Category Dialog */}
+        {showNewCategoryDialog && parsedResult.suggestedCategory && (
+          <NewCategoryDialog
+            suggestedCategory={parsedResult.suggestedCategory}
+            persona={settings.persona}
+            existingCategories={DEFAULT_CATEGORIES}
+            onConfirm={handleNewCategoryConfirm}
+            onSelectExisting={handleSelectExistingCategory}
+          />
+        )}
+
+        {/* Recent Transactions */}
+        <RecentTransactions transactions={recentTransactions} />
+
+        {/* Footer */}
+        <div className="text-center py-sm mt-xl">
+          <p className="text-[var(--font-size-small)] text-text-tertiary tracking-[1px]">
+            POWERED BY AI · 精準記帳 · 情緒滿分
           </p>
-        </section>
+        </div>
       </div>
 
-      <VoiceInput onSubmit={handleSubmit} />
+      <VoiceInput onSubmit={handleSubmit} disabled={isParsing || isSaving} />
     </>
   )
 }

--- a/frontend/src/stores/dashboardStore.ts
+++ b/frontend/src/stores/dashboardStore.ts
@@ -1,0 +1,238 @@
+import { create } from 'zustand'
+import api from '../lib/api'
+import type { Transaction } from '../stores/index'
+
+export interface ParsedResult {
+  amount: number | null
+  category: string | null
+  merchant: string
+  date: string
+  confidence: number
+  isNewCategory: boolean
+  suggestedCategory: string | null
+}
+
+export interface AIFeedbackContent {
+  text: string
+  emotionTag: string
+}
+
+export interface BudgetContext {
+  monthlyBudget: number
+  spentThisMonth: number
+  remaining: number
+  usedRatio: number
+  categorySpent: number
+  categoryLimit: number
+}
+
+export interface BudgetSummary {
+  month: string
+  monthlyBudget: number
+  totalSpent: number
+  remaining: number
+  usedRatio: number
+  transactionCount: number
+}
+
+export type DashboardStatus =
+  | 'idle'
+  | 'parsing'
+  | 'parsed'
+  | 'confirming'
+  | 'saving'
+  | 'error'
+
+interface DashboardState {
+  status: DashboardStatus
+  parsedResult: ParsedResult | null
+  aiFeedback: AIFeedbackContent | null
+  budgetContext: BudgetContext | null
+  budgetSummary: BudgetSummary | null
+  recentTransactions: Transaction[]
+  errorMessage: string
+  lastFeedbackText: string
+  lastPersona: string
+
+  // Actions
+  parseInput: (rawText: string) => Promise<void>
+  confirmTransaction: (data: {
+    amount: number
+    category: string
+    merchant: string
+    date: string
+    rawText: string
+    feedback?: AIFeedbackContent
+  }) => Promise<void>
+  createCategory: (category: string) => Promise<void>
+  fetchBudgetSummary: () => Promise<void>
+  fetchRecentTransactions: () => Promise<void>
+  resetParsedResult: () => void
+  setError: (message: string) => void
+}
+
+export const useDashboardStore = create<DashboardState>((set, get) => ({
+  status: 'idle',
+  parsedResult: null,
+  aiFeedback: null,
+  budgetContext: null,
+  budgetSummary: null,
+  recentTransactions: [],
+  errorMessage: '',
+  lastFeedbackText: '',
+  lastPersona: 'gentle',
+
+  parseInput: async (rawText: string) => {
+    set({ status: 'parsing', errorMessage: '' })
+    try {
+      const llmApiKey = localStorage.getItem('llm_api_key') ?? ''
+      const res = await api.post(
+        '/ai/parse',
+        { raw_text: rawText },
+        { headers: { 'X-LLM-API-Key': llmApiKey } }
+      )
+      const { parsed, feedback, budget_context: bc } = res.data.data
+      set({
+        status: 'parsed',
+        parsedResult: {
+          amount: parsed.amount,
+          category: parsed.category,
+          merchant: parsed.merchant,
+          date: parsed.date,
+          confidence: parsed.confidence,
+          isNewCategory: parsed.is_new_category ?? false,
+          suggestedCategory: parsed.suggested_category ?? null,
+        },
+        aiFeedback: feedback
+          ? { text: feedback.text, emotionTag: feedback.emotion_tag }
+          : null,
+        budgetContext: bc
+          ? {
+              monthlyBudget: bc.monthly_budget,
+              spentThisMonth: bc.spent_this_month,
+              remaining: bc.remaining,
+              usedRatio: bc.used_ratio,
+              categorySpent: bc.category_spent,
+              categoryLimit: bc.category_limit,
+            }
+          : null,
+        lastFeedbackText: feedback?.text ?? '',
+      })
+    } catch (err: unknown) {
+      const message =
+        (err as { response?: { data?: { message?: string } } })?.response?.data
+          ?.message ?? '記帳失敗，請稍後重試'
+      set({ status: 'error', errorMessage: message })
+    }
+  },
+
+  confirmTransaction: async (data) => {
+    set({ status: 'saving', errorMessage: '' })
+    try {
+      const res = await api.post('/transactions', {
+        amount: data.amount,
+        category: data.category,
+        merchant: data.merchant,
+        raw_text: data.rawText,
+        transaction_date: data.date,
+        feedback: data.feedback
+          ? {
+              text: data.feedback.text,
+              emotion_tag: data.feedback.emotionTag,
+              persona_used: get().lastPersona,
+            }
+          : undefined,
+      })
+      const tx = res.data.data.transaction
+      const newTransaction: Transaction = {
+        id: tx.id,
+        amount: tx.amount,
+        category: tx.category,
+        merchant: tx.merchant,
+        rawText: tx.raw_text,
+        note: tx.note,
+        transactionDate: tx.transaction_date,
+        createdAt: tx.created_at,
+      }
+
+      const feedback = res.data.data.feedback
+      set((state) => ({
+        status: 'idle',
+        parsedResult: null,
+        recentTransactions: [newTransaction, ...state.recentTransactions].slice(
+          0,
+          5
+        ),
+        lastFeedbackText: feedback?.feedback_text ?? state.lastFeedbackText,
+        lastPersona: feedback?.persona_used ?? state.lastPersona,
+      }))
+    } catch (err: unknown) {
+      const message =
+        (err as { response?: { data?: { message?: string } } })?.response?.data
+          ?.message ?? '儲存失敗，請稍後重試'
+      set({ status: 'error', errorMessage: message })
+    }
+  },
+
+  createCategory: async (category: string) => {
+    try {
+      await api.post('/budget/categories', { category })
+    } catch (err: unknown) {
+      const message =
+        (err as { response?: { data?: { message?: string } } })?.response?.data
+          ?.message ?? '新增類別失敗'
+      set({ status: 'error', errorMessage: message })
+      throw err
+    }
+  },
+
+  fetchBudgetSummary: async () => {
+    try {
+      const res = await api.get('/budget/summary')
+      const d = res.data.data
+      set({
+        budgetSummary: {
+          month: d.month,
+          monthlyBudget: d.monthly_budget,
+          totalSpent: d.total_spent,
+          remaining: d.remaining,
+          usedRatio: d.used_ratio,
+          transactionCount: d.transaction_count,
+        },
+      })
+    } catch {
+      // Silently fail - budget card will show default state
+    }
+  },
+
+  fetchRecentTransactions: async () => {
+    try {
+      const res = await api.get('/transactions', {
+        params: { limit: 5, sort: 'desc' },
+      })
+      const items = res.data.data.items.map(
+        (t: Record<string, unknown>) =>
+          ({
+            id: t.id as string,
+            amount: t.amount as number,
+            category: t.category as string,
+            merchant: t.merchant as string,
+            rawText: '',
+            transactionDate: t.transaction_date as string,
+            createdAt: t.created_at as string,
+          }) satisfies Transaction
+      )
+      set({ recentTransactions: items })
+    } catch {
+      // Silently fail
+    }
+  },
+
+  resetParsedResult: () => {
+    set({ status: 'idle', parsedResult: null, errorMessage: '' })
+  },
+
+  setError: (message: string) => {
+    set({ status: 'error', errorMessage: message })
+  },
+}))

--- a/frontend/src/test/VoiceInput.test.tsx
+++ b/frontend/src/test/VoiceInput.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import VoiceInput from '../components/VoiceInput'
+
+describe('VoiceInput', () => {
+  const mockOnSubmit = vi.fn()
+
+  beforeEach(() => {
+    mockOnSubmit.mockClear()
+  })
+
+  afterEach(() => {
+    delete (window as unknown as Record<string, unknown>).SpeechRecognition
+    delete (window as unknown as Record<string, unknown>).webkitSpeechRecognition
+  })
+
+  it('renders input field and send button', () => {
+    render(<VoiceInput onSubmit={mockOnSubmit} />)
+
+    expect(screen.getByLabelText('消費描述輸入')).toBeInTheDocument()
+    expect(screen.getByLabelText('送出')).toBeInTheDocument()
+  })
+
+  it('shows mic button when SpeechRecognition is supported', () => {
+    ;(window as unknown as Record<string, unknown>).SpeechRecognition = function () {
+      return { start: vi.fn(), stop: vi.fn(), abort: vi.fn() }
+    }
+
+    render(<VoiceInput onSubmit={mockOnSubmit} />)
+    expect(screen.getByLabelText('語音輸入')).toBeInTheDocument()
+  })
+
+  it('hides mic button when SpeechRecognition is not supported', () => {
+    delete (window as unknown as Record<string, unknown>).SpeechRecognition
+    delete (window as unknown as Record<string, unknown>).webkitSpeechRecognition
+
+    render(<VoiceInput onSubmit={mockOnSubmit} />)
+    expect(screen.queryByLabelText('語音輸入')).not.toBeInTheDocument()
+  })
+
+  it('calls onSubmit when send button is clicked with text', async () => {
+    const user = userEvent.setup()
+    render(<VoiceInput onSubmit={mockOnSubmit} />)
+
+    const input = screen.getByLabelText('消費描述輸入')
+    await user.type(input, '午餐吃拉麵 180 元')
+    await user.click(screen.getByLabelText('送出'))
+
+    expect(mockOnSubmit).toHaveBeenCalledWith('午餐吃拉麵 180 元')
+  })
+
+  it('clears input after submission', async () => {
+    const user = userEvent.setup()
+    render(<VoiceInput onSubmit={mockOnSubmit} />)
+
+    const input = screen.getByLabelText('消費描述輸入') as HTMLInputElement
+    await user.type(input, '咖啡 150')
+    await user.click(screen.getByLabelText('送出'))
+
+    expect(input.value).toBe('')
+  })
+
+  it('does not submit empty text', async () => {
+    const user = userEvent.setup()
+    render(<VoiceInput onSubmit={mockOnSubmit} />)
+
+    await user.click(screen.getByLabelText('送出'))
+
+    expect(mockOnSubmit).not.toHaveBeenCalled()
+  })
+
+  it('does not submit whitespace-only text', async () => {
+    const user = userEvent.setup()
+    render(<VoiceInput onSubmit={mockOnSubmit} />)
+
+    const input = screen.getByLabelText('消費描述輸入')
+    await user.type(input, '   ')
+    await user.click(screen.getByLabelText('送出'))
+
+    expect(mockOnSubmit).not.toHaveBeenCalled()
+  })
+
+  it('submits on Enter key', async () => {
+    const user = userEvent.setup()
+    render(<VoiceInput onSubmit={mockOnSubmit} />)
+
+    const input = screen.getByLabelText('消費描述輸入')
+    await user.type(input, '搭捷運 35{Enter}')
+
+    expect(mockOnSubmit).toHaveBeenCalledWith('搭捷運 35')
+  })
+
+  it('disables input and buttons when disabled prop is true', () => {
+    render(<VoiceInput onSubmit={mockOnSubmit} disabled />)
+
+    const input = screen.getByLabelText('消費描述輸入') as HTMLInputElement
+    expect(input.disabled).toBe(true)
+    expect(screen.getByLabelText('送出')).toBeDisabled()
+  })
+
+  it('shows default placeholder text', () => {
+    render(<VoiceInput onSubmit={mockOnSubmit} />)
+
+    const input = screen.getByLabelText('消費描述輸入')
+    expect(input).toHaveAttribute('placeholder', '例如：中午吃拉麵 280 元')
+  })
+
+  it('send button is disabled when input is empty', () => {
+    render(<VoiceInput onSubmit={mockOnSubmit} />)
+    expect(screen.getByLabelText('送出')).toBeDisabled()
+  })
+})

--- a/frontend/src/test/dashboardComponents.test.tsx
+++ b/frontend/src/test/dashboardComponents.test.tsx
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import BudgetCard from '../components/BudgetCard'
+import AIFeedbackCard from '../components/AIFeedbackCard'
+import RecentTransactions from '../components/RecentTransactions'
+import ParsedResultCard from '../components/ParsedResultCard'
+import NewCategoryDialog from '../components/NewCategoryDialog'
+import type { BudgetSummary } from '../stores/dashboardStore'
+import type { Transaction } from '../stores/index'
+
+describe('BudgetCard', () => {
+  it('shows placeholder when summary is null', () => {
+    render(<BudgetCard summary={null} />)
+    expect(screen.getByText('--')).toBeInTheDocument()
+    expect(screen.getByText('尚未設定預算')).toBeInTheDocument()
+  })
+
+  it('shows budget info when summary is provided', () => {
+    const summary: BudgetSummary = {
+      month: '2026-03',
+      monthlyBudget: 20000,
+      totalSpent: 5000,
+      remaining: 15000,
+      usedRatio: 0.25,
+      transactionCount: 10,
+    }
+    render(<BudgetCard summary={summary} />)
+    expect(screen.getByText('75%')).toBeInTheDocument()
+    expect(screen.getByText('$5,000')).toBeInTheDocument()
+    expect(screen.getByText('目標：$20,000')).toBeInTheDocument()
+  })
+
+  it('shows danger styling when budget is low', () => {
+    const summary: BudgetSummary = {
+      month: '2026-03',
+      monthlyBudget: 20000,
+      totalSpent: 18000,
+      remaining: 2000,
+      usedRatio: 0.9,
+      transactionCount: 30,
+    }
+    render(<BudgetCard summary={summary} />)
+    expect(screen.getByText('10%')).toBeInTheDocument()
+  })
+
+  it('shows overbudget state', () => {
+    const summary: BudgetSummary = {
+      month: '2026-03',
+      monthlyBudget: 20000,
+      totalSpent: 22000,
+      remaining: -2000,
+      usedRatio: 1.1,
+      transactionCount: 40,
+    }
+    render(<BudgetCard summary={summary} />)
+    expect(screen.getByText('超支')).toBeInTheDocument()
+  })
+})
+
+describe('AIFeedbackCard', () => {
+  it('renders gentle persona feedback', () => {
+    render(
+      <AIFeedbackCard
+        feedbackText="享受美味是很重要的"
+        persona="gentle"
+      />
+    )
+    expect(screen.getByText('溫柔管家 💖 的即時回饋')).toBeInTheDocument()
+    expect(screen.getByText('「享受美味是很重要的」')).toBeInTheDocument()
+  })
+
+  it('renders sarcastic persona feedback', () => {
+    render(
+      <AIFeedbackCard
+        feedbackText="又亂花錢了"
+        persona="sarcastic"
+      />
+    )
+    expect(screen.getByText('毒舌教練 🔥 的即時回饋')).toBeInTheDocument()
+  })
+
+  it('renders guilt_trip persona feedback', () => {
+    render(
+      <AIFeedbackCard
+        feedbackText="我好擔心你"
+        persona="guilt_trip"
+      />
+    )
+    expect(screen.getByText('心疼天使 🥺 的即時回饋')).toBeInTheDocument()
+  })
+})
+
+describe('RecentTransactions', () => {
+  it('shows empty state when no transactions', () => {
+    render(<RecentTransactions transactions={[]} />)
+    expect(
+      screen.getByText('還沒有記帳紀錄，開始記帳吧！')
+    ).toBeInTheDocument()
+  })
+
+  it('renders transaction items', () => {
+    const txs: Transaction[] = [
+      {
+        id: '1',
+        amount: 250,
+        category: 'food',
+        merchant: '拉麵',
+        rawText: '午餐吃拉麵 250',
+        transactionDate: '2026-03-18',
+        createdAt: '2026-03-18T01:07:00Z',
+      },
+    ]
+    render(<RecentTransactions transactions={txs} />)
+    expect(screen.getByText('拉麵')).toBeInTheDocument()
+    expect(screen.getByText('-$250')).toBeInTheDocument()
+    expect(screen.getByText('飲食')).toBeInTheDocument()
+  })
+})
+
+describe('ParsedResultCard', () => {
+  const defaultResult = {
+    amount: 180,
+    category: 'food',
+    merchant: '拉麵店',
+    date: '2026-03-18',
+    confidence: 0.95,
+    isNewCategory: false,
+    suggestedCategory: null,
+  }
+  const categories = ['food', 'transport', 'entertainment', 'other']
+
+  it('renders parsed result fields', () => {
+    render(
+      <ParsedResultCard
+        result={defaultResult}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+        categories={categories}
+      />
+    )
+    expect(screen.getByText('✨ AI 幫你整理好了')).toBeInTheDocument()
+    expect(screen.getByText('$180')).toBeInTheDocument()
+    expect(screen.getByText('飲食')).toBeInTheDocument()
+    expect(screen.getByText('拉麵店')).toBeInTheDocument()
+  })
+
+  it('calls onConfirm when confirm button clicked', async () => {
+    const onConfirm = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <ParsedResultCard
+        result={defaultResult}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+        categories={categories}
+      />
+    )
+    await user.click(screen.getByText('✓ 確認記帳'))
+    expect(onConfirm).toHaveBeenCalledWith({
+      amount: 180,
+      category: 'food',
+      merchant: '拉麵店',
+      date: '2026-03-18',
+    })
+  })
+
+  it('enters edit mode when modify button clicked', async () => {
+    const user = userEvent.setup()
+    render(
+      <ParsedResultCard
+        result={defaultResult}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+        categories={categories}
+      />
+    )
+    await user.click(screen.getByText('修改'))
+    expect(screen.getByLabelText('金額')).toBeInTheDocument()
+    expect(screen.getByLabelText('類別')).toBeInTheDocument()
+    expect(screen.getByLabelText('商家')).toBeInTheDocument()
+    expect(screen.getByText('取消')).toBeInTheDocument()
+  })
+})
+
+describe('NewCategoryDialog', () => {
+  const defaultProps = {
+    suggestedCategory: '寵物',
+    persona: 'gentle' as const,
+    existingCategories: ['food', 'transport', 'other'],
+    onConfirm: vi.fn(),
+    onSelectExisting: vi.fn(),
+    onCancel: vi.fn(),
+  }
+
+  it('renders category suggestion', () => {
+    render(<NewCategoryDialog {...defaultProps} />)
+    expect(screen.getAllByText(/寵物/).length).toBeGreaterThan(0)
+    expect(screen.getByText('確認')).toBeInTheDocument()
+    expect(screen.getByText('修改名稱')).toBeInTheDocument()
+    expect(screen.getByText('選現有')).toBeInTheDocument()
+  })
+
+  it('calls onConfirm when confirm is clicked', async () => {
+    const onConfirm = vi.fn()
+    const user = userEvent.setup()
+    render(<NewCategoryDialog {...defaultProps} onConfirm={onConfirm} />)
+    await user.click(screen.getByText('確認'))
+    expect(onConfirm).toHaveBeenCalledWith('寵物')
+  })
+
+  it('shows rename input when modify name clicked', async () => {
+    const user = userEvent.setup()
+    render(<NewCategoryDialog {...defaultProps} />)
+    await user.click(screen.getByText('修改名稱'))
+    expect(screen.getByLabelText('類別名稱')).toBeInTheDocument()
+  })
+
+  it('shows category selection when select existing clicked', async () => {
+    const user = userEvent.setup()
+    render(<NewCategoryDialog {...defaultProps} />)
+    await user.click(screen.getByText('選現有'))
+    expect(screen.getByText('選擇類別')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/dashboardStore.test.ts
+++ b/frontend/src/test/dashboardStore.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useDashboardStore } from '../stores/dashboardStore'
+
+describe('dashboardStore', () => {
+  beforeEach(() => {
+    useDashboardStore.setState({
+      status: 'idle',
+      parsedResult: null,
+      aiFeedback: null,
+      budgetContext: null,
+      budgetSummary: null,
+      recentTransactions: [],
+      errorMessage: '',
+      lastFeedbackText: '',
+      lastPersona: 'gentle',
+    })
+  })
+
+  describe('state management', () => {
+    it('starts with idle status', () => {
+      const state = useDashboardStore.getState()
+      expect(state.status).toBe('idle')
+      expect(state.parsedResult).toBeNull()
+      expect(state.recentTransactions).toEqual([])
+    })
+
+    it('resetParsedResult clears to idle', () => {
+      useDashboardStore.setState({
+        status: 'parsed',
+        parsedResult: {
+          amount: 100,
+          category: 'food',
+          merchant: 'test',
+          date: '2026-03-18',
+          confidence: 0.9,
+          isNewCategory: false,
+          suggestedCategory: null,
+        },
+        errorMessage: 'some error',
+      })
+
+      useDashboardStore.getState().resetParsedResult()
+
+      const state = useDashboardStore.getState()
+      expect(state.status).toBe('idle')
+      expect(state.parsedResult).toBeNull()
+      expect(state.errorMessage).toBe('')
+    })
+
+    it('setError sets error status', () => {
+      useDashboardStore.getState().setError('test error')
+
+      const state = useDashboardStore.getState()
+      expect(state.status).toBe('error')
+      expect(state.errorMessage).toBe('test error')
+    })
+
+    it('can store parsed result via setState', () => {
+      useDashboardStore.setState({
+        status: 'parsed',
+        parsedResult: {
+          amount: 180,
+          category: 'food',
+          merchant: '拉麵店',
+          date: '2026-03-18',
+          confidence: 0.95,
+          isNewCategory: false,
+          suggestedCategory: null,
+        },
+        aiFeedback: {
+          text: '享受美味',
+          emotionTag: '鼓勵',
+        },
+      })
+
+      const state = useDashboardStore.getState()
+      expect(state.status).toBe('parsed')
+      expect(state.parsedResult?.amount).toBe(180)
+      expect(state.parsedResult?.category).toBe('food')
+      expect(state.aiFeedback?.text).toBe('享受美味')
+    })
+
+    it('can store new category parse result', () => {
+      useDashboardStore.setState({
+        status: 'parsed',
+        parsedResult: {
+          amount: 1200,
+          category: null,
+          merchant: '獸醫',
+          date: '2026-03-18',
+          confidence: 0.9,
+          isNewCategory: true,
+          suggestedCategory: '寵物',
+        },
+      })
+
+      const state = useDashboardStore.getState()
+      expect(state.parsedResult?.isNewCategory).toBe(true)
+      expect(state.parsedResult?.suggestedCategory).toBe('寵物')
+    })
+
+    it('can store budget summary', () => {
+      useDashboardStore.setState({
+        budgetSummary: {
+          month: '2026-03',
+          monthlyBudget: 20000,
+          totalSpent: 5000,
+          remaining: 15000,
+          usedRatio: 0.25,
+          transactionCount: 10,
+        },
+      })
+
+      const state = useDashboardStore.getState()
+      expect(state.budgetSummary?.monthlyBudget).toBe(20000)
+      expect(state.budgetSummary?.totalSpent).toBe(5000)
+      expect(state.budgetSummary?.usedRatio).toBe(0.25)
+    })
+
+    it('can store recent transactions', () => {
+      useDashboardStore.setState({
+        recentTransactions: [
+          {
+            id: 'tx-1',
+            amount: 180,
+            category: 'food',
+            merchant: '拉麵店',
+            rawText: '拉麵 180',
+            transactionDate: '2026-03-18',
+            createdAt: '2026-03-18T12:00:00Z',
+          },
+          {
+            id: 'tx-2',
+            amount: 35,
+            category: 'transport',
+            merchant: '捷運',
+            rawText: '搭捷運 35',
+            transactionDate: '2026-03-18',
+            createdAt: '2026-03-18T08:30:00Z',
+          },
+        ],
+      })
+
+      const state = useDashboardStore.getState()
+      expect(state.recentTransactions).toHaveLength(2)
+      expect(state.recentTransactions[0].merchant).toBe('拉麵店')
+    })
+
+    it('stores feedback text', () => {
+      useDashboardStore.setState({
+        lastFeedbackText: '享受美味是很重要的',
+        lastPersona: 'gentle',
+      })
+
+      const state = useDashboardStore.getState()
+      expect(state.lastFeedbackText).toBe('享受美味是很重要的')
+      expect(state.lastPersona).toBe('gentle')
+    })
+  })
+})

--- a/frontend/src/test/useVoiceRecognition.test.ts
+++ b/frontend/src/test/useVoiceRecognition.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import {
+  useVoiceRecognition,
+  isSpeechRecognitionSupported,
+} from '../hooks/useVoiceRecognition'
+
+// Mock SpeechRecognition
+function createMockRecognition() {
+  return {
+    lang: '',
+    interimResults: false,
+    continuous: false,
+    maxAlternatives: 1,
+    onstart: null as (() => void) | null,
+    onresult: null as ((e: unknown) => void) | null,
+    onerror: null as ((e: unknown) => void) | null,
+    onend: null as (() => void) | null,
+    start: vi.fn(),
+    stop: vi.fn(),
+    abort: vi.fn(),
+  }
+}
+
+type MockRecognition = ReturnType<typeof createMockRecognition>
+
+describe('isSpeechRecognitionSupported', () => {
+  afterEach(() => {
+    // Clean up mock
+    delete (window as unknown as Record<string, unknown>).SpeechRecognition
+    delete (window as unknown as Record<string, unknown>).webkitSpeechRecognition
+  })
+
+  it('returns true when SpeechRecognition is available', () => {
+    ;(window as unknown as Record<string, unknown>).SpeechRecognition = vi.fn()
+    expect(isSpeechRecognitionSupported()).toBe(true)
+  })
+
+  it('returns true when webkitSpeechRecognition is available', () => {
+    ;(window as unknown as Record<string, unknown>).webkitSpeechRecognition = vi.fn()
+    expect(isSpeechRecognitionSupported()).toBe(true)
+  })
+
+  it('returns false when neither is available', () => {
+    delete (window as unknown as Record<string, unknown>).SpeechRecognition
+    delete (window as unknown as Record<string, unknown>).webkitSpeechRecognition
+    expect(isSpeechRecognitionSupported()).toBe(false)
+  })
+})
+
+describe('useVoiceRecognition', () => {
+  let mockRecognition: MockRecognition
+
+  beforeEach(() => {
+    mockRecognition = createMockRecognition()
+    // Must use function keyword for `new` to work
+    ;(window as unknown as Record<string, unknown>).SpeechRecognition = function () {
+      return mockRecognition
+    }
+  })
+
+  afterEach(() => {
+    delete (window as unknown as Record<string, unknown>).SpeechRecognition
+    delete (window as unknown as Record<string, unknown>).webkitSpeechRecognition
+  })
+
+  it('reports supported when SpeechRecognition exists', () => {
+    const { result } = renderHook(() => useVoiceRecognition())
+    expect(result.current.isSupported).toBe(true)
+  })
+
+  it('reports unsupported when SpeechRecognition missing', () => {
+    delete (window as unknown as Record<string, unknown>).SpeechRecognition
+    const { result } = renderHook(() => useVoiceRecognition())
+    expect(result.current.isSupported).toBe(false)
+  })
+
+  it('starts with idle status', () => {
+    const { result } = renderHook(() => useVoiceRecognition())
+    expect(result.current.status).toBe('idle')
+    expect(result.current.transcript).toBe('')
+    expect(result.current.interimTranscript).toBe('')
+    expect(result.current.errorMessage).toBe('')
+  })
+
+  it('transitions to recording on startRecording', () => {
+    const { result } = renderHook(() => useVoiceRecognition())
+
+    act(() => {
+      result.current.startRecording()
+    })
+
+    expect(mockRecognition.start).toHaveBeenCalledOnce()
+    expect(mockRecognition.lang).toBe('zh-TW')
+    expect(mockRecognition.interimResults).toBe(true)
+
+    // Simulate onstart callback
+    act(() => {
+      mockRecognition.onstart?.()
+    })
+
+    expect(result.current.status).toBe('recording')
+  })
+
+  it('handles interim results', () => {
+    const onInterimResult = vi.fn()
+    const { result } = renderHook(() =>
+      useVoiceRecognition({ onInterimResult })
+    )
+
+    act(() => {
+      result.current.startRecording()
+      mockRecognition.onstart?.()
+    })
+
+    act(() => {
+      mockRecognition.onresult?.({
+        results: [{ 0: { transcript: '午餐' }, isFinal: false, length: 1 }],
+        resultIndex: 0,
+      } as unknown)
+    })
+
+    expect(result.current.status).toBe('recognizing')
+    expect(onInterimResult).toHaveBeenCalledWith('午餐')
+  })
+
+  it('handles final results and calls onResult', () => {
+    const onResult = vi.fn()
+    const { result } = renderHook(() => useVoiceRecognition({ onResult }))
+
+    act(() => {
+      result.current.startRecording()
+      mockRecognition.onstart?.()
+    })
+
+    act(() => {
+      mockRecognition.onresult?.({
+        results: [
+          { 0: { transcript: '午餐吃拉麵 180 元' }, isFinal: true, length: 1 },
+        ],
+        resultIndex: 0,
+      } as unknown)
+    })
+
+    expect(result.current.transcript).toBe('午餐吃拉麵 180 元')
+    expect(onResult).toHaveBeenCalledWith('午餐吃拉麵 180 元')
+  })
+
+  it('handles errors and calls onError', () => {
+    const onError = vi.fn()
+    const { result } = renderHook(() => useVoiceRecognition({ onError }))
+
+    act(() => {
+      result.current.startRecording()
+      mockRecognition.onstart?.()
+    })
+
+    act(() => {
+      mockRecognition.onerror?.({ error: 'no-speech' })
+    })
+
+    expect(result.current.status).toBe('error')
+    expect(result.current.errorMessage).toBe('未偵測到語音，請再試一次')
+    expect(onError).toHaveBeenCalled()
+  })
+
+  it('returns to idle after recognition ends normally', () => {
+    const { result } = renderHook(() => useVoiceRecognition())
+
+    act(() => {
+      result.current.startRecording()
+      mockRecognition.onstart?.()
+    })
+
+    act(() => {
+      mockRecognition.onend?.()
+    })
+
+    expect(result.current.status).toBe('idle')
+  })
+
+  it('stays in error state after recognition ends with error', () => {
+    const { result } = renderHook(() => useVoiceRecognition())
+
+    act(() => {
+      result.current.startRecording()
+      mockRecognition.onstart?.()
+    })
+
+    act(() => {
+      mockRecognition.onerror?.({ error: 'not-allowed' })
+    })
+
+    act(() => {
+      mockRecognition.onend?.()
+    })
+
+    expect(result.current.status).toBe('error')
+  })
+
+  it('stops recording when stopRecording is called', () => {
+    const { result } = renderHook(() => useVoiceRecognition())
+
+    act(() => {
+      result.current.startRecording()
+    })
+
+    act(() => {
+      result.current.stopRecording()
+    })
+
+    expect(mockRecognition.stop).toHaveBeenCalledOnce()
+  })
+
+  it('aborts on unmount', () => {
+    const { result, unmount } = renderHook(() => useVoiceRecognition())
+
+    act(() => {
+      result.current.startRecording()
+    })
+
+    unmount()
+
+    expect(mockRecognition.abort).toHaveBeenCalled()
+  })
+
+  it('does nothing when startRecording and unsupported', () => {
+    delete (window as unknown as Record<string, unknown>).SpeechRecognition
+    const { result } = renderHook(() => useVoiceRecognition())
+
+    act(() => {
+      result.current.startRecording()
+    })
+
+    expect(result.current.status).toBe('idle')
+  })
+})

--- a/frontend/src/types/speech-recognition.d.ts
+++ b/frontend/src/types/speech-recognition.d.ts
@@ -1,0 +1,77 @@
+// Web Speech API type declarations
+// These are not included in lib.dom.d.ts by default
+
+interface SpeechRecognitionErrorEvent extends Event {
+  readonly error: SpeechRecognitionErrorCode
+  readonly message: string
+}
+
+type SpeechRecognitionErrorCode =
+  | 'aborted'
+  | 'audio-capture'
+  | 'bad-grammar'
+  | 'language-not-supported'
+  | 'network'
+  | 'no-speech'
+  | 'not-allowed'
+  | 'service-not-allowed'
+
+interface SpeechRecognitionAlternative {
+  readonly confidence: number
+  readonly transcript: string
+}
+
+interface SpeechRecognitionResult {
+  readonly isFinal: boolean
+  readonly length: number
+  item(index: number): SpeechRecognitionAlternative
+  [index: number]: SpeechRecognitionAlternative
+}
+
+interface SpeechRecognitionResultList {
+  readonly length: number
+  item(index: number): SpeechRecognitionResult
+  [index: number]: SpeechRecognitionResult
+}
+
+interface SpeechRecognitionEvent extends Event {
+  readonly resultIndex: number
+  readonly results: SpeechRecognitionResultList
+}
+
+interface SpeechRecognition extends EventTarget {
+  continuous: boolean
+  interimResults: boolean
+  lang: string
+  maxAlternatives: number
+  onaudioend: ((this: SpeechRecognition, ev: Event) => void) | null
+  onaudiostart: ((this: SpeechRecognition, ev: Event) => void) | null
+  onend: ((this: SpeechRecognition, ev: Event) => void) | null
+  onerror:
+    | ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => void)
+    | null
+  onnomatch:
+    | ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => void)
+    | null
+  onresult:
+    | ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => void)
+    | null
+  onsoundend: ((this: SpeechRecognition, ev: Event) => void) | null
+  onsoundstart: ((this: SpeechRecognition, ev: Event) => void) | null
+  onspeechend: ((this: SpeechRecognition, ev: Event) => void) | null
+  onspeechstart: ((this: SpeechRecognition, ev: Event) => void) | null
+  onstart: ((this: SpeechRecognition, ev: Event) => void) | null
+  abort(): void
+  start(): void
+  stop(): void
+}
+
+declare var SpeechRecognition: {
+  prototype: SpeechRecognition
+  new (): SpeechRecognition
+}
+
+interface Window {
+  SpeechRecognition?: typeof SpeechRecognition
+  webkitSpeechRecognition?: typeof SpeechRecognition
+}


### PR DESCRIPTION
## Summary
- 實作 `BudgetCard` 組件：顯示預算百分比、進度條（綠/黃/紅色系 + 呼吸燈動畫）、超支狀態
- 實作 `AIFeedbackCard` 組件：依據人設（溫柔/毒舌/情勒）顯示即時 AI 回饋
- 實作 `RecentTransactions` 組件：顯示最近 5 筆交易記錄
- 實作 `ParsedResultCard` 組件：AI 解析結果確認卡片，支援確認/修改模式切換
- 實作 `NewCategoryDialog` 組件（PRD-F-012）：新類別確認對話流（確認新增/修改名稱/選擇現有），含三種操作分支
- 實作 `dashboardStore`（Zustand）：管理解析狀態、確認流程、預算摘要、最近帳目快取
- 串接 API：`POST /ai/parse`、`POST /transactions`、`POST /budget/categories`、`GET /budget/summary`、`GET /transactions`
- 重構 `DashboardPage` 整合所有組件，含 skeleton loading、error toast、footer
- 新增 CSS 動畫：budget-pulse（呼吸燈）、slide-up（底部彈出面板）

## Test Plan
- [x] 53 個單元測試全部通過
- [x] TypeScript 編譯無錯誤
- [x] ESLint 檢查通過
- [ ] 👁️ 手動：完整記帳流程（輸入 → 解析 → 確認 → 儲存）
- [ ] 👁️ 手動：新類別偵測時顯示確認對話框並完成新增類別 + 記帳

Closes #10