### PR TITLE
feat(backend): T-301 預算與統計 API（含類別 CRUD）

### DIFF
--- a/backend/src/routes/budgetRoutes.test.ts
+++ b/backend/src/routes/budgetRoutes.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import app from '../app';
+
+// Mock prisma
+vi.mock('../config/database', () => {
+  return {
+    default: {
+      user: {
+        findUnique: vi.fn(),
+      },
+      categoryBudget: {
+        findUnique: vi.fn(),
+        findMany: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        count: vi.fn(),
+      },
+      transaction: {
+        findMany: vi.fn(),
+        updateMany: vi.fn(),
+      },
+    },
+  };
+});
+
+// Mock auth middleware
+vi.mock('../middlewares/auth', () => ({
+  authMiddleware: (req: any, _res: any, next: any) => {
+    req.userId = 'test-user-id';
+    next();
+  },
+  AuthRequest: {},
+}));
+
+import prisma from '../config/database';
+
+const mockedPrisma = vi.mocked(prisma);
+
+describe('Budget Routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ==========================================
+  // POST /budget/categories
+  // ==========================================
+  describe('POST /api/v1/budget/categories', () => {
+    it('should create a new category', async () => {
+      mockedPrisma.categoryBudget.count.mockResolvedValue(5);
+      mockedPrisma.categoryBudget.findUnique.mockResolvedValue(null);
+      mockedPrisma.categoryBudget.create.mockResolvedValue({
+        id: 'cat-1',
+        userId: 'test-user-id',
+        category: 'food',
+        budgetLimit: 0 as any,
+        isCustom: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const res = await request(app)
+        .post('/api/v1/budget/categories')
+        .send({ category: 'food' });
+
+      expect(res.status).toBe(201);
+      expect(res.body.data.category).toBe('food');
+    });
+
+    it('should create a category with budget_limit', async () => {
+      mockedPrisma.categoryBudget.count.mockResolvedValue(5);
+      mockedPrisma.categoryBudget.findUnique.mockResolvedValue(null);
+      mockedPrisma.categoryBudget.create.mockResolvedValue({
+        id: 'cat-2',
+        userId: 'test-user-id',
+        category: 'transport',
+        budgetLimit: 5000 as any,
+        isCustom: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const res = await request(app)
+        .post('/api/v1/budget/categories')
+        .send({ category: 'transport', budget_limit: 5000 });
+
+      expect(res.status).toBe(201);
+      expect(res.body.data.budget_limit).toBe(5000);
+    });
+
+    it('should reject duplicate category name', async () => {
+      mockedPrisma.categoryBudget.count.mockResolvedValue(5);
+      mockedPrisma.categoryBudget.findUnique.mockResolvedValue({
+        id: 'cat-1',
+        userId: 'test-user-id',
+        category: 'food',
+        budgetLimit: 0 as any,
+        isCustom: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const res = await request(app)
+        .post('/api/v1/budget/categories')
+        .send({ category: 'food' });
+
+      expect(res.status).toBe(409);
+      expect(res.body.message).toContain('已存在');
+    });
+
+    it('should reject when category limit of 20 reached', async () => {
+      mockedPrisma.categoryBudget.count.mockResolvedValue(20);
+
+      const res = await request(app)
+        .post('/api/v1/budget/categories')
+        .send({ category: 'newcat' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.message).toContain('上限');
+    });
+
+    it('should reject empty category name', async () => {
+      const res = await request(app)
+        .post('/api/v1/budget/categories')
+        .send({ category: '' });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ==========================================
+  // PUT /budget/categories
+  // ==========================================
+  describe('PUT /api/v1/budget/categories', () => {
+    it('should batch update category budget limits', async () => {
+      mockedPrisma.categoryBudget.findUnique.mockResolvedValue({
+        id: 'cat-1',
+        userId: 'test-user-id',
+        category: 'food',
+        budgetLimit: 0 as any,
+        isCustom: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      mockedPrisma.categoryBudget.update.mockResolvedValue({
+        id: 'cat-1',
+        userId: 'test-user-id',
+        category: 'food',
+        budgetLimit: 8000 as any,
+        isCustom: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const res = await request(app)
+        .put('/api/v1/budget/categories')
+        .send({
+          categories: [{ category: 'food', budget_limit: 8000 }],
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data[0].category).toBe('food');
+      expect(res.body.data[0].budget_limit).toBe(8000);
+    });
+
+    it('should reject when category does not exist', async () => {
+      mockedPrisma.categoryBudget.findUnique.mockResolvedValue(null);
+
+      const res = await request(app)
+        .put('/api/v1/budget/categories')
+        .send({
+          categories: [{ category: 'nonexistent', budget_limit: 1000 }],
+        });
+
+      expect(res.status).toBe(404);
+    });
+
+    it('should reject empty categories array', async () => {
+      const res = await request(app)
+        .put('/api/v1/budget/categories')
+        .send({ categories: [] });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('should reject negative budget_limit', async () => {
+      const res = await request(app)
+        .put('/api/v1/budget/categories')
+        .send({
+          categories: [{ category: 'food', budget_limit: -100 }],
+        });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ==========================================
+  // DELETE /budget/categories/:category
+  // ==========================================
+  describe('DELETE /api/v1/budget/categories/:category', () => {
+    it('should delete a custom category and reassign transactions', async () => {
+      mockedPrisma.categoryBudget.findUnique.mockResolvedValue({
+        id: 'cat-1',
+        userId: 'test-user-id',
+        category: 'snacks',
+        budgetLimit: 0 as any,
+        isCustom: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      mockedPrisma.transaction.updateMany.mockResolvedValue({ count: 3 });
+      mockedPrisma.categoryBudget.delete.mockResolvedValue({
+        id: 'cat-1',
+        userId: 'test-user-id',
+        category: 'snacks',
+        budgetLimit: 0 as any,
+        isCustom: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const res = await request(app)
+        .delete('/api/v1/budget/categories/snacks');
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toContain('刪除成功');
+
+      // Verify transactions were reassigned to "other"
+      expect(mockedPrisma.transaction.updateMany).toHaveBeenCalledWith({
+        where: { userId: 'test-user-id', category: 'snacks' },
+        data: { category: 'other' },
+      });
+    });
+
+    it('should reject deleting non-custom (system) category', async () => {
+      mockedPrisma.categoryBudget.findUnique.mockResolvedValue({
+        id: 'cat-sys',
+        userId: 'test-user-id',
+        category: 'food',
+        budgetLimit: 0 as any,
+        isCustom: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const res = await request(app)
+        .delete('/api/v1/budget/categories/food');
+
+      expect(res.status).toBe(400);
+      expect(res.body.message).toContain('系統預設');
+    });
+
+    it('should return 404 for non-existent category', async () => {
+      mockedPrisma.categoryBudget.findUnique.mockResolvedValue(null);
+
+      const res = await request(app)
+        .delete('/api/v1/budget/categories/nonexistent');
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  // ==========================================
+  // GET /budget/summary
+  // ==========================================
+  describe('GET /api/v1/budget/summary', () => {
+    it('should return monthly summary with category breakdown', async () => {
+      mockedPrisma.user.findUnique.mockResolvedValue({
+        id: 'test-user-id',
+        name: 'Test',
+        email: 'test@test.com',
+        passwordHash: 'hash',
+        persona: 'gentle',
+        aiEngine: 'gemini',
+        monthlyBudget: 30000 as any,
+        currency: 'TWD',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      mockedPrisma.transaction.findMany.mockResolvedValue([
+        {
+          id: 't1',
+          userId: 'test-user-id',
+          amount: 5000 as any,
+          category: 'food',
+          merchant: null,
+          rawText: '午餐',
+          note: null,
+          transactionDate: new Date(),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 't2',
+          userId: 'test-user-id',
+          amount: 3000 as any,
+          category: 'transport',
+          merchant: null,
+          rawText: '計程車',
+          note: null,
+          transactionDate: new Date(),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+
+      mockedPrisma.categoryBudget.findMany.mockResolvedValue([
+        {
+          id: 'cb1',
+          userId: 'test-user-id',
+          category: 'food',
+          budgetLimit: 8000 as any,
+          isCustom: false,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 'cb2',
+          userId: 'test-user-id',
+          category: 'transport',
+          budgetLimit: 5000 as any,
+          isCustom: false,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+
+      const res = await request(app).get('/api/v1/budget/summary');
+
+      expect(res.status).toBe(200);
+      const data = res.body.data;
+      expect(data.monthly_budget).toBe(30000);
+      expect(data.total_spent).toBe(8000);
+      expect(data.remaining).toBe(22000);
+      expect(data.used_ratio).toBeCloseTo(0.27, 1);
+      expect(data.transaction_count).toBe(2);
+      expect(data.categories).toHaveLength(2);
+
+      const foodCat = data.categories.find((c: any) => c.category === 'food');
+      expect(foodCat.budget_limit).toBe(8000);
+      expect(foodCat.spent).toBe(5000);
+      expect(foodCat.remaining).toBe(3000);
+    });
+
+    it('should return 404 for non-existent user', async () => {
+      mockedPrisma.user.findUnique.mockResolvedValue(null);
+
+      const res = await request(app).get('/api/v1/budget/summary');
+
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/backend/src/routes/budgetRoutes.ts
+++ b/backend/src/routes/budgetRoutes.ts
@@ -6,17 +6,25 @@ import { ApiResponse } from '../types';
 
 const router = Router();
 
+const MAX_CATEGORIES = 20;
+
 // POST /budget/categories - 新增類別
 router.post('/categories', authMiddleware, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     const userId = req.userId!;
-    const { category } = req.body;
+    const { category, budget_limit } = req.body;
 
     if (!category || typeof category !== 'string' || !category.trim()) {
       throw new AppError('請提供類別名稱', 400);
     }
 
     const trimmed = category.trim();
+
+    // Check category count limit
+    const count = await prisma.categoryBudget.count({ where: { userId } });
+    if (count >= MAX_CATEGORIES) {
+      throw new AppError(`類別數量已達上限 ${MAX_CATEGORIES}`, 400);
+    }
 
     // Check duplicate
     const existing = await prisma.categoryBudget.findUnique({
@@ -27,19 +35,24 @@ router.post('/categories', authMiddleware, async (req: AuthRequest, res: Respons
       throw new AppError('該類別已存在', 409);
     }
 
+    const budgetLimit = budget_limit != null ? Number(budget_limit) : 0;
+    if (isNaN(budgetLimit) || budgetLimit < 0) {
+      throw new AppError('budget_limit 必須為非負數', 400);
+    }
+
     const created = await prisma.categoryBudget.create({
       data: {
         userId,
         category: trimmed,
         isCustom: true,
-        budgetLimit: 0,
+        budgetLimit,
       },
     });
 
-    const response: ApiResponse<{ id: string; category: string }> = {
+    const response: ApiResponse<{ id: string; category: string; budget_limit: number }> = {
       code: 201,
       message: '類別新增成功',
-      data: { id: created.id, category: created.category },
+      data: { id: created.id, category: created.category, budget_limit: Number(created.budgetLimit) },
       timestamp: new Date().toISOString(),
     };
 
@@ -71,16 +84,123 @@ router.get('/categories', authMiddleware, async (req: AuthRequest, res: Response
   }
 });
 
-// GET /budget/summary - 取得當月預算摘要
+// PUT /budget/categories - 批次更新類別預算限額
+router.put('/categories', authMiddleware, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const userId = req.userId!;
+    const { categories } = req.body;
+
+    if (!Array.isArray(categories) || categories.length === 0) {
+      throw new AppError('請提供要更新的類別清單', 400);
+    }
+
+    const results = [];
+
+    for (const item of categories) {
+      if (!item.category || typeof item.category !== 'string') {
+        throw new AppError('每個項目必須包含 category 欄位', 400);
+      }
+      if (item.budget_limit == null || isNaN(Number(item.budget_limit)) || Number(item.budget_limit) < 0) {
+        throw new AppError(`類別 "${item.category}" 的 budget_limit 必須為非負數`, 400);
+      }
+
+      const existing = await prisma.categoryBudget.findUnique({
+        where: { userId_category: { userId, category: item.category } },
+      });
+
+      if (!existing) {
+        throw new AppError(`類別 "${item.category}" 不存在`, 404);
+      }
+
+      const updated = await prisma.categoryBudget.update({
+        where: { userId_category: { userId, category: item.category } },
+        data: { budgetLimit: Number(item.budget_limit) },
+      });
+
+      results.push({
+        category: updated.category,
+        budget_limit: Number(updated.budgetLimit),
+      });
+    }
+
+    const response: ApiResponse<typeof results> = {
+      code: 200,
+      message: '類別預算更新成功',
+      data: results,
+      timestamp: new Date().toISOString(),
+    };
+
+    res.status(200).json(response);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// DELETE /budget/categories/:category - 刪除自訂類別
+router.delete('/categories/:category', authMiddleware, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const userId = req.userId!;
+    const category = req.params.category as string;
+
+    const existing = await prisma.categoryBudget.findUnique({
+      where: { userId_category: { userId, category } },
+    });
+
+    if (!existing) {
+      throw new AppError('類別不存在', 404);
+    }
+
+    if (!existing.isCustom) {
+      throw new AppError('無法刪除系統預設類別', 400);
+    }
+
+    // Update related transactions to "other"
+    await prisma.transaction.updateMany({
+      where: { userId, category },
+      data: { category: 'other' },
+    });
+
+    // Delete the category
+    await prisma.categoryBudget.delete({
+      where: { userId_category: { userId, category } },
+    });
+
+    const response: ApiResponse<{ category: string }> = {
+      code: 200,
+      message: '類別刪除成功，相關交易已歸類為 other',
+      data: { category },
+      timestamp: new Date().toISOString(),
+    };
+
+    res.status(200).json(response);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /budget/summary - 取得當月預算摘要（含各類別明細）
 router.get('/summary', authMiddleware, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     const userId = req.userId!;
     const user = await prisma.user.findUnique({ where: { id: userId } });
     if (!user) throw new AppError('使用者不存在', 404);
 
-    const now = new Date();
-    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
-    const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+    // Support optional month query param (format: YYYY-MM)
+    const monthParam = req.query.month as string | undefined;
+    let year: number, month: number;
+
+    if (monthParam && /^\d{4}-\d{2}$/.test(monthParam)) {
+      const parts = monthParam.split('-');
+      year = parseInt(parts[0], 10);
+      month = parseInt(parts[1], 10) - 1; // JS months are 0-indexed
+    } else {
+      const now = new Date();
+      year = now.getFullYear();
+      month = now.getMonth();
+    }
+
+    const monthStart = new Date(year, month, 1);
+    const monthEnd = new Date(year, month + 1, 0, 23, 59, 59, 999);
 
     const transactions = await prisma.transaction.findMany({
       where: {
@@ -94,16 +214,47 @@ router.get('/summary', authMiddleware, async (req: AuthRequest, res: Response, n
     const remaining = monthlyBudget - totalSpent;
     const usedRatio = monthlyBudget > 0 ? Math.round((totalSpent / monthlyBudget) * 100) / 100 : 0;
 
+    // Build category breakdown
+    const categoryBudgets = await prisma.categoryBudget.findMany({
+      where: { userId },
+    });
+
+    const categorySpentMap: Record<string, number> = {};
+    for (const t of transactions) {
+      categorySpentMap[t.category] = (categorySpentMap[t.category] || 0) + Number(t.amount);
+    }
+
+    // Include all categories that have budgets or have spending
+    const allCategories = new Set([
+      ...categoryBudgets.map(cb => cb.category),
+      ...Object.keys(categorySpentMap),
+    ]);
+
+    const categoriesDetail = Array.from(allCategories).map(cat => {
+      const budget = categoryBudgets.find(cb => cb.category === cat);
+      const budgetLimit = budget ? Number(budget.budgetLimit) : 0;
+      const spent = categorySpentMap[cat] || 0;
+      return {
+        category: cat,
+        budget_limit: budgetLimit,
+        spent,
+        remaining: budgetLimit - spent,
+      };
+    });
+
+    const monthStr = `${year}-${String(month + 1).padStart(2, '0')}`;
+
     const response: ApiResponse<Record<string, unknown>> = {
       code: 200,
       message: '取得成功',
       data: {
-        month: `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`,
+        month: monthStr,
         monthly_budget: monthlyBudget,
         total_spent: totalSpent,
         remaining,
         used_ratio: usedRatio,
         transaction_count: transactions.length,
+        categories: categoriesDetail,
       },
       timestamp: new Date().toISOString(),
     };

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -5,6 +5,7 @@ import userRoutes from './userRoutes';
 import aiRoutes from './aiRoutes';
 import transactionRoutes from './transactionRoutes';
 import budgetRoutes from './budgetRoutes';
+import statsRoutes from './statsRoutes';
 
 const router = Router();
 
@@ -17,8 +18,6 @@ router.use('/api/v1/users', userRoutes);
 router.use('/api/v1/ai', aiRoutes);
 router.use('/api/v1/transactions', transactionRoutes);
 router.use('/api/v1/budget', budgetRoutes);
-
-// Future routes will be added here:
-// router.use('/api/v1/stats', statsRoutes);
+router.use('/api/v1/stats', statsRoutes);
 
 export default router;

--- a/backend/src/routes/statsRoutes.test.ts
+++ b/backend/src/routes/statsRoutes.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import app from '../app';
+
+// Mock prisma
+vi.mock('../config/database', () => {
+  return {
+    default: {
+      user: {
+        findUnique: vi.fn(),
+      },
+      categoryBudget: {
+        findUnique: vi.fn(),
+        findMany: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        count: vi.fn(),
+      },
+      transaction: {
+        findMany: vi.fn(),
+        updateMany: vi.fn(),
+      },
+    },
+  };
+});
+
+// Mock auth middleware
+vi.mock('../middlewares/auth', () => ({
+  authMiddleware: (req: any, _res: any, next: any) => {
+    req.userId = 'test-user-id';
+    next();
+  },
+  AuthRequest: {},
+}));
+
+import prisma from '../config/database';
+
+const mockedPrisma = vi.mocked(prisma);
+
+describe('Stats Routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ==========================================
+  // GET /stats/distribution
+  // ==========================================
+  describe('GET /api/v1/stats/distribution', () => {
+    it('should return spending distribution by category', async () => {
+      mockedPrisma.transaction.findMany.mockResolvedValue([
+        {
+          id: 't1',
+          userId: 'test-user-id',
+          amount: 5000 as any,
+          category: 'food',
+          merchant: null,
+          rawText: '午餐',
+          note: null,
+          transactionDate: new Date(),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 't2',
+          userId: 'test-user-id',
+          amount: 3000 as any,
+          category: 'transport',
+          merchant: null,
+          rawText: '計程車',
+          note: null,
+          transactionDate: new Date(),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 't3',
+          userId: 'test-user-id',
+          amount: 2000 as any,
+          category: 'food',
+          merchant: null,
+          rawText: '晚餐',
+          note: null,
+          transactionDate: new Date(),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+
+      const res = await request(app).get('/api/v1/stats/distribution');
+
+      expect(res.status).toBe(200);
+      const data = res.body.data;
+      expect(data.total).toBe(10000);
+      expect(data.distribution).toHaveLength(2);
+
+      // Should be sorted by amount descending
+      expect(data.distribution[0].category).toBe('food');
+      expect(data.distribution[0].amount).toBe(7000);
+      expect(data.distribution[0].ratio).toBe(0.7);
+
+      expect(data.distribution[1].category).toBe('transport');
+      expect(data.distribution[1].amount).toBe(3000);
+      expect(data.distribution[1].ratio).toBe(0.3);
+
+      // Ratios should sum to ~1
+      const totalRatio = data.distribution.reduce((sum: number, d: any) => sum + d.ratio, 0);
+      expect(totalRatio).toBeCloseTo(1.0, 1);
+    });
+
+    it('should return empty distribution when no transactions', async () => {
+      mockedPrisma.transaction.findMany.mockResolvedValue([]);
+
+      const res = await request(app).get('/api/v1/stats/distribution');
+
+      expect(res.status).toBe(200);
+      const data = res.body.data;
+      expect(data.total).toBe(0);
+      expect(data.distribution).toHaveLength(0);
+    });
+
+    it('should support month query parameter', async () => {
+      mockedPrisma.transaction.findMany.mockResolvedValue([
+        {
+          id: 't1',
+          userId: 'test-user-id',
+          amount: 1000 as any,
+          category: 'food',
+          merchant: null,
+          rawText: 'test',
+          note: null,
+          transactionDate: new Date('2026-01-15'),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+
+      const res = await request(app).get('/api/v1/stats/distribution?month=2026-01');
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.month).toBe('2026-01');
+    });
+  });
+});

--- a/backend/src/routes/statsRoutes.ts
+++ b/backend/src/routes/statsRoutes.ts
@@ -1,0 +1,73 @@
+import { Router, Response, NextFunction } from 'express';
+import { authMiddleware, AuthRequest } from '../middlewares/auth';
+import prisma from '../config/database';
+import { AppError } from '../middlewares/errorHandler';
+import { ApiResponse } from '../types';
+
+const router = Router();
+
+// GET /stats/distribution - 消費分佈比例
+router.get('/distribution', authMiddleware, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const userId = req.userId!;
+
+    // Support optional month query param (format: YYYY-MM)
+    const monthParam = req.query.month as string | undefined;
+    let year: number, month: number;
+
+    if (monthParam && /^\d{4}-\d{2}$/.test(monthParam)) {
+      const parts = monthParam.split('-');
+      year = parseInt(parts[0], 10);
+      month = parseInt(parts[1], 10) - 1;
+    } else {
+      const now = new Date();
+      year = now.getFullYear();
+      month = now.getMonth();
+    }
+
+    const monthStart = new Date(year, month, 1);
+    const monthEnd = new Date(year, month + 1, 0, 23, 59, 59, 999);
+
+    const transactions = await prisma.transaction.findMany({
+      where: {
+        userId,
+        transactionDate: { gte: monthStart, lte: monthEnd },
+      },
+    });
+
+    const total = transactions.reduce((sum, t) => sum + Number(t.amount), 0);
+
+    // Aggregate by category
+    const categoryMap: Record<string, number> = {};
+    for (const t of transactions) {
+      categoryMap[t.category] = (categoryMap[t.category] || 0) + Number(t.amount);
+    }
+
+    const distribution = Object.entries(categoryMap)
+      .map(([category, amount]) => ({
+        category,
+        amount,
+        ratio: total > 0 ? Math.round((amount / total) * 100) / 100 : 0,
+      }))
+      .sort((a, b) => b.amount - a.amount);
+
+    const monthStr = `${year}-${String(month + 1).padStart(2, '0')}`;
+
+    const response: ApiResponse<Record<string, unknown>> = {
+      code: 200,
+      message: '取得成功',
+      data: {
+        month: monthStr,
+        total,
+        distribution,
+      },
+      timestamp: new Date().toISOString(),
+    };
+
+    res.status(200).json(response);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/backend/src/routes/statsRoutes.ts
+++ b/backend/src/routes/statsRoutes.ts
@@ -1,7 +1,6 @@
 import { Router, Response, NextFunction } from 'express';
 import { authMiddleware, AuthRequest } from '../middlewares/auth';
 import prisma from '../config/database';
-import { AppError } from '../middlewares/errorHandler';
 import { ApiResponse } from '../types';
 
 const router = Router();


### PR DESCRIPTION
## 變更摘要
實作 M3 預算與統計 API：擴充 budget summary 含類別明細、類別 CRUD（批次更新/刪除+歸類）、消費分佈統計端點。

## 關聯 Issue
Closes #12

## 變更清單
- `budgetRoutes.ts` — 擴充 GET /summary（加類別明細）、POST /categories（上限 20 驗證）、新增 PUT /categories（批次更新）、DELETE /categories/:category（刪除+歸類 other）
- `statsRoutes.ts` — 新增 GET /stats/distribution（消費分佈比例）
- `routes/index.ts` — 註冊 stats 路由
- `budgetRoutes.test.ts` — budget API 完整測試
- `statsRoutes.test.ts` — stats API 測試

## 測試結果
- 後端測試：✅ 全部通過（85/85）
- TypeScript：✅ 編譯通過