### PR TITLE
fix(backend): 修正 LLM Prompt Review 發現的問題 (T-205)

### DIFF
--- a/backend/src/prompts/personaFeedbackPrompt.ts
+++ b/backend/src/prompts/personaFeedbackPrompt.ts
@@ -35,7 +35,7 @@ export function buildPersonaFeedbackPrompt(input: PersonaFeedbackInput): string 
 ## 輸出格式
 僅回傳以下 JSON，不要包含任何其他文字或 markdown 標記：
 {
-  "feedback": "<你的評論，50字以內>",
+  "text": "<你的評論，50字以內>",
   "emotion_tag": "<情緒標籤，如 sarcastic_warning, gentle_encouragement, guilt_heavy 等>"
 }`;
 }

--- a/backend/src/services/llm/geminiProvider.ts
+++ b/backend/src/services/llm/geminiProvider.ts
@@ -1,6 +1,7 @@
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { LLMProvider } from './llmProvider';
 import { ParsedTransaction, AIFeedbackContent } from '../../types/llm';
+import { DATA_EXTRACTOR_SYSTEM_PROMPT } from '../../prompts/dataExtractorPrompt';
 import { AppError } from '../../middlewares/errorHandler';
 
 const GEMINI_MODEL = process.env.GEMINI_MODEL || 'gemini-2.0-flash-lite';
@@ -29,14 +30,16 @@ export class GeminiProvider implements LLMProvider {
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       try {
-        const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
-
-        const result = await model.generateContent({
+        const generatePromise = model.generateContent({
           contents: [{ role: 'user', parts: [{ text: userPrompt }] }],
         });
 
-        clearTimeout(timeout);
+        const timeoutPromise = new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('Gemini API timeout')), TIMEOUT_MS)
+        );
+
+        const result = await Promise.race([generatePromise, timeoutPromise]);
+
         const text = result.response.text();
         if (!text) {
           throw new Error('Gemini 回傳空結果');
@@ -61,8 +64,7 @@ export class GeminiProvider implements LLMProvider {
   }
 
   async extractData(prompt: string, apiKey: string): Promise<ParsedTransaction> {
-    const systemPrompt = '你是一個精確的記帳資料萃取引擎。你只能回傳 JSON 格式的結果，不能包含任何其他文字。';
-    const text = await this.callWithRetry(apiKey, systemPrompt, prompt, 0, 200);
+    const text = await this.callWithRetry(apiKey, DATA_EXTRACTOR_SYSTEM_PROMPT, prompt, 0, 200);
     return this.parseJSON<ParsedTransaction>(text);
   }
 

--- a/backend/src/services/llm/openaiProvider.ts
+++ b/backend/src/services/llm/openaiProvider.ts
@@ -1,6 +1,7 @@
 import OpenAI from 'openai';
 import { LLMProvider } from './llmProvider';
 import { ParsedTransaction, AIFeedbackContent } from '../../types/llm';
+import { DATA_EXTRACTOR_SYSTEM_PROMPT } from '../../prompts/dataExtractorPrompt';
 import { AppError } from '../../middlewares/errorHandler';
 
 const OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-4o-mini';
@@ -55,8 +56,7 @@ export class OpenAIProvider implements LLMProvider {
   }
 
   async extractData(prompt: string, apiKey: string): Promise<ParsedTransaction> {
-    const systemPrompt = '你是一個精確的記帳資料萃取引擎。你只能回傳 JSON 格式的結果，不能包含任何其他文字。';
-    const text = await this.callWithRetry(apiKey, systemPrompt, prompt, 0, 200);
+    const text = await this.callWithRetry(apiKey, DATA_EXTRACTOR_SYSTEM_PROMPT, prompt, 0, 200);
     return this.parseJSON<ParsedTransaction>(text);
   }
 


### PR DESCRIPTION
## Summary
- 修正 `personaFeedbackPrompt` 欄位名稱不一致（`feedback` → `text`），避免前端收到 `undefined`
- 修正 Gemini Provider timeout 未生效，改用 `Promise.race` 確保 3 秒 timeout 保護
- 統一兩個 Provider 的 System Prompt 來源，消除重複定義

Closes #11

## 變更內容
| 檔案 | 說明 |
|------|------|
| `backend/src/prompts/personaFeedbackPrompt.ts` | Prompt JSON 欄位 `"feedback"` → `"text"` 對齊 `AIFeedbackContent` type |
| `backend/src/services/llm/geminiProvider.ts` | Timeout 改用 `Promise.race`；引用 `DATA_EXTRACTOR_SYSTEM_PROMPT` |
| `backend/src/services/llm/openaiProvider.ts` | 引用 `DATA_EXTRACTOR_SYSTEM_PROMPT` |

## Test plan
- [x] AI Controller 測試 18/18 通過
- [x] 全部後端測試 68/68 通過
- [x] TypeScript 型別檢查零錯誤
- [x] ESLint 零警告