### PR TITLE
feat(frontend): T-206 帳目明細展開與管理（檢視/修改/刪除）

### DIFF
--- a/backend/src/controllers/aiController.test.ts
+++ b/backend/src/controllers/aiController.test.ts
@@ -263,12 +263,6 @@ describe('POST /api/v1/ai/parse', () => {
 
   // --- 案例 11: LLM API Key 無效 ---
   it('應在 LLM API Key 無效時回傳 403', async () => {
-    mockExtractData.mockRejectedValue(
-      Object.assign(new Error('Gemini API Key 無效，請確認您的 API Key'), {
-        statusCode: 403,
-      })
-    );
-    // Re-mock to throw AppError
     const { AppError } = await import('../middlewares/errorHandler');
     mockExtractData.mockRejectedValue(new AppError('Gemini API Key 無效，請確認您的 API Key', 403));
 

--- a/backend/src/controllers/transactionController.ts
+++ b/backend/src/controllers/transactionController.ts
@@ -87,6 +87,28 @@ export async function getTransaction(
   }
 }
 
+export async function updateTransaction(
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const id = req.params.id as string;
+    const result = await transactionService.updateTransaction(req.userId!, id, req.body);
+
+    const response: ApiResponse<typeof result> = {
+      code: 200,
+      message: '交易更新成功',
+      data: result,
+      timestamp: new Date().toISOString(),
+    };
+
+    res.status(200).json(response);
+  } catch (err) {
+    next(err);
+  }
+}
+
 export async function deleteTransaction(
   req: AuthRequest,
   res: Response,

--- a/backend/src/routes/transactionRoutes.ts
+++ b/backend/src/routes/transactionRoutes.ts
@@ -4,6 +4,7 @@ import {
   createTransaction,
   listTransactions,
   getTransaction,
+  updateTransaction,
   deleteTransaction,
 } from '../controllers/transactionController';
 
@@ -12,6 +13,7 @@ const router = Router();
 router.post('/', authMiddleware, createTransaction);
 router.get('/', authMiddleware, listTransactions);
 router.get('/:id', authMiddleware, getTransaction);
+router.put('/:id', authMiddleware, updateTransaction);
 router.delete('/:id', authMiddleware, deleteTransaction);
 
 export default router;

--- a/backend/src/services/transactionService.ts
+++ b/backend/src/services/transactionService.ts
@@ -101,6 +101,31 @@ export async function getTransaction(userId: string, id: string) {
   return formatTransactionDetail(transaction);
 }
 
+export async function updateTransaction(
+  userId: string,
+  id: string,
+  input: { amount?: number; category?: string; merchant?: string; transaction_date?: string; note?: string }
+) {
+  const transaction = await prisma.transaction.findUnique({ where: { id } });
+  if (!transaction) throw new AppError('交易記錄不存在', 404);
+  if (transaction.userId !== userId) throw new AppError('交易記錄不存在', 404);
+
+  const data: Record<string, unknown> = {};
+  if (input.amount !== undefined) data.amount = input.amount;
+  if (input.category !== undefined) data.category = input.category;
+  if (input.merchant !== undefined) data.merchant = input.merchant;
+  if (input.transaction_date !== undefined) data.transactionDate = new Date(input.transaction_date);
+  if (input.note !== undefined) data.note = input.note;
+
+  const updated = await prisma.transaction.update({
+    where: { id },
+    data,
+    include: { aiFeedback: true },
+  });
+
+  return formatTransaction(updated);
+}
+
 export async function deleteTransaction(userId: string, id: string) {
   const transaction = await prisma.transaction.findUnique({
     where: { id },
@@ -166,6 +191,7 @@ function formatTransactionListItem(t: {
   amount: unknown;
   category: string;
   merchant: string | null;
+  note: string | null;
   transactionDate: Date;
   createdAt: Date;
 }) {
@@ -174,6 +200,7 @@ function formatTransactionListItem(t: {
     amount: Number(t.amount),
     category: t.category,
     merchant: t.merchant,
+    note: t.note,
     transaction_date: t.transactionDate.toISOString().split('T')[0],
     created_at: t.createdAt.toISOString(),
   };

--- a/frontend/src/components/RecentTransactions.tsx
+++ b/frontend/src/components/RecentTransactions.tsx
@@ -1,4 +1,6 @@
+import { useState, useCallback } from 'react'
 import type { Transaction } from '../stores/index'
+import { useDashboardStore } from '../stores/dashboardStore'
 
 interface RecentTransactionsProps {
   transactions: Transaction[]
@@ -15,15 +17,6 @@ const categoryIcons: Record<string, string> = {
   other: '📦',
 }
 
-function formatTime(dateStr: string): string {
-  const date = new Date(dateStr)
-  const hours = date.getHours()
-  const minutes = date.getMinutes().toString().padStart(2, '0')
-  const period = hours < 12 ? '上午' : '下午'
-  const displayHour = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours
-  return `${period}${displayHour.toString().padStart(2, '0')}:${minutes}`
-}
-
 const categoryNames: Record<string, string> = {
   food: '飲食',
   transport: '交通',
@@ -35,7 +28,77 @@ const categoryNames: Record<string, string> = {
   other: '其他',
 }
 
+function formatTime(dateStr: string): string {
+  const date = new Date(dateStr)
+  const hours = date.getHours()
+  const minutes = date.getMinutes().toString().padStart(2, '0')
+  const period = hours < 12 ? '上午' : '下午'
+  const displayHour = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours
+  return `${period}${displayHour.toString().padStart(2, '0')}:${minutes}`
+}
+
+function formatDate(dateStr: string): string {
+  if (!dateStr) return '--'
+  // Handle both ISO and YYYY-MM-DD
+  return dateStr.split('T')[0]
+}
+
 function RecentTransactions({ transactions }: RecentTransactionsProps) {
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null)
+  const [editForm, setEditForm] = useState({ amount: '', category: '', merchant: '', date: '', note: '' })
+
+  const updateTransaction = useDashboardStore((s) => s.updateTransaction)
+  const deleteTransaction = useDashboardStore((s) => s.deleteTransaction)
+  const fetchBudgetSummary = useDashboardStore((s) => s.fetchBudgetSummary)
+
+  const handleToggle = useCallback((id: string) => {
+    setExpandedId((prev) => (prev === id ? null : id))
+    setEditingId(null)
+    setDeleteConfirmId(null)
+  }, [])
+
+  const handleStartEdit = useCallback((tx: Transaction) => {
+    setEditingId(tx.id)
+    setEditForm({
+      amount: tx.amount.toString(),
+      category: tx.category,
+      merchant: tx.merchant || '',
+      date: formatDate(tx.transactionDate),
+      note: tx.note || '',
+    })
+  }, [])
+
+  const handleSaveEdit = useCallback(async (id: string) => {
+    const parsedAmount = parseFloat(editForm.amount)
+    if (isNaN(parsedAmount) || parsedAmount <= 0) return
+    try {
+      await updateTransaction(id, {
+        amount: parsedAmount,
+        category: editForm.category,
+        merchant: editForm.merchant,
+        date: editForm.date,
+        note: editForm.note || undefined,
+      })
+      fetchBudgetSummary()
+      setEditingId(null)
+    } catch {
+      // Error handled by store
+    }
+  }, [editForm, updateTransaction, fetchBudgetSummary])
+
+  const handleDelete = useCallback(async (id: string) => {
+    try {
+      await deleteTransaction(id)
+      fetchBudgetSummary()
+      setExpandedId(null)
+      setDeleteConfirmId(null)
+    } catch {
+      // Error handled by store
+    }
+  }, [deleteTransaction, fetchBudgetSummary])
+
   return (
     <section className="px-2xl" aria-label="最近帳目">
       <h2 className="text-title font-semibold text-text-primary mb-md">
@@ -48,32 +111,198 @@ function RecentTransactions({ transactions }: RecentTransactionsProps) {
         </p>
       ) : (
         <div>
-          {transactions.map((tx) => (
-            <div
-              key={tx.id}
-              className="flex items-center gap-md py-md border-b border-border last:border-b-0"
-            >
-              <div className="w-10 h-10 rounded-md bg-danger-light flex items-center justify-center text-lg shrink-0">
-                {categoryIcons[tx.category] ?? '📦'}
-              </div>
-              <div className="flex-1 min-w-0">
-                <p className="text-body font-semibold text-text-primary truncate">
-                  {tx.merchant || tx.category}
-                </p>
-                <div className="flex items-center gap-xs">
-                  <span className="text-small text-text-secondary bg-[#F0F0F0] rounded-sm px-2 py-0.5">
-                    {categoryNames[tx.category] ?? tx.category}
+          {transactions.map((tx) => {
+            const isExpanded = expandedId === tx.id
+            const isEditing = editingId === tx.id
+            const isDeleting = deleteConfirmId === tx.id
+
+            return (
+              <div key={tx.id} className="border-b border-border last:border-b-0">
+                {/* Summary row */}
+                <button
+                  type="button"
+                  onClick={() => handleToggle(tx.id)}
+                  className="w-full flex items-center gap-md py-md hover:bg-bg transition-colors"
+                >
+                  <div className="w-10 h-10 rounded-md bg-danger-light flex items-center justify-center text-lg shrink-0">
+                    {categoryIcons[tx.category] ?? '📦'}
+                  </div>
+                  <div className="flex-1 min-w-0 text-left">
+                    <p className="text-body font-semibold text-text-primary truncate">
+                      {tx.merchant || tx.category}
+                    </p>
+                    <div className="flex items-center gap-xs">
+                      <span className="text-small text-text-secondary bg-[#F0F0F0] rounded-sm px-2 py-0.5">
+                        {categoryNames[tx.category] ?? tx.category}
+                      </span>
+                      <span className="text-small text-text-secondary">
+                        · {formatTime(tx.createdAt)}
+                      </span>
+                    </div>
+                  </div>
+                  <p className="text-title font-semibold text-danger shrink-0">
+                    -${tx.amount.toLocaleString()}
+                  </p>
+                  <span className={`text-text-tertiary text-sm transition-transform ${isExpanded ? 'rotate-180' : ''}`}>
+                    ▼
                   </span>
-                  <span className="text-small text-text-secondary">
-                    · {formatTime(tx.createdAt)}
-                  </span>
-                </div>
+                </button>
+
+                {/* Expanded detail */}
+                {isExpanded && (
+                  <div className="pb-md pl-14 pr-md animate-slide-down">
+                    {isDeleting ? (
+                      /* Delete confirmation */
+                      <div className="bg-danger-light rounded-md p-lg text-center">
+                        <p className="text-body text-danger font-semibold mb-md">
+                          確定要刪除這筆帳目嗎？
+                        </p>
+                        <p className="text-caption text-text-secondary mb-lg">
+                          {tx.merchant} -${tx.amount.toLocaleString()}
+                        </p>
+                        <div className="flex gap-sm">
+                          <button
+                            type="button"
+                            onClick={() => setDeleteConfirmId(null)}
+                            className="flex-1 h-9 rounded-sm border border-border text-text-secondary text-body"
+                          >
+                            取消
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleDelete(tx.id)}
+                            className="flex-1 h-9 rounded-sm bg-danger text-surface font-semibold text-body"
+                          >
+                            確認刪除
+                          </button>
+                        </div>
+                      </div>
+                    ) : isEditing ? (
+                      /* Edit mode */
+                      <div className="space-y-sm">
+                        <div className="flex items-center gap-md">
+                          <span className="text-caption text-text-secondary w-[50px] shrink-0">金額</span>
+                          <input
+                            type="number"
+                            value={editForm.amount}
+                            onChange={(e) => setEditForm((f) => ({ ...f, amount: e.target.value }))}
+                            className="flex-1 h-9 rounded-md border border-border px-sm text-body text-danger font-semibold"
+                            min="0.01"
+                            step="1"
+                          />
+                        </div>
+                        <div className="flex items-center gap-md">
+                          <span className="text-caption text-text-secondary w-[50px] shrink-0">類別</span>
+                          <input
+                            type="text"
+                            value={editForm.category}
+                            onChange={(e) => setEditForm((f) => ({ ...f, category: e.target.value }))}
+                            className="flex-1 h-9 rounded-md border border-border px-sm text-body"
+                          />
+                        </div>
+                        <div className="flex items-center gap-md">
+                          <span className="text-caption text-text-secondary w-[50px] shrink-0">商家</span>
+                          <input
+                            type="text"
+                            value={editForm.merchant}
+                            onChange={(e) => setEditForm((f) => ({ ...f, merchant: e.target.value }))}
+                            className="flex-1 h-9 rounded-md border border-border px-sm text-body"
+                          />
+                        </div>
+                        <div className="flex items-center gap-md">
+                          <span className="text-caption text-text-secondary w-[50px] shrink-0">日期</span>
+                          <input
+                            type="date"
+                            value={editForm.date}
+                            onChange={(e) => setEditForm((f) => ({ ...f, date: e.target.value }))}
+                            className="flex-1 h-9 rounded-md border border-border px-sm text-body"
+                          />
+                        </div>
+                        <div className="flex items-center gap-md">
+                          <span className="text-caption text-text-secondary w-[50px] shrink-0">備註</span>
+                          <input
+                            type="text"
+                            value={editForm.note}
+                            onChange={(e) => setEditForm((f) => ({ ...f, note: e.target.value }))}
+                            className="flex-1 h-9 rounded-md border border-border px-sm text-body"
+                          />
+                        </div>
+                        <div className="flex gap-sm mt-md">
+                          <button
+                            type="button"
+                            onClick={() => setEditingId(null)}
+                            className="flex-1 h-9 rounded-sm border border-border text-text-secondary text-body"
+                          >
+                            取消
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleSaveEdit(tx.id)}
+                            className="flex-1 h-9 rounded-sm bg-primary text-surface font-semibold text-body"
+                          >
+                            儲存
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      /* View mode */
+                      <>
+                        <div className="space-y-sm mb-lg">
+                          <div className="flex items-center gap-md">
+                            <span className="text-caption text-text-secondary w-[50px] shrink-0">金額</span>
+                            <span className="text-body text-danger font-semibold">${tx.amount.toLocaleString()}</span>
+                          </div>
+                          <div className="flex items-center gap-md">
+                            <span className="text-caption text-text-secondary w-[50px] shrink-0">類別</span>
+                            <span className="text-body text-text-primary">
+                              {categoryIcons[tx.category] ?? '📦'} {categoryNames[tx.category] ?? tx.category}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-md">
+                            <span className="text-caption text-text-secondary w-[50px] shrink-0">商家</span>
+                            <span className="text-body text-text-primary">{tx.merchant || '--'}</span>
+                          </div>
+                          <div className="flex items-center gap-md">
+                            <span className="text-caption text-text-secondary w-[50px] shrink-0">日期</span>
+                            <span className="text-body text-text-primary">{formatDate(tx.transactionDate)}</span>
+                          </div>
+                          {tx.note && (
+                            <div className="flex items-start gap-md">
+                              <span className="text-caption text-text-secondary w-[50px] shrink-0">備註</span>
+                              <span className="text-caption text-text-secondary">{tx.note}</span>
+                            </div>
+                          )}
+                        </div>
+                        <div className="flex gap-sm">
+                          <button
+                            type="button"
+                            onClick={() => handleToggle(tx.id)}
+                            className="flex-1 h-9 rounded-sm border border-border text-text-secondary text-body"
+                          >
+                            確認
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleStartEdit(tx)}
+                            className="flex-1 h-9 rounded-sm border border-primary text-primary text-body"
+                          >
+                            修改
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setDeleteConfirmId(tx.id)}
+                            className="flex-1 h-9 rounded-sm border border-danger text-danger text-body"
+                          >
+                            刪除
+                          </button>
+                        </div>
+                      </>
+                    )}
+                  </div>
+                )}
               </div>
-              <p className="text-title font-semibold text-danger shrink-0">
-                -${tx.amount.toLocaleString()}
-              </p>
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
     </section>

--- a/frontend/src/components/RecentTransactions.tsx
+++ b/frontend/src/components/RecentTransactions.tsx
@@ -4,6 +4,7 @@ import { useDashboardStore } from '../stores/dashboardStore'
 
 interface RecentTransactionsProps {
   transactions: Transaction[]
+  categories?: string[]
 }
 
 const categoryIcons: Record<string, string> = {
@@ -43,7 +44,9 @@ function formatDate(dateStr: string): string {
   return dateStr.split('T')[0]
 }
 
-function RecentTransactions({ transactions }: RecentTransactionsProps) {
+const defaultCategories = ['food', 'transport', 'entertainment', 'shopping', 'daily', 'medical', 'education', 'other']
+
+function RecentTransactions({ transactions, categories = defaultCategories }: RecentTransactionsProps) {
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null)
@@ -193,12 +196,23 @@ function RecentTransactions({ transactions }: RecentTransactionsProps) {
                         </div>
                         <div className="flex items-center gap-md">
                           <span className="text-caption text-text-secondary w-[50px] shrink-0">類別</span>
-                          <input
-                            type="text"
+                          <select
                             value={editForm.category}
                             onChange={(e) => setEditForm((f) => ({ ...f, category: e.target.value }))}
                             className="flex-1 h-9 rounded-md border border-border px-sm text-body"
-                          />
+                          >
+                            {categories.map((cat) => (
+                              <option key={cat} value={cat}>
+                                {categoryIcons[cat] ?? '📦'} {categoryNames[cat] ?? cat}
+                              </option>
+                            ))}
+                            {/* 若目前類別不在列表中，也顯示 */}
+                            {!categories.includes(editForm.category) && (
+                              <option value={editForm.category}>
+                                📦 {editForm.category}
+                              </option>
+                            )}
+                          </select>
                         </div>
                         <div className="flex items-center gap-md">
                           <span className="text-caption text-text-secondary w-[50px] shrink-0">商家</span>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -140,6 +140,24 @@ body {
   animation: slide-up 300ms ease-out;
 }
 
+/* ===== Slide-down Animation (accordion) ===== */
+
+@keyframes slide-down {
+  from {
+    opacity: 0;
+    max-height: 0;
+  }
+  to {
+    opacity: 1;
+    max-height: 500px;
+  }
+}
+
+.animate-slide-down {
+  animation: slide-down 200ms ease-out;
+  overflow: hidden;
+}
+
 /* Respect reduced motion preferences */
 @media (prefers-reduced-motion: reduce) {
   *,

--- a/frontend/src/stores/dashboardStore.ts
+++ b/frontend/src/stores/dashboardStore.ts
@@ -67,6 +67,8 @@ interface DashboardState {
     feedback?: AIFeedbackContent
   }) => Promise<void>
   createCategory: (category: string) => Promise<void>
+  updateTransaction: (id: string, data: { amount: number; category: string; merchant: string; date: string; note?: string }) => Promise<void>
+  deleteTransaction: (id: string) => Promise<void>
   fetchBudgetSummary: () => Promise<void>
   fetchRecentTransactions: () => Promise<void>
   resetParsedResult: () => void
@@ -222,6 +224,7 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
             category: t.category as string,
             merchant: t.merchant as string,
             rawText: '',
+            note: (t.note as string) ?? undefined,
             transactionDate: t.transaction_date as string,
             createdAt: t.created_at as string,
           }) satisfies Transaction
@@ -229,6 +232,46 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
       set({ recentTransactions: items })
     } catch {
       // Silently fail
+    }
+  },
+
+  updateTransaction: async (id: string, data) => {
+    try {
+      await api.put(`/transactions/${id}`, {
+        amount: data.amount,
+        category: data.category,
+        merchant: data.merchant,
+        transaction_date: data.date,
+        note: data.note ?? undefined,
+      })
+      set((state) => ({
+        recentTransactions: state.recentTransactions.map((tx) =>
+          tx.id === id
+            ? { ...tx, amount: data.amount, category: data.category, merchant: data.merchant, transactionDate: data.date, note: data.note }
+            : tx
+        ),
+      }))
+    } catch (err: unknown) {
+      const message =
+        (err as { response?: { data?: { message?: string } } })?.response?.data
+          ?.message ?? '更新失敗，請稍後重試'
+      set({ status: 'error', errorMessage: message })
+      throw err
+    }
+  },
+
+  deleteTransaction: async (id: string) => {
+    try {
+      await api.delete(`/transactions/${id}`)
+      set((state) => ({
+        recentTransactions: state.recentTransactions.filter((tx) => tx.id !== id),
+      }))
+    } catch (err: unknown) {
+      const message =
+        (err as { response?: { data?: { message?: string } } })?.response?.data
+          ?.message ?? '刪除失敗，請稍後重試'
+      set({ status: 'error', errorMessage: message })
+      throw err
     }
   },
 


### PR DESCRIPTION
## 變更摘要
實作帳目明細展開功能：點擊「最近帳目」列表項目可展開顯示完整明細（金額、類別、商家、日期、備註），並提供確認/修改/刪除操作。

## 關聯 Issue
Closes #46

## 變更清單
### 前端
- `RecentTransactions.tsx` — 重寫為手風琴列表，支援展開/收合（同時只展開一筆）
  - 檢視模式：顯示金額、類別（含圖示）、商家、日期、備註
  - 編輯模式：可修改各欄位並儲存（`PUT /transactions/:id`）
  - 刪除：二次確認對話框，刪除後列表即時更新
- `dashboardStore.ts` — 新增 `updateTransaction`、`deleteTransaction` actions；`fetchRecentTransactions` 加入 `note` 欄位映射
- `index.css` — 新增 `animate-slide-down` 展開動畫

### 後端
- `transactionRoutes.ts` — 新增 `PUT /:id` 路由
- `transactionController.ts` — 新增 `updateTransaction` handler
- `transactionService.ts` — 新增 `updateTransaction` 函數；列表 API 加入 `note` 欄位
- `aiController.test.ts` — 修正既有 mock 設定問題（API Key 403 測試）

## 測試結果
- 前端測試：✅ 全部通過（75/75）
- 後端測試：✅ 全部通過（68/68）
- 本地驗證：✅ Vibe Check 通過