### PR TITLE
fix: M2 驗證修復與備註欄位功能

### DIFF
--- a/backend/src/prompts/dataExtractorPrompt.ts
+++ b/backend/src/prompts/dataExtractorPrompt.ts
@@ -25,8 +25,15 @@ export function buildDataExtractorPrompt(input: DataExtractorInput): string {
   "date": "<YYYY-MM-DD>",
   "confidence": <number>,
   "is_new_category": <boolean>,
-  "suggested_category": "<string | null>"
+  "suggested_category": "<string | null>",
+  "note": "<string | null>"
 }
+
+## note 欄位規則
+- 將無法歸入金額、類別、商家、日期的有價值上下文資訊整理為備註
+- 例如地點描述、商品細節、購買原因等
+- 用自然流暢的中文撰寫，不超過 100 字
+- 若輸入內容已被結構化欄位完整涵蓋，note 為 null
 
 ## 使用者輸入
 ${input.rawText}`;

--- a/backend/src/prompts/dataExtractorPrompt.ts
+++ b/backend/src/prompts/dataExtractorPrompt.ts
@@ -9,7 +9,7 @@ export function buildDataExtractorPrompt(input: DataExtractorInput): string {
 1. 從使用者輸入中萃取：金額、類別、商家、日期
 2. 金額必須為正數。若無法辨識金額，回傳 amount 為 null
 3. 類別必須從以下清單中選擇：[${categoriesList}]
-4. 若無法匹配任何現有類別，將 is_new_category 設為 true，並在 suggested_category 中填入建議的新類別名稱
+4. 「other」僅用於真正無法歸類的雜項消費。若消費有明確主題（如寵物、健身、才藝、育兒等），不應歸入 other，而應設 is_new_category 為 true，並在 suggested_category 中填入建議的新類別名稱（使用中文）
 5. 偵測相似類別名稱（如「咖啡」與「飲料」），避免重複建立，優先歸入現有類別
 6. 若未提及商家，根據消費內容推測合理的商家名稱
 7. 若未提及日期，使用今天的日期：${input.currentDate}

--- a/backend/src/routes/budgetRoutes.ts
+++ b/backend/src/routes/budgetRoutes.ts
@@ -1,0 +1,117 @@
+import { Router, Response, NextFunction } from 'express';
+import { authMiddleware, AuthRequest } from '../middlewares/auth';
+import prisma from '../config/database';
+import { AppError } from '../middlewares/errorHandler';
+import { ApiResponse } from '../types';
+
+const router = Router();
+
+// POST /budget/categories - 新增類別
+router.post('/categories', authMiddleware, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const userId = req.userId!;
+    const { category } = req.body;
+
+    if (!category || typeof category !== 'string' || !category.trim()) {
+      throw new AppError('請提供類別名稱', 400);
+    }
+
+    const trimmed = category.trim();
+
+    // Check duplicate
+    const existing = await prisma.categoryBudget.findUnique({
+      where: { userId_category: { userId, category: trimmed } },
+    });
+
+    if (existing) {
+      throw new AppError('該類別已存在', 409);
+    }
+
+    const created = await prisma.categoryBudget.create({
+      data: {
+        userId,
+        category: trimmed,
+        isCustom: true,
+        budgetLimit: 0,
+      },
+    });
+
+    const response: ApiResponse<{ id: string; category: string }> = {
+      code: 201,
+      message: '類別新增成功',
+      data: { id: created.id, category: created.category },
+      timestamp: new Date().toISOString(),
+    };
+
+    res.status(201).json(response);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /budget/categories - 取得使用者類別清單
+router.get('/categories', authMiddleware, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const userId = req.userId!;
+    const categories = await prisma.categoryBudget.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    const response: ApiResponse<typeof categories> = {
+      code: 200,
+      message: '取得成功',
+      data: categories,
+      timestamp: new Date().toISOString(),
+    };
+
+    res.status(200).json(response);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /budget/summary - 取得當月預算摘要
+router.get('/summary', authMiddleware, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const userId = req.userId!;
+    const user = await prisma.user.findUnique({ where: { id: userId } });
+    if (!user) throw new AppError('使用者不存在', 404);
+
+    const now = new Date();
+    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+    const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+
+    const transactions = await prisma.transaction.findMany({
+      where: {
+        userId,
+        transactionDate: { gte: monthStart, lte: monthEnd },
+      },
+    });
+
+    const monthlyBudget = Number(user.monthlyBudget);
+    const totalSpent = transactions.reduce((sum, t) => sum + Number(t.amount), 0);
+    const remaining = monthlyBudget - totalSpent;
+    const usedRatio = monthlyBudget > 0 ? Math.round((totalSpent / monthlyBudget) * 100) / 100 : 0;
+
+    const response: ApiResponse<Record<string, unknown>> = {
+      code: 200,
+      message: '取得成功',
+      data: {
+        month: `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`,
+        monthly_budget: monthlyBudget,
+        total_spent: totalSpent,
+        remaining,
+        used_ratio: usedRatio,
+        transaction_count: transactions.length,
+      },
+      timestamp: new Date().toISOString(),
+    };
+
+    res.status(200).json(response);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -4,6 +4,7 @@ import authRoutes from './authRoutes';
 import userRoutes from './userRoutes';
 import aiRoutes from './aiRoutes';
 import transactionRoutes from './transactionRoutes';
+import budgetRoutes from './budgetRoutes';
 
 const router = Router();
 
@@ -15,9 +16,9 @@ router.use('/api/v1/auth', authRoutes);
 router.use('/api/v1/users', userRoutes);
 router.use('/api/v1/ai', aiRoutes);
 router.use('/api/v1/transactions', transactionRoutes);
+router.use('/api/v1/budget', budgetRoutes);
 
 // Future routes will be added here:
-// router.use('/api/v1/budget', budgetRoutes);
 // router.use('/api/v1/stats', statsRoutes);
 
 export default router;

--- a/backend/src/services/llm/geminiProvider.ts
+++ b/backend/src/services/llm/geminiProvider.ts
@@ -5,7 +5,7 @@ import { DATA_EXTRACTOR_SYSTEM_PROMPT } from '../../prompts/dataExtractorPrompt'
 import { AppError } from '../../middlewares/errorHandler';
 
 const GEMINI_MODEL = process.env.GEMINI_MODEL || 'gemini-2.5-flash';
-const TIMEOUT_MS = Number(process.env.LLM_TIMEOUT_MS) || 10000;
+const TIMEOUT_MS = Number(process.env.LLM_TIMEOUT_MS) || 30000;
 const MAX_RETRIES = 2;
 
 export class GeminiProvider implements LLMProvider {
@@ -14,15 +14,22 @@ export class GeminiProvider implements LLMProvider {
     systemPrompt: string,
     userPrompt: string,
     temperature: number,
-    maxTokens: number
+    maxTokens: number,
+    responseMimeType?: string
   ): Promise<string> {
     const genAI = new GoogleGenerativeAI(apiKey);
+    const generationConfig: Record<string, unknown> = {
+      temperature,
+      maxOutputTokens: maxTokens,
+      // Disable thinking to reduce latency and token usage
+      thinkingConfig: { thinkingBudget: 0 },
+    };
+    if (responseMimeType) {
+      generationConfig.responseMimeType = responseMimeType;
+    }
     const model = genAI.getGenerativeModel({
       model: GEMINI_MODEL,
-      generationConfig: {
-        temperature,
-        maxOutputTokens: maxTokens,
-      },
+      generationConfig,
       systemInstruction: systemPrompt,
     });
 
@@ -54,17 +61,18 @@ export class GeminiProvider implements LLMProvider {
     }
 
     const message = lastError?.message || '';
+    console.error('[Gemini Error]', message, lastError);
     if (message.includes('API_KEY_INVALID') || message.includes('PERMISSION_DENIED')) {
       throw new AppError('Gemini API Key 無效，請確認您的 API Key', 403);
     }
     if (message.includes('RESOURCE_EXHAUSTED') || message.includes('quota')) {
       throw new AppError('Gemini API 額度已用盡，請檢查您的配額或切換引擎', 403);
     }
-    throw new AppError('LLM 服務暫時不可用，請稍後再試', 502);
+    throw new AppError(`LLM 服務暫時不可用，請稍後再試 (${message})`, 502);
   }
 
   async extractData(prompt: string, apiKey: string): Promise<ParsedTransaction> {
-    const text = await this.callWithRetry(apiKey, DATA_EXTRACTOR_SYSTEM_PROMPT, prompt, 0, 2048);
+    const text = await this.callWithRetry(apiKey, DATA_EXTRACTOR_SYSTEM_PROMPT, prompt, 0, 2048, 'application/json');
     return this.parseJSON<ParsedTransaction>(text);
   }
 
@@ -73,19 +81,34 @@ export class GeminiProvider implements LLMProvider {
     const parts = prompt.split('\n---SYSTEM---\n');
     const systemPrompt = parts.length > 1 ? parts[0] : '';
     const userPrompt = parts.length > 1 ? parts[1] : prompt;
-    const text = await this.callWithRetry(apiKey, systemPrompt, userPrompt, 0.8, 1024);
+    const text = await this.callWithRetry(apiKey, systemPrompt, userPrompt, 0.8, 4096, 'application/json');
     return this.parseJSON<AIFeedbackContent>(text);
   }
 
   private parseJSON<T>(text: string): T {
-    // Strip markdown code blocks if present
     let cleaned = text.trim();
+
+    // Strip thinking tags (e.g. <think>...</think>)
+    cleaned = cleaned.replace(/<think>[\s\S]*?<\/think>/gi, '').trim();
+
+    // Strip markdown code blocks if present
     if (cleaned.startsWith('```')) {
       cleaned = cleaned.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '');
     }
+
+    // Try direct parse first
     try {
       return JSON.parse(cleaned) as T;
     } catch {
+      // Fallback: extract first JSON object from text
+      const match = cleaned.match(/\{[\s\S]*\}/);
+      if (match) {
+        try {
+          return JSON.parse(match[0]) as T;
+        } catch {
+          // fall through
+        }
+      }
       throw new AppError('LLM 回傳格式異常，無法解析', 502);
     }
   }

--- a/backend/src/services/llm/openaiProvider.ts
+++ b/backend/src/services/llm/openaiProvider.ts
@@ -70,12 +70,26 @@ export class OpenAIProvider implements LLMProvider {
 
   private parseJSON<T>(text: string): T {
     let cleaned = text.trim();
+
+    // Strip thinking tags
+    cleaned = cleaned.replace(/<think>[\s\S]*?<\/think>/gi, '').trim();
+
+    // Strip markdown code blocks
     if (cleaned.startsWith('```')) {
       cleaned = cleaned.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '');
     }
+
     try {
       return JSON.parse(cleaned) as T;
     } catch {
+      const match = cleaned.match(/\{[\s\S]*\}/);
+      if (match) {
+        try {
+          return JSON.parse(match[0]) as T;
+        } catch {
+          // fall through
+        }
+      }
       throw new AppError('LLM 回傳格式異常，無法解析', 502);
     }
   }

--- a/backend/src/types/llm.ts
+++ b/backend/src/types/llm.ts
@@ -9,6 +9,7 @@ export interface ParsedTransaction {
   confidence: number;
   is_new_category: boolean;
   suggested_category: string | null;
+  note: string | null;
 }
 
 export interface AIFeedbackContent {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-basic-ssl": "^2.2.0",
         "@vitejs/plugin-react": "^6.0.0",
         "autoprefixer": "^10.4.27",
         "eslint": "^9.39.4",
@@ -2135,6 +2136,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitejs/plugin-basic-ssl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.2.0.tgz",
+      "integrity": "sha512-nmyQ1HGRkfUxjsv3jw0+hMhEdZdrtkvMTdkzRUaRWfiO6PCWw2V2Pz3gldCq96Tn9S8htcgdTxw/gmbLLEbfYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-basic-ssl": "^2.2.0",
     "@vitejs/plugin-react": "^6.0.0",
     "autoprefixer": "^10.4.27",
     "eslint": "^9.39.4",

--- a/frontend/src/components/AIFeedbackCard.tsx
+++ b/frontend/src/components/AIFeedbackCard.tsx
@@ -26,11 +26,11 @@ function AIFeedbackCard({ feedbackText, persona }: AIFeedbackCardProps) {
         <div className="w-9 h-9 rounded-full bg-primary flex items-center justify-center text-surface text-lg">
           {config.icon}
         </div>
-        <p className="text-[var(--font-size-caption)] text-text-secondary">
+        <p className="text-caption text-text-secondary">
           {config.name} {config.emoji} 的即時回饋
         </p>
       </div>
-      <p className="text-[var(--font-size-body)] text-primary-dark">
+      <p className="text-body text-primary-dark">
         「{feedbackText}」
       </p>
     </section>

--- a/frontend/src/components/BudgetCard.tsx
+++ b/frontend/src/components/BudgetCard.tsx
@@ -11,13 +11,13 @@ function BudgetCard({ summary }: BudgetCardProps) {
         className="bg-surface rounded-lg shadow-card p-lg mx-2xl mb-xl"
         aria-label="預算概覽"
       >
-        <h2 className="text-[var(--font-size-caption)] text-text-secondary mb-sm">
+        <h2 className="text-caption text-text-secondary mb-sm">
           預算剩餘
         </h2>
-        <p className="text-[var(--font-size-display)] font-bold text-text-primary">
+        <p className="text-display font-bold text-text-primary">
           --
         </p>
-        <p className="text-[var(--font-size-caption)] text-text-secondary mt-sm">
+        <p className="text-caption text-text-secondary mt-sm">
           尚未設定預算
         </p>
       </section>
@@ -55,22 +55,22 @@ function BudgetCard({ summary }: BudgetCardProps) {
     >
       <div className="flex justify-between items-start mb-sm">
         <div>
-          <p className="text-[var(--font-size-caption)] text-text-secondary">
+          <p className="text-caption text-text-secondary">
             預算剩餘
           </p>
           <p
-            className={`text-[var(--font-size-display)] font-bold ${getPercentColor()}`}
+            className={`text-display font-bold ${getPercentColor()}`}
             aria-live="polite"
           >
             {isOverBudget ? '超支' : `${remainingPercent}%`}
           </p>
         </div>
         <div className="text-right">
-          <p className="text-[var(--font-size-caption)] text-text-secondary">
+          <p className="text-caption text-text-secondary">
             本月支出
           </p>
           <p
-            className="text-[var(--font-size-headline)] font-bold text-danger"
+            className="text-headline font-bold text-danger"
             aria-live="polite"
           >
             {formatMoney(totalSpent)}
@@ -94,10 +94,10 @@ function BudgetCard({ summary }: BudgetCardProps) {
       </div>
 
       <div className="flex justify-between">
-        <span className="text-[var(--font-size-small)] text-text-secondary">
+        <span className="text-small text-text-secondary">
           $0
         </span>
-        <span className="text-[var(--font-size-small)] text-text-secondary">
+        <span className="text-small text-text-secondary">
           目標：{formatMoney(monthlyBudget)}
         </span>
       </div>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -41,7 +41,7 @@ function Layout() {
                 <span className="text-xl leading-none" role="img" aria-hidden="true">
                   {tab.icon}
                 </span>
-                <span className="text-[var(--font-size-small)] mt-0.5">
+                <span className="text-small mt-0.5">
                   {tab.label}
                 </span>
               </>

--- a/frontend/src/components/NewCategoryDialog.tsx
+++ b/frontend/src/components/NewCategoryDialog.tsx
@@ -56,23 +56,23 @@ function NewCategoryDialog({
     return (
       <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/30">
         <div
-          className="w-full max-w-lg bg-surface rounded-t-xl p-lg animate-slide-up"
+          className="w-full max-w-[512px] bg-surface rounded-t-xl p-lg pb-[120px] animate-slide-up"
           role="dialog"
           aria-label="修改類別名稱"
         >
-          <h3 className="text-[var(--font-size-title)] font-semibold text-text-primary mb-md">
+          <h3 className="text-title font-semibold text-text-primary mb-md">
             修改類別名稱
           </h3>
           <input
             type="text"
             value={customName}
             onChange={(e) => setCustomName(e.target.value)}
-            className="w-full h-[44px] rounded-md border border-border px-lg text-[var(--font-size-body)] mb-xs"
+            className="w-full h-[44px] rounded-md border border-border px-lg text-body mb-xs"
             maxLength={50}
             autoFocus
             aria-label="類別名稱"
           />
-          <p className="text-[var(--font-size-small)] text-text-tertiary mb-lg">
+          <p className="text-small text-text-tertiary mb-lg">
             ⚠️ 類別名稱 2–50 字元
           </p>
           <div className="flex gap-sm">
@@ -103,11 +103,11 @@ function NewCategoryDialog({
     return (
       <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/30">
         <div
-          className="w-full max-w-lg bg-surface rounded-t-xl p-lg animate-slide-up"
+          className="w-full max-w-[512px] bg-surface rounded-t-xl p-lg pb-[120px] animate-slide-up"
           role="dialog"
           aria-label="選擇類別"
         >
-          <h3 className="text-[var(--font-size-title)] font-semibold text-text-primary mb-md">
+          <h3 className="text-title font-semibold text-text-primary mb-md">
             選擇類別
           </h3>
           <div className="flex flex-wrap gap-sm mb-lg">
@@ -116,7 +116,7 @@ function NewCategoryDialog({
                 key={cat}
                 type="button"
                 onClick={() => onSelectExisting(cat)}
-                className="px-lg py-sm rounded-sm bg-bg text-[var(--font-size-body)] text-text-primary hover:bg-border transition-colors"
+                className="px-lg py-sm rounded-sm bg-bg text-body text-text-primary hover:bg-border transition-colors"
               >
                 {categoryIcons[cat] ?? '📦'}{' '}
                 {categoryNames[cat] ?? cat}
@@ -147,7 +147,7 @@ function NewCategoryDialog({
           <div className="w-7 h-7 rounded-full bg-primary flex items-center justify-center text-surface text-sm shrink-0">
             {config.emoji}
           </div>
-          <p className="text-[var(--font-size-body)] text-text-primary">
+          <p className="text-body text-text-primary">
             我覺得這筆消費屬於「
             <span className="font-semibold bg-primary/20 rounded-sm px-1.5 py-0.5">
               {suggestedCategory}
@@ -163,21 +163,21 @@ function NewCategoryDialog({
           <button
             type="button"
             onClick={() => onConfirm(suggestedCategory)}
-            className="h-9 px-lg rounded-sm bg-primary text-surface text-[var(--font-size-body)] font-medium"
+            className="h-9 px-lg rounded-sm bg-primary text-surface text-body font-medium"
           >
             確認
           </button>
           <button
             type="button"
             onClick={() => setMode('rename')}
-            className="h-9 px-lg rounded-sm border border-primary text-primary text-[var(--font-size-body)]"
+            className="h-9 px-lg rounded-sm border border-primary text-primary text-body"
           >
             修改名稱
           </button>
           <button
             type="button"
             onClick={() => setMode('select')}
-            className="h-9 px-lg rounded-sm border border-border text-text-secondary text-[var(--font-size-body)]"
+            className="h-9 px-lg rounded-sm border border-border text-text-secondary text-body"
           >
             選現有
           </button>

--- a/frontend/src/components/ParsedResultCard.tsx
+++ b/frontend/src/components/ParsedResultCard.tsx
@@ -53,13 +53,13 @@ function ParsedResultCard({
       role="region"
       aria-label="AI 解析結果"
     >
-      <h3 className="text-[var(--font-size-body)] font-semibold text-text-primary mb-md">
+      <h3 className="text-body font-semibold text-text-primary mb-md">
         ✨ AI 幫你整理好了
       </h3>
 
       <div className="space-y-sm mb-lg">
         <div className="flex items-center gap-md">
-          <span className="text-[var(--font-size-caption)] text-text-secondary w-[60px] shrink-0">
+          <span className="text-caption text-text-secondary w-[60px] shrink-0">
             金額
           </span>
           {isEditing ? (
@@ -67,27 +67,27 @@ function ParsedResultCard({
               type="number"
               value={amount}
               onChange={(e) => setAmount(e.target.value)}
-              className="flex-1 h-9 rounded-md border border-border px-sm text-[var(--font-size-body)] text-danger font-semibold"
+              className="flex-1 h-9 rounded-md border border-border px-sm text-body text-danger font-semibold"
               min="0.01"
               step="1"
               aria-label="金額"
             />
           ) : (
-            <span className="text-[var(--font-size-body)] text-danger font-semibold">
+            <span className="text-body text-danger font-semibold">
               ${result.amount?.toLocaleString() ?? '--'}
             </span>
           )}
         </div>
 
         <div className="flex items-center gap-md">
-          <span className="text-[var(--font-size-caption)] text-text-secondary w-[60px] shrink-0">
+          <span className="text-caption text-text-secondary w-[60px] shrink-0">
             類別
           </span>
           {isEditing ? (
             <select
               value={category}
               onChange={(e) => setCategory(e.target.value)}
-              className="flex-1 h-9 rounded-md border border-border px-sm text-[var(--font-size-body)]"
+              className="flex-1 h-9 rounded-md border border-border px-sm text-body"
               aria-label="類別"
             >
               {categories.map((cat) => (
@@ -97,14 +97,14 @@ function ParsedResultCard({
               ))}
             </select>
           ) : (
-            <span className="text-[var(--font-size-body)] text-text-primary">
+            <span className="text-body text-text-primary">
               {categoryNames[result.category ?? ''] ?? result.category ?? '--'}
             </span>
           )}
         </div>
 
         <div className="flex items-center gap-md">
-          <span className="text-[var(--font-size-caption)] text-text-secondary w-[60px] shrink-0">
+          <span className="text-caption text-text-secondary w-[60px] shrink-0">
             商家
           </span>
           {isEditing ? (
@@ -112,18 +112,18 @@ function ParsedResultCard({
               type="text"
               value={merchant}
               onChange={(e) => setMerchant(e.target.value)}
-              className="flex-1 h-9 rounded-md border border-border px-sm text-[var(--font-size-body)]"
+              className="flex-1 h-9 rounded-md border border-border px-sm text-body"
               aria-label="商家"
             />
           ) : (
-            <span className="text-[var(--font-size-body)] text-text-primary">
+            <span className="text-body text-text-primary">
               {result.merchant || '--'}
             </span>
           )}
         </div>
 
         <div className="flex items-center gap-md">
-          <span className="text-[var(--font-size-caption)] text-text-secondary w-[60px] shrink-0">
+          <span className="text-caption text-text-secondary w-[60px] shrink-0">
             日期
           </span>
           {isEditing ? (
@@ -131,11 +131,11 @@ function ParsedResultCard({
               type="date"
               value={date}
               onChange={(e) => setDate(e.target.value)}
-              className="flex-1 h-9 rounded-md border border-border px-sm text-[var(--font-size-body)]"
+              className="flex-1 h-9 rounded-md border border-border px-sm text-body"
               aria-label="日期"
             />
           ) : (
-            <span className="text-[var(--font-size-body)] text-text-primary">
+            <span className="text-body text-text-primary">
               {result.date ?? '--'}
             </span>
           )}
@@ -153,14 +153,14 @@ function ParsedResultCard({
               setIsEditing(true)
             }
           }}
-          className="flex-1 h-10 rounded-sm border border-border text-text-secondary text-[var(--font-size-body)] transition-colors duration-[var(--transition-fast)] hover:bg-bg"
+          className="flex-1 h-10 rounded-sm border border-border text-text-secondary text-body transition-colors duration-[var(--transition-fast)] hover:bg-bg"
         >
           {isEditing ? '取消' : '修改'}
         </button>
         <button
           type="button"
           onClick={handleConfirm}
-          className="flex-1 h-10 rounded-sm bg-primary text-surface font-semibold text-[var(--font-size-body)] transition-opacity duration-[var(--transition-fast)] hover:opacity-90"
+          className="flex-1 h-10 rounded-sm bg-primary text-surface font-semibold text-body transition-opacity duration-[var(--transition-fast)] hover:opacity-90"
         >
           ✓ 確認記帳
         </button>

--- a/frontend/src/components/ParsedResultCard.tsx
+++ b/frontend/src/components/ParsedResultCard.tsx
@@ -140,6 +140,17 @@ function ParsedResultCard({
             </span>
           )}
         </div>
+
+        {result.note && (
+          <div className="flex items-start gap-md">
+            <span className="text-caption text-text-secondary w-[60px] shrink-0">
+              備註
+            </span>
+            <span className="text-caption text-text-secondary">
+              {result.note}
+            </span>
+          </div>
+        )}
       </div>
 
       <div className="flex gap-sm">

--- a/frontend/src/components/RecentTransactions.tsx
+++ b/frontend/src/components/RecentTransactions.tsx
@@ -38,12 +38,12 @@ const categoryNames: Record<string, string> = {
 function RecentTransactions({ transactions }: RecentTransactionsProps) {
   return (
     <section className="px-2xl" aria-label="最近帳目">
-      <h2 className="text-[var(--font-size-title)] font-semibold text-text-primary mb-md">
+      <h2 className="text-title font-semibold text-text-primary mb-md">
         🕐 最近帳目
       </h2>
 
       {transactions.length === 0 ? (
-        <p className="text-[var(--font-size-body)] text-text-tertiary text-center py-3xl">
+        <p className="text-body text-text-tertiary text-center py-3xl">
           還沒有記帳紀錄，開始記帳吧！
         </p>
       ) : (
@@ -57,19 +57,19 @@ function RecentTransactions({ transactions }: RecentTransactionsProps) {
                 {categoryIcons[tx.category] ?? '📦'}
               </div>
               <div className="flex-1 min-w-0">
-                <p className="text-[var(--font-size-body)] font-semibold text-text-primary truncate">
+                <p className="text-body font-semibold text-text-primary truncate">
                   {tx.merchant || tx.category}
                 </p>
                 <div className="flex items-center gap-xs">
-                  <span className="text-[var(--font-size-small)] text-text-secondary bg-[#F0F0F0] rounded-sm px-2 py-0.5">
+                  <span className="text-small text-text-secondary bg-[#F0F0F0] rounded-sm px-2 py-0.5">
                     {categoryNames[tx.category] ?? tx.category}
                   </span>
-                  <span className="text-[var(--font-size-small)] text-text-secondary">
+                  <span className="text-small text-text-secondary">
                     · {formatTime(tx.createdAt)}
                   </span>
                 </div>
               </div>
-              <p className="text-[var(--font-size-title)] font-semibold text-danger shrink-0">
+              <p className="text-title font-semibold text-danger shrink-0">
                 -${tx.amount.toLocaleString()}
               </p>
             </div>

--- a/frontend/src/components/VoiceInput.tsx
+++ b/frontend/src/components/VoiceInput.tsx
@@ -91,7 +91,7 @@ function VoiceInput({ onSubmit, disabled = false }: VoiceInputProps) {
       {/* Error message */}
       {showError && errorMessage && (
         <div
-          className="mb-sm px-lg py-sm rounded-md text-[var(--font-size-small)] text-danger bg-danger-light text-center"
+          className="mb-sm px-lg py-sm rounded-md text-small text-danger bg-danger-light text-center"
           role="alert"
         >
           {errorMessage}
@@ -107,7 +107,7 @@ function VoiceInput({ onSubmit, disabled = false }: VoiceInputProps) {
           onKeyDown={handleKeyDown}
           placeholder={getPlaceholder()}
           disabled={disabled || isActive}
-          className={`flex-1 h-[44px] rounded-xl px-lg text-[var(--font-size-body)] border outline-none transition-colors duration-[var(--transition-fast)] ${
+          className={`flex-1 h-[44px] rounded-xl px-lg text-body border outline-none transition-colors duration-[var(--transition-fast)] ${
             isActive
               ? 'bg-primary-light border-primary'
               : 'bg-bg border-border focus:border-primary'

--- a/frontend/src/hooks/useVoiceRecognition.ts
+++ b/frontend/src/hooks/useVoiceRecognition.ts
@@ -61,7 +61,7 @@ export function useVoiceRecognition(
     const recognition = new SpeechRecognitionClass()
     recognition.lang = lang
     recognition.interimResults = true
-    recognition.continuous = false
+    recognition.continuous = true
     recognition.maxAlternatives = 1
 
     recognition.onstart = () => {
@@ -84,17 +84,21 @@ export function useVoiceRecognition(
         }
       }
 
-      if (interim) {
-        setInterimTranscript(interim)
+      // In continuous mode, show combined final + interim as live feedback
+      const liveText = finalTranscript + interim
+      if (liveText) {
+        setInterimTranscript(liveText)
         setStatus('recognizing')
-        callbacksRef.current.onInterimResult?.(interim)
+        callbacksRef.current.onInterimResult?.(liveText)
       }
+    }
 
-      if (finalTranscript) {
-        setTranscript(finalTranscript)
-        setInterimTranscript('')
-        callbacksRef.current.onResult?.(finalTranscript)
-      }
+    // When stop() is called, onend fires — deliver accumulated result
+    recognition.onspeechend = () => {
+      // Collect all final results
+      const recognition_ = recognitionRef.current
+      if (!recognition_) return
+      // The final result will be delivered via onresult before onend
     }
 
     recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
@@ -116,6 +120,14 @@ export function useVoiceRecognition(
   const stopRecording = useCallback(() => {
     if (recognitionRef.current) {
       recognitionRef.current.stop()
+      // Deliver whatever we have as final result
+      setInterimTranscript((current) => {
+        if (current) {
+          setTranscript(current)
+          callbacksRef.current.onResult?.(current)
+        }
+        return ''
+      })
     }
   }, [])
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -43,7 +43,15 @@
   --shadow-input: 0 1px 4px rgba(0, 0, 0, 0.04);
   --shadow-fab: 0 4px 12px rgba(0, 200, 150, 0.30);
 
-  /* Font Sizes */
+  /* Font Sizes (--text-* for Tailwind v4 text-{name} utilities) */
+  --text-display: 36px;
+  --text-headline: 24px;
+  --text-title: 18px;
+  --text-body: 16px;
+  --text-caption: 14px;
+  --text-small: 12px;
+
+  /* Legacy aliases */
   --font-size-display: 36px;
   --font-size-headline: 24px;
   --font-size-title: 18px;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL ?? '/api',
+  baseURL: import.meta.env.VITE_API_BASE_URL ?? '/api/v1',
   timeout: 10000,
   headers: {
     'Content-Type': 'application/json',

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -62,6 +62,7 @@ function DashboardPage() {
       await confirmTransaction({
         ...data,
         rawText: parsedResult?.merchant ?? data.merchant,
+        note: parsedResult?.note,
         feedback: aiFeedback ?? undefined,
       })
       fetchBudgetSummary()
@@ -80,6 +81,7 @@ function DashboardPage() {
             merchant: parsedResult.merchant,
             date: parsedResult.date,
             rawText: parsedResult.merchant,
+            note: parsedResult.note,
             feedback: aiFeedback ?? undefined,
           })
           fetchBudgetSummary()
@@ -106,6 +108,7 @@ function DashboardPage() {
           merchant: parsedResult.merchant,
           date: parsedResult.date,
           rawText: parsedResult.merchant,
+          note: parsedResult.note,
           feedback: aiFeedback ?? undefined,
         })
         fetchBudgetSummary()

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -135,10 +135,10 @@ function DashboardPage() {
               💰
             </div>
             <div>
-              <h1 className="text-[var(--font-size-title)] font-semibold text-text-primary leading-tight">
+              <h1 className="text-title font-semibold text-text-primary leading-tight">
                 Vibe Money Book
               </h1>
-              <p className="text-[var(--font-size-small)] text-text-secondary tracking-[2px]">
+              <p className="text-small text-text-secondary tracking-[2px]">
                 語音記帳教練
               </p>
             </div>
@@ -167,7 +167,7 @@ function DashboardPage() {
         {/* Error toast */}
         {status === 'error' && errorMessage && (
           <div
-            className="mx-2xl mb-md px-lg py-sm rounded-md bg-danger text-surface text-[var(--font-size-body)] text-center"
+            className="mx-2xl mb-md px-lg py-sm rounded-md bg-danger text-surface text-body text-center"
             role="alert"
           >
             {errorMessage}
@@ -211,7 +211,7 @@ function DashboardPage() {
 
         {/* Footer */}
         <div className="text-center py-sm mt-xl">
-          <p className="text-[var(--font-size-small)] text-text-tertiary tracking-[1px]">
+          <p className="text-small text-text-tertiary tracking-[1px]">
             POWERED BY AI · 精準記帳 · 情緒滿分
           </p>
         </div>

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -2,22 +2,22 @@ function HistoryPage() {
   return (
     <div className="p-2xl">
       <header className="h-14 flex items-center justify-between mb-lg">
-        <h1 className="text-[var(--font-size-title)] font-semibold text-text-primary">
+        <h1 className="text-title font-semibold text-text-primary">
           📋 記錄
         </h1>
       </header>
 
       <div className="flex gap-sm mb-xl">
-        <button className="px-lg py-sm bg-bg rounded-xl text-[var(--font-size-caption)] text-text-secondary">
+        <button className="px-lg py-sm bg-bg rounded-xl text-caption text-text-secondary">
           全部類別
         </button>
-        <button className="px-lg py-sm bg-bg rounded-xl text-[var(--font-size-caption)] text-text-secondary">
+        <button className="px-lg py-sm bg-bg rounded-xl text-caption text-text-secondary">
           本月
         </button>
       </div>
 
       <div className="text-center py-3xl">
-        <p className="text-[var(--font-size-body)] text-text-tertiary">
+        <p className="text-body text-text-tertiary">
           還沒有記帳紀錄，開始記帳吧！
         </p>
       </div>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -55,17 +55,17 @@ function LoginPage() {
       <div className="w-16 h-16 bg-primary rounded-lg flex items-center justify-center text-3xl mb-lg">
         💰
       </div>
-      <h1 className="text-[var(--font-size-title)] font-semibold text-text-primary mb-xs">
+      <h1 className="text-title font-semibold text-text-primary mb-xs">
         Vibe Money Book
       </h1>
-      <p className="text-[var(--font-size-small)] text-text-secondary tracking-[2px] mb-3xl">
+      <p className="text-small text-text-secondary tracking-[2px] mb-3xl">
         語音記帳教練
       </p>
 
-      <form onSubmit={handleSubmit} className="w-full max-w-sm" noValidate>
+      <form onSubmit={handleSubmit} className="w-full max-w-[384px]" noValidate>
         {error && (
           <div
-            className="mb-lg p-md rounded-md bg-danger-light text-danger text-[var(--font-size-caption)] text-center"
+            className="mb-lg p-md rounded-md bg-danger-light text-danger text-caption text-center"
             role="alert"
           >
             {error}
@@ -87,7 +87,7 @@ function LoginPage() {
                 })
               }
             }}
-            className={`w-full h-12 rounded-md border bg-surface px-lg text-[var(--font-size-body)] outline-none transition-colors ${
+            className={`w-full h-12 rounded-md border bg-surface px-lg text-body outline-none transition-colors ${
               validationErrors.email
                 ? 'border-danger focus:border-danger'
                 : 'border-border focus:border-primary'
@@ -97,7 +97,7 @@ function LoginPage() {
             autoComplete="email"
           />
           {validationErrors.email && (
-            <p className="mt-xs text-[var(--font-size-small)] text-danger" role="alert">
+            <p className="mt-xs text-small text-danger" role="alert">
               {validationErrors.email}
             </p>
           )}
@@ -118,7 +118,7 @@ function LoginPage() {
                 })
               }
             }}
-            className={`w-full h-12 rounded-md border bg-surface px-lg text-[var(--font-size-body)] outline-none transition-colors ${
+            className={`w-full h-12 rounded-md border bg-surface px-lg text-body outline-none transition-colors ${
               validationErrors.password
                 ? 'border-danger focus:border-danger'
                 : 'border-border focus:border-primary'
@@ -128,7 +128,7 @@ function LoginPage() {
             autoComplete="current-password"
           />
           {validationErrors.password && (
-            <p className="mt-xs text-[var(--font-size-small)] text-danger" role="alert">
+            <p className="mt-xs text-small text-danger" role="alert">
               {validationErrors.password}
             </p>
           )}
@@ -137,12 +137,12 @@ function LoginPage() {
         <button
           type="submit"
           disabled={loading}
-          className="w-full h-12 bg-primary text-surface rounded-md font-semibold text-[var(--font-size-body)] hover:bg-primary-dark transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+          className="w-full h-12 bg-primary text-surface rounded-md font-semibold text-body hover:bg-primary-dark transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
         >
           {loading ? '登入中...' : '登入'}
         </button>
 
-        <p className="text-center mt-xl text-[var(--font-size-caption)]">
+        <p className="text-center mt-xl text-caption">
           <span className="text-text-secondary">還沒有帳號？</span>
           <Link to="/register" className="text-primary underline ml-xs">
             立即註冊

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -75,17 +75,17 @@ function RegisterPage() {
       <div className="w-16 h-16 bg-primary rounded-lg flex items-center justify-center text-3xl mb-lg">
         💰
       </div>
-      <h1 className="text-[var(--font-size-title)] font-semibold text-text-primary mb-xs">
+      <h1 className="text-title font-semibold text-text-primary mb-xs">
         Vibe Money Book
       </h1>
-      <p className="text-[var(--font-size-small)] text-text-secondary tracking-[2px] mb-3xl">
+      <p className="text-small text-text-secondary tracking-[2px] mb-3xl">
         語音記帳教練
       </p>
 
-      <form onSubmit={handleSubmit} className="w-full max-w-sm" noValidate>
+      <form onSubmit={handleSubmit} className="w-full max-w-[384px]" noValidate>
         {error && (
           <div
-            className="mb-lg p-md rounded-md bg-danger-light text-danger text-[var(--font-size-caption)] text-center"
+            className="mb-lg p-md rounded-md bg-danger-light text-danger text-caption text-center"
             role="alert"
           >
             {error}
@@ -101,7 +101,7 @@ function RegisterPage() {
               setName(e.target.value)
               clearFieldError('name')
             }}
-            className={`w-full h-12 rounded-md border bg-surface px-lg text-[var(--font-size-body)] outline-none transition-colors ${
+            className={`w-full h-12 rounded-md border bg-surface px-lg text-body outline-none transition-colors ${
               validationErrors.name
                 ? 'border-danger focus:border-danger'
                 : 'border-border focus:border-primary'
@@ -111,7 +111,7 @@ function RegisterPage() {
             autoComplete="name"
           />
           {validationErrors.name && (
-            <p className="mt-xs text-[var(--font-size-small)] text-danger" role="alert">
+            <p className="mt-xs text-small text-danger" role="alert">
               {validationErrors.name}
             </p>
           )}
@@ -126,7 +126,7 @@ function RegisterPage() {
               setEmail(e.target.value)
               clearFieldError('email')
             }}
-            className={`w-full h-12 rounded-md border bg-surface px-lg text-[var(--font-size-body)] outline-none transition-colors ${
+            className={`w-full h-12 rounded-md border bg-surface px-lg text-body outline-none transition-colors ${
               validationErrors.email
                 ? 'border-danger focus:border-danger'
                 : 'border-border focus:border-primary'
@@ -136,7 +136,7 @@ function RegisterPage() {
             autoComplete="email"
           />
           {validationErrors.email && (
-            <p className="mt-xs text-[var(--font-size-small)] text-danger" role="alert">
+            <p className="mt-xs text-small text-danger" role="alert">
               {validationErrors.email}
             </p>
           )}
@@ -151,7 +151,7 @@ function RegisterPage() {
               setPassword(e.target.value)
               clearFieldError('password')
             }}
-            className={`w-full h-12 rounded-md border bg-surface px-lg text-[var(--font-size-body)] outline-none transition-colors ${
+            className={`w-full h-12 rounded-md border bg-surface px-lg text-body outline-none transition-colors ${
               validationErrors.password
                 ? 'border-danger focus:border-danger'
                 : 'border-border focus:border-primary'
@@ -161,7 +161,7 @@ function RegisterPage() {
             autoComplete="new-password"
           />
           {validationErrors.password && (
-            <p className="mt-xs text-[var(--font-size-small)] text-danger" role="alert">
+            <p className="mt-xs text-small text-danger" role="alert">
               {validationErrors.password}
             </p>
           )}
@@ -176,7 +176,7 @@ function RegisterPage() {
               setConfirmPassword(e.target.value)
               clearFieldError('confirmPassword')
             }}
-            className={`w-full h-12 rounded-md border bg-surface px-lg text-[var(--font-size-body)] outline-none transition-colors ${
+            className={`w-full h-12 rounded-md border bg-surface px-lg text-body outline-none transition-colors ${
               validationErrors.confirmPassword
                 ? 'border-danger focus:border-danger'
                 : 'border-border focus:border-primary'
@@ -186,7 +186,7 @@ function RegisterPage() {
             autoComplete="new-password"
           />
           {validationErrors.confirmPassword && (
-            <p className="mt-xs text-[var(--font-size-small)] text-danger" role="alert">
+            <p className="mt-xs text-small text-danger" role="alert">
               {validationErrors.confirmPassword}
             </p>
           )}
@@ -195,12 +195,12 @@ function RegisterPage() {
         <button
           type="submit"
           disabled={loading}
-          className="w-full h-12 bg-primary text-surface rounded-md font-semibold text-[var(--font-size-body)] hover:bg-primary-dark transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+          className="w-full h-12 bg-primary text-surface rounded-md font-semibold text-body hover:bg-primary-dark transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
         >
           {loading ? '註冊中...' : '註冊'}
         </button>
 
-        <p className="text-center mt-xl text-[var(--font-size-caption)]">
+        <p className="text-center mt-xl text-caption">
           <span className="text-text-secondary">已有帳號？</span>
           <Link to="/login" className="text-primary underline ml-xs">
             返回登入

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -2,7 +2,7 @@ function SettingsPage() {
   return (
     <div className="p-2xl">
       <header className="h-14 flex items-center mb-lg">
-        <h1 className="text-[var(--font-size-title)] font-semibold text-text-primary">
+        <h1 className="text-title font-semibold text-text-primary">
           ⚙️ 設定
         </h1>
       </header>
@@ -13,10 +13,10 @@ function SettingsPage() {
             👤
           </div>
           <div>
-            <p className="text-[var(--font-size-body)] font-semibold text-text-primary">
+            <p className="text-body font-semibold text-text-primary">
               使用者名稱
             </p>
-            <p className="text-[var(--font-size-small)] text-text-secondary">
+            <p className="text-small text-text-secondary">
               user@email.com
             </p>
           </div>
@@ -24,53 +24,53 @@ function SettingsPage() {
       </section>
 
       <section className="bg-surface rounded-lg shadow-card p-lg mb-xl" aria-label="AI 人設選擇">
-        <h2 className="text-[var(--font-size-caption)] text-text-secondary mb-md">
+        <h2 className="text-caption text-text-secondary mb-md">
           AI 人設選擇
         </h2>
         <div className="flex gap-md">
           <div className="w-[100px] h-[100px] bg-surface rounded-lg shadow-card flex flex-col items-center justify-center cursor-pointer">
             <span className="text-2xl">🔥</span>
-            <span className="text-[var(--font-size-caption)] mt-xs">毒舌</span>
+            <span className="text-caption mt-xs">毒舌</span>
           </div>
           <div className="w-[100px] h-[100px] bg-primary-light rounded-lg border-2 border-primary flex flex-col items-center justify-center cursor-pointer">
             <span className="text-2xl">💖</span>
-            <span className="text-[var(--font-size-caption)] mt-xs">溫柔</span>
+            <span className="text-caption mt-xs">溫柔</span>
           </div>
           <div className="w-[100px] h-[100px] bg-surface rounded-lg shadow-card flex flex-col items-center justify-center cursor-pointer">
             <span className="text-2xl">🥺</span>
-            <span className="text-[var(--font-size-caption)] mt-xs">情勒</span>
+            <span className="text-caption mt-xs">情勒</span>
           </div>
         </div>
       </section>
 
       <section className="bg-surface rounded-lg shadow-card p-lg mb-xl" aria-label="月預算設定">
-        <h2 className="text-[var(--font-size-caption)] text-text-secondary mb-md">
+        <h2 className="text-caption text-text-secondary mb-md">
           月預算設定
         </h2>
-        <p className="text-[var(--font-size-body)] text-text-tertiary">
+        <p className="text-body text-text-tertiary">
           尚未設定預算
         </p>
       </section>
 
       <section className="bg-surface rounded-lg shadow-card p-lg mb-xl" aria-label="AI 引擎設定">
-        <h2 className="text-[var(--font-size-caption)] text-text-secondary mb-md">
+        <h2 className="text-caption text-text-secondary mb-md">
           AI 引擎設定
         </h2>
         <div className="flex gap-md">
           <div className="flex-1 h-20 bg-primary-light rounded-lg border-2 border-primary flex flex-col items-center justify-center cursor-pointer">
             <span className="text-lg">✨</span>
-            <span className="text-[var(--font-size-body)] font-semibold">Gemini</span>
-            <span className="text-[var(--font-size-small)] text-text-secondary">(預設)</span>
+            <span className="text-body font-semibold">Gemini</span>
+            <span className="text-small text-text-secondary">(預設)</span>
           </div>
           <div className="flex-1 h-20 bg-surface rounded-lg shadow-card flex flex-col items-center justify-center cursor-pointer">
             <span className="text-lg">🤖</span>
-            <span className="text-[var(--font-size-body)] font-semibold">OpenAI</span>
-            <span className="text-[var(--font-size-small)] text-text-secondary">(GPT-4o-mini)</span>
+            <span className="text-body font-semibold">OpenAI</span>
+            <span className="text-small text-text-secondary">(GPT-4o-mini)</span>
           </div>
         </div>
       </section>
 
-      <button className="w-full h-12 bg-surface rounded-md text-danger font-semibold text-[var(--font-size-body)] shadow-card">
+      <button className="w-full h-12 bg-surface rounded-md text-danger font-semibold text-body shadow-card">
         登出
       </button>
     </div>

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -2,7 +2,7 @@ function StatsPage() {
   return (
     <div className="p-2xl">
       <header className="h-14 flex items-center mb-lg">
-        <h1 className="text-[var(--font-size-title)] font-semibold text-text-primary">
+        <h1 className="text-title font-semibold text-text-primary">
           📊 統計
         </h1>
       </header>
@@ -11,17 +11,17 @@ function StatsPage() {
         className="bg-surface rounded-lg shadow-card p-lg mb-xl"
         aria-label="本月總支出"
       >
-        <p className="text-[var(--font-size-caption)] text-text-secondary mb-xs">
+        <p className="text-caption text-text-secondary mb-xs">
           本月總支出
         </p>
-        <p className="text-[var(--font-size-headline)] font-bold text-danger">
+        <p className="text-headline font-bold text-danger">
           $0
         </p>
       </section>
 
       <section aria-label="消費分佈" className="text-center py-3xl">
         <div className="w-[200px] h-[200px] mx-auto border-2 border-dashed border-text-tertiary rounded-full flex items-center justify-center mb-lg">
-          <p className="text-[var(--font-size-body)] text-text-tertiary">
+          <p className="text-body text-text-tertiary">
             本月尚無消費記錄
           </p>
         </div>

--- a/frontend/src/stores/dashboardStore.ts
+++ b/frontend/src/stores/dashboardStore.ts
@@ -10,6 +10,7 @@ export interface ParsedResult {
   confidence: number
   isNewCategory: boolean
   suggestedCategory: string | null
+  note: string | null
 }
 
 export interface AIFeedbackContent {
@@ -62,6 +63,7 @@ interface DashboardState {
     merchant: string
     date: string
     rawText: string
+    note?: string | null
     feedback?: AIFeedbackContent
   }) => Promise<void>
   createCategory: (category: string) => Promise<void>
@@ -102,6 +104,7 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
           confidence: parsed.confidence,
           isNewCategory: parsed.is_new_category ?? false,
           suggestedCategory: parsed.suggested_category ?? null,
+          note: parsed.note ?? null,
         },
         aiFeedback: feedback
           ? { text: feedback.text, emotionTag: feedback.emotion_tag }
@@ -135,6 +138,7 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
         merchant: data.merchant,
         raw_text: data.rawText,
         transaction_date: data.date,
+        note: data.note ?? undefined,
         feedback: data.feedback
           ? {
               text: data.feedback.text,

--- a/frontend/src/test/dashboardComponents.test.tsx
+++ b/frontend/src/test/dashboardComponents.test.tsx
@@ -127,6 +127,7 @@ describe('ParsedResultCard', () => {
     confidence: 0.95,
     isNewCategory: false,
     suggestedCategory: null,
+    note: null,
   }
   const categories = ['food', 'transport', 'entertainment', 'other']
 
@@ -186,6 +187,7 @@ describe('ParsedResultCard', () => {
 describe('NewCategoryDialog', () => {
   const defaultProps = {
     suggestedCategory: '寵物',
+    note: null,
     persona: 'gentle' as const,
     existingCategories: ['food', 'transport', 'other'],
     onConfirm: vi.fn(),

--- a/frontend/src/test/dashboardStore.test.ts
+++ b/frontend/src/test/dashboardStore.test.ts
@@ -35,6 +35,7 @@ describe('dashboardStore', () => {
           confidence: 0.9,
           isNewCategory: false,
           suggestedCategory: null,
+    note: null,
         },
         errorMessage: 'some error',
       })
@@ -66,6 +67,7 @@ describe('dashboardStore', () => {
           confidence: 0.95,
           isNewCategory: false,
           suggestedCategory: null,
+    note: null,
         },
         aiFeedback: {
           text: '享受美味',
@@ -91,6 +93,7 @@ describe('dashboardStore', () => {
           confidence: 0.9,
           isNewCategory: true,
           suggestedCategory: '寵物',
+    note: null,
         },
       })
 

--- a/frontend/src/test/useVoiceRecognition.test.ts
+++ b/frontend/src/test/useVoiceRecognition.test.ts
@@ -142,6 +142,13 @@ describe('useVoiceRecognition', () => {
       } as unknown)
     })
 
+    // In continuous mode, results are accumulated as interim until stopRecording
+    expect(result.current.interimTranscript).toBe('午餐吃拉麵 180 元')
+
+    act(() => {
+      result.current.stopRecording()
+    })
+
     expect(result.current.transcript).toBe('午餐吃拉麵 180 元')
     expect(onResult).toHaveBeenCalledWith('午餐吃拉麵 180 元')
   })

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,17 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import basicSsl from '@vitejs/plugin-basic-ssl'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), basicSsl()],
+  server: {
+    host: true,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary

M2 驗證（#25, #26, #27）過程中發現並修復多項問題，同時新增 AI 自動備註功能。

- Tailwind CSS v4 命名衝突導致全站版面崩潰（`max-w-sm` = 8px）
- 前後端 API 連接缺失（無 Vite proxy、baseURL 不匹配）
- Gemini LLM 回傳格式異常與 timeout 問題
- Budget API 端點缺失導致新類別流程失敗
- 語音錄製 continuous 模式與 UI 修復
- 新增 AI 自動產生備註欄位（note）

## 修改總結

### 1. Tailwind CSS v4 相容性修復（13 個檔案, 95 處）
- `@theme` 中 `--spacing-sm/lg` 與 `max-w-sm/lg` 命名衝突，`max-w-sm` 被解析為 8px
- `text-[var(--font-size-*)]` 被解析為 `color` 而非 `font-size`
- **修復**：新增 `--text-*` tokens，全域替換為 `text-body/caption/title/...`；`max-w-sm` → `max-w-[384px]`

### 2. 前後端 API 連接
- Vite 無 proxy，API 請求無法轉發至 localhost:3000
- `api.ts` baseURL `/api` 與後端 `/api/v1` 不匹配
- **修復**：`vite.config.ts` 新增 proxy + `host: true` + HTTPS（basic-ssl）；baseURL 改為 `/api/v1`

### 3. Gemini LLM 穩定性
- Gemini 2.5 Flash thinking model 回傳含 markdown/thinking tags 的 JSON，解析失敗
- Feedback 回傳被 maxTokens 截斷
- 10s timeout 對 thinking model 太短
- **修復**：`responseMimeType: 'application/json'`；`thinkingBudget: 0` 關閉思考；timeout 30s；`parseJSON` 容錯加強

### 4. Budget API
- `POST /budget/categories` 和 `GET /budget/summary` 端點不存在
- **修復**：新增 `budgetRoutes.ts`（類別 CRUD + 月預算摘要）

### 5. 新類別偵測 Prompt
- Gemini 將所有未匹配消費歸入 `other`，不觸發 `is_new_category`
- **修復**：Prompt 明確指示 `other` 僅用於雜項，有主題的消費應建議新類別

### 6. UI 修復
- NewCategoryDialog 底部按鈕被導覽列遮擋 → 新增 `pb-[120px]`
- 語音 `continuous = false` 導致短暫停頓即結束 → 改為 `continuous = true`

### 7. AI 自動備註欄位（note）
- Prompt 新增 `note` 欄位，AI 自動將地點、商品細節等上下文資訊整理為備註
- 前端解析結果卡片顯示備註，儲存時帶入後端

## 影響範圍
- `frontend/` — 17 個檔案
- `backend/` — 7 個檔案（含 1 個新增）
- 全部測試通過（前端 75/75、後端 68/68）

## Test plan
- [x] 前端 `npm run test` 75 tests passed
- [x] 後端 `npm run test` 68 tests passed
- [x] Playwright Firefox 驗證麥克風按鈕隱藏
- [x] 手動驗證登入/註冊頁面版面
- [x] 手動驗證語音辨識 + 記帳流程
- [x] 手動驗證新類別偵測對話框

Closes #25, Closes #26, Closes #27