### PR TITLE
feat(frontend): T-304 設定頁面（人設切換/預算/AI 引擎/API Key）

### DIFF
--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,12 +1,141 @@
+import { useEffect, useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuthStore } from '../stores/authStore.ts'
+import { useSettingsStore } from '../stores/settingsStore.ts'
+import type { Persona, AIEngine, KeyValidationStatus } from '../stores/settingsStore.ts'
+
+/** 人設選項定義 */
+const PERSONA_OPTIONS: { value: Persona; label: string; emoji: string }[] = [
+  { value: 'sarcastic', label: '毒舌', emoji: '🔥' },
+  { value: 'gentle', label: '溫柔', emoji: '💖' },
+  { value: 'guilt_trip', label: '情勒', emoji: '🥺' },
+]
+
+/** AI 引擎選項定義 */
+const ENGINE_OPTIONS: { value: AIEngine; label: string; emoji: string; sub: string }[] = [
+  { value: 'gemini', label: 'Gemini', emoji: '✨', sub: '(預設)' },
+  { value: 'openai', label: 'OpenAI', emoji: '🤖', sub: '(GPT-4o-mini)' },
+]
+
 function SettingsPage() {
+  const navigate = useNavigate()
+  const logout = useAuthStore((s) => s.logout)
+
+  const {
+    persona,
+    aiEngine,
+    monthlyBudget,
+    userName,
+    userEmail,
+    loading,
+    saving,
+    error,
+    keyValidationStatus,
+    fetchProfile,
+    updatePersona,
+    updateBudget,
+    updateAIEngine,
+    validateApiKey,
+    clearError,
+  } = useSettingsStore()
+
+  // Local state for budget input (so user can type freely)
+  const [budgetInput, setBudgetInput] = useState('')
+  const [budgetEditing, setBudgetEditing] = useState(false)
+
+  // Local state for API key
+  const [apiKey, setApiKey] = useState(() => localStorage.getItem('llm_api_key') ?? '')
+  const [showApiKey, setShowApiKey] = useState(false)
+
+  // Load profile on mount
+  useEffect(() => {
+    fetchProfile()
+  }, [fetchProfile])
+
+  // Sync budget from store to local input when not editing
+  useEffect(() => {
+    if (!budgetEditing) {
+      setBudgetInput(monthlyBudget > 0 ? String(monthlyBudget) : '')
+    }
+  }, [monthlyBudget, budgetEditing])
+
+  const handleBudgetSave = useCallback(() => {
+    const val = parseInt(budgetInput, 10)
+    if (!isNaN(val) && val >= 0) {
+      updateBudget(val)
+    }
+    setBudgetEditing(false)
+  }, [budgetInput, updateBudget])
+
+  const handleApiKeySave = useCallback(() => {
+    localStorage.setItem('llm_api_key', apiKey)
+  }, [apiKey])
+
+  const handleValidateKey = useCallback(async () => {
+    handleApiKeySave()
+    await validateApiKey(apiKey)
+  }, [apiKey, handleApiKeySave, validateApiKey])
+
+  const handleLogout = useCallback(() => {
+    logout()
+    navigate('/login')
+  }, [logout, navigate])
+
+  const keyStatusText = (status: KeyValidationStatus) => {
+    switch (status) {
+      case 'validating': return '⏳ 驗證中...'
+      case 'valid': return '✅ 金鑰有效'
+      case 'invalid': return '❌ 金鑰無效'
+      default: return null
+    }
+  }
+
+  const keyStatusColor = (status: KeyValidationStatus) => {
+    switch (status) {
+      case 'valid': return 'text-success'
+      case 'invalid': return 'text-danger'
+      default: return 'text-text-secondary'
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="p-2xl flex items-center justify-center min-h-[50vh]">
+        <p className="text-body text-text-secondary">載入設定中...</p>
+      </div>
+    )
+  }
+
   return (
     <div className="p-2xl">
+      {/* Header */}
       <header className="h-14 flex items-center mb-lg">
         <h1 className="text-title font-semibold text-text-primary">
           ⚙️ 設定
         </h1>
+        {saving && (
+          <span className="ml-auto text-small text-text-secondary">儲存中...</span>
+        )}
       </header>
 
+      {/* Error banner */}
+      {error && (
+        <div
+          className="bg-danger-light rounded-lg p-md mb-lg flex items-center justify-between"
+          role="alert"
+        >
+          <span className="text-caption text-danger">{error}</span>
+          <button
+            onClick={clearError}
+            className="text-danger text-caption font-semibold ml-md"
+            aria-label="關閉錯誤"
+          >
+            ✕
+          </button>
+        </div>
+      )}
+
+      {/* 使用者資訊區 */}
       <section className="bg-surface rounded-lg shadow-card p-lg mb-xl" aria-label="使用者資訊">
         <div className="flex items-center gap-md">
           <div className="w-10 h-10 bg-bg rounded-full flex items-center justify-center text-xl">
@@ -14,63 +143,156 @@ function SettingsPage() {
           </div>
           <div>
             <p className="text-body font-semibold text-text-primary">
-              使用者名稱
+              {userName || '使用者名稱'}
             </p>
             <p className="text-small text-text-secondary">
-              user@email.com
+              {userEmail || 'user@email.com'}
             </p>
           </div>
         </div>
       </section>
 
+      {/* AI 人設選擇 */}
       <section className="bg-surface rounded-lg shadow-card p-lg mb-xl" aria-label="AI 人設選擇">
         <h2 className="text-caption text-text-secondary mb-md">
           AI 人設選擇
         </h2>
         <div className="flex gap-md">
-          <div className="w-[100px] h-[100px] bg-surface rounded-lg shadow-card flex flex-col items-center justify-center cursor-pointer">
-            <span className="text-2xl">🔥</span>
-            <span className="text-caption mt-xs">毒舌</span>
-          </div>
-          <div className="w-[100px] h-[100px] bg-primary-light rounded-lg border-2 border-primary flex flex-col items-center justify-center cursor-pointer">
-            <span className="text-2xl">💖</span>
-            <span className="text-caption mt-xs">溫柔</span>
-          </div>
-          <div className="w-[100px] h-[100px] bg-surface rounded-lg shadow-card flex flex-col items-center justify-center cursor-pointer">
-            <span className="text-2xl">🥺</span>
-            <span className="text-caption mt-xs">情勒</span>
-          </div>
+          {PERSONA_OPTIONS.map((opt) => {
+            const selected = persona === opt.value
+            return (
+              <button
+                key={opt.value}
+                onClick={() => updatePersona(opt.value)}
+                disabled={saving}
+                className={`w-[100px] h-[100px] rounded-lg flex flex-col items-center justify-center cursor-pointer transition-all ${
+                  selected
+                    ? 'bg-primary-light border-2 border-primary'
+                    : 'bg-surface shadow-card hover:shadow-card-hover'
+                }`}
+                aria-pressed={selected}
+                aria-label={`選擇${opt.label}人設`}
+              >
+                <span className="text-2xl">{opt.emoji}</span>
+                <span className="text-caption mt-xs">{opt.label}</span>
+              </button>
+            )
+          })}
         </div>
       </section>
 
+      {/* 月預算設定 */}
       <section className="bg-surface rounded-lg shadow-card p-lg mb-xl" aria-label="月預算設定">
         <h2 className="text-caption text-text-secondary mb-md">
           月預算設定
         </h2>
-        <p className="text-body text-text-tertiary">
-          尚未設定預算
-        </p>
+        <div className="flex items-center gap-sm">
+          <span className="text-body text-text-primary font-semibold">$</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            min="0"
+            value={budgetInput}
+            placeholder="輸入每月預算"
+            onChange={(e) => {
+              setBudgetInput(e.target.value)
+              setBudgetEditing(true)
+            }}
+            onBlur={handleBudgetSave}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleBudgetSave()
+            }}
+            className="flex-1 h-12 rounded-md border border-border bg-bg px-lg text-body text-text-primary text-right focus:outline-none focus:border-primary"
+            aria-label="每月預算金額"
+          />
+        </div>
+        {monthlyBudget > 0 && !budgetEditing && (
+          <p className="text-small text-text-secondary mt-sm">
+            目前設定：${monthlyBudget.toLocaleString()}
+          </p>
+        )}
       </section>
 
+      {/* AI 引擎設定 */}
       <section className="bg-surface rounded-lg shadow-card p-lg mb-xl" aria-label="AI 引擎設定">
         <h2 className="text-caption text-text-secondary mb-md">
           AI 引擎設定
         </h2>
-        <div className="flex gap-md">
-          <div className="flex-1 h-20 bg-primary-light rounded-lg border-2 border-primary flex flex-col items-center justify-center cursor-pointer">
-            <span className="text-lg">✨</span>
-            <span className="text-body font-semibold">Gemini</span>
-            <span className="text-small text-text-secondary">(預設)</span>
+        <div className="flex gap-md mb-lg">
+          {ENGINE_OPTIONS.map((opt) => {
+            const selected = aiEngine === opt.value
+            return (
+              <button
+                key={opt.value}
+                onClick={() => updateAIEngine(opt.value)}
+                disabled={saving}
+                className={`flex-1 h-20 rounded-lg flex flex-col items-center justify-center cursor-pointer transition-all ${
+                  selected
+                    ? 'bg-primary-light border-2 border-primary'
+                    : 'bg-surface shadow-card hover:shadow-card-hover'
+                }`}
+                aria-pressed={selected}
+                aria-label={`選擇 ${opt.label} 引擎`}
+              >
+                <span className="text-lg">{opt.emoji}</span>
+                <span className="text-body font-semibold">{opt.label}</span>
+                <span className="text-small text-text-secondary">{opt.sub}</span>
+              </button>
+            )
+          })}
+        </div>
+
+        {/* API Key 輸入 */}
+        <div className="mt-md">
+          <label className="text-caption text-text-secondary mb-sm block">
+            API Key
+          </label>
+          <div className="flex items-center gap-sm">
+            <div className="relative flex-1">
+              <input
+                type={showApiKey ? 'text' : 'password'}
+                value={apiKey}
+                onChange={(e) => {
+                  setApiKey(e.target.value)
+                  // Auto-save to localStorage on change
+                  localStorage.setItem('llm_api_key', e.target.value)
+                }}
+                placeholder="輸入 API Key"
+                className="w-full h-12 rounded-md border border-border bg-bg px-lg pr-12 text-body text-text-primary focus:outline-none focus:border-primary"
+                aria-label="API Key 輸入"
+              />
+              <button
+                type="button"
+                onClick={() => setShowApiKey(!showApiKey)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-text-secondary hover:text-text-primary"
+                aria-label={showApiKey ? '隱藏 API Key' : '顯示 API Key'}
+              >
+                {showApiKey ? '🙈' : '👁️'}
+              </button>
+            </div>
+            <button
+              onClick={handleValidateKey}
+              disabled={!apiKey || keyValidationStatus === 'validating'}
+              className="h-12 px-lg rounded-md bg-primary text-white text-caption font-semibold disabled:opacity-50 transition-all hover:bg-primary-dark"
+              aria-label="驗證 API Key"
+            >
+              驗證
+            </button>
           </div>
-          <div className="flex-1 h-20 bg-surface rounded-lg shadow-card flex flex-col items-center justify-center cursor-pointer">
-            <span className="text-lg">🤖</span>
-            <span className="text-body font-semibold">OpenAI</span>
-            <span className="text-small text-text-secondary">(GPT-4o-mini)</span>
-          </div>
+          {keyStatusText(keyValidationStatus) && (
+            <p className={`text-caption mt-sm ${keyStatusColor(keyValidationStatus)}`} role="status">
+              {keyStatusText(keyValidationStatus)}
+            </p>
+          )}
         </div>
       </section>
 
-      <button className="w-full h-12 bg-surface rounded-md text-danger font-semibold text-body shadow-card">
+      {/* 登出按鈕 */}
+      <button
+        onClick={handleLogout}
+        className="w-full h-12 bg-surface rounded-md text-danger font-semibold text-body shadow-card hover:shadow-card-hover transition-all"
+        aria-label="登出"
+      >
         登出
       </button>
     </div>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -40,7 +40,9 @@ function SettingsPage() {
   } = useSettingsStore()
 
   // Local state for budget input (so user can type freely)
-  const [budgetInput, setBudgetInput] = useState('')
+  const [budgetInput, setBudgetInput] = useState(() =>
+    monthlyBudget > 0 ? String(monthlyBudget) : ''
+  )
   const [budgetEditing, setBudgetEditing] = useState(false)
 
   // Local state for API key
@@ -49,10 +51,12 @@ function SettingsPage() {
 
   // Load profile on mount and sync budget input
   useEffect(() => {
-    fetchProfile().then(() => {
+    const load = async () => {
+      await fetchProfile()
       const budget = useSettingsStore.getState().monthlyBudget
       if (budget > 0) setBudgetInput(String(budget))
-    })
+    }
+    load()
   }, [fetchProfile])
 
   const handleBudgetSave = useCallback(() => {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -47,25 +47,24 @@ function SettingsPage() {
   const [apiKey, setApiKey] = useState(() => localStorage.getItem('llm_api_key') ?? '')
   const [showApiKey, setShowApiKey] = useState(false)
 
-  // Load profile on mount
+  // Load profile on mount and sync budget input
   useEffect(() => {
-    fetchProfile()
+    fetchProfile().then(() => {
+      const budget = useSettingsStore.getState().monthlyBudget
+      if (budget > 0) setBudgetInput(String(budget))
+    })
   }, [fetchProfile])
-
-  // Sync budget from store to local input when not editing
-  useEffect(() => {
-    if (!budgetEditing) {
-      setBudgetInput(monthlyBudget > 0 ? String(monthlyBudget) : '')
-    }
-  }, [monthlyBudget, budgetEditing])
 
   const handleBudgetSave = useCallback(() => {
     const val = parseInt(budgetInput, 10)
     if (!isNaN(val) && val >= 0) {
       updateBudget(val)
+    } else {
+      // Reset to store value if invalid
+      setBudgetInput(monthlyBudget > 0 ? String(monthlyBudget) : '')
     }
     setBudgetEditing(false)
-  }, [budgetInput, updateBudget])
+  }, [budgetInput, updateBudget, monthlyBudget])
 
   const handleApiKeySave = useCallback(() => {
     localStorage.setItem('llm_api_key', apiKey)

--- a/frontend/src/stores/settingsStore.ts
+++ b/frontend/src/stores/settingsStore.ts
@@ -1,0 +1,131 @@
+import { create } from 'zustand'
+import api from '../lib/api.ts'
+import type { User } from '../types/index.ts'
+
+export type Persona = 'sarcastic' | 'gentle' | 'guilt_trip'
+export type AIEngine = 'gemini' | 'openai'
+
+export type KeyValidationStatus = 'idle' | 'validating' | 'valid' | 'invalid'
+
+interface SettingsState {
+  /** 使用者 Profile（從後端載入） */
+  persona: Persona
+  aiEngine: AIEngine
+  monthlyBudget: number
+  userName: string
+  userEmail: string
+
+  /** 載入/更新狀態 */
+  loading: boolean
+  saving: boolean
+  error: string | null
+
+  /** API Key 驗證狀態 */
+  keyValidationStatus: KeyValidationStatus
+
+  /** 從後端載入使用者設定 */
+  fetchProfile: () => Promise<void>
+  /** 更新人設 */
+  updatePersona: (persona: Persona) => Promise<void>
+  /** 更新月預算 */
+  updateBudget: (monthlyBudget: number) => Promise<void>
+  /** 更新 AI 引擎 */
+  updateAIEngine: (aiEngine: AIEngine) => Promise<void>
+  /** 驗證 API Key */
+  validateApiKey: (apiKey: string) => Promise<boolean>
+  /** 清除錯誤 */
+  clearError: () => void
+}
+
+export const useSettingsStore = create<SettingsState>((set, get) => ({
+  persona: 'gentle',
+  aiEngine: 'gemini',
+  monthlyBudget: 0,
+  userName: '',
+  userEmail: '',
+  loading: false,
+  saving: false,
+  error: null,
+  keyValidationStatus: 'idle',
+
+  fetchProfile: async () => {
+    set({ loading: true, error: null })
+    try {
+      const res = await api.get<{ data: { user: User } }>('/users/profile')
+      const user = res.data.data.user
+      set({
+        persona: user.persona,
+        aiEngine: user.aiEngine,
+        monthlyBudget: user.monthlyBudget,
+        userName: user.name,
+        userEmail: user.email,
+        loading: false,
+      })
+    } catch (err: unknown) {
+      const message = extractErrorMessage(err, '載入設定失敗')
+      set({ loading: false, error: message })
+    }
+  },
+
+  updatePersona: async (persona: Persona) => {
+    const prev = get().persona
+    set({ persona, saving: true, error: null })
+    try {
+      await api.put('/users/profile', { persona })
+      set({ saving: false })
+    } catch (err: unknown) {
+      const message = extractErrorMessage(err, '更新人設失敗')
+      set({ persona: prev, saving: false, error: message })
+    }
+  },
+
+  updateBudget: async (monthlyBudget: number) => {
+    const prev = get().monthlyBudget
+    set({ monthlyBudget, saving: true, error: null })
+    try {
+      await api.put('/users/profile', { monthly_budget: monthlyBudget })
+      set({ saving: false })
+    } catch (err: unknown) {
+      const message = extractErrorMessage(err, '更新預算失敗')
+      set({ monthlyBudget: prev, saving: false, error: message })
+    }
+  },
+
+  updateAIEngine: async (aiEngine: AIEngine) => {
+    const prev = get().aiEngine
+    set({ aiEngine, saving: true, error: null })
+    try {
+      await api.put('/users/profile', { ai_engine: aiEngine })
+      set({ saving: false })
+    } catch (err: unknown) {
+      const message = extractErrorMessage(err, '更新 AI 引擎失敗')
+      set({ aiEngine: prev, saving: false, error: message })
+    }
+  },
+
+  validateApiKey: async (apiKey: string) => {
+    set({ keyValidationStatus: 'validating' })
+    try {
+      await api.post('/ai/validate-key', {}, {
+        headers: { 'X-LLM-API-Key': apiKey },
+      })
+      set({ keyValidationStatus: 'valid' })
+      return true
+    } catch {
+      set({ keyValidationStatus: 'invalid' })
+      return false
+    }
+  },
+
+  clearError: () => set({ error: null }),
+}))
+
+function extractErrorMessage(err: unknown, fallback: string): string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const response = (err as { response?: { data?: { message?: string } } }).response
+    if (response?.data?.message) {
+      return response.data.message
+    }
+  }
+  return fallback
+}

--- a/frontend/src/test/App.test.tsx
+++ b/frontend/src/test/App.test.tsx
@@ -1,8 +1,9 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import App from '../App'
 import { useAuthStore } from '../stores/authStore.ts'
+import { useSettingsStore } from '../stores/settingsStore.ts'
 
 function renderWithRouter(initialRoute = '/') {
   return render(
@@ -63,6 +64,7 @@ describe('App Routing', () => {
     })
 
     it('renders settings page at /settings', () => {
+      useSettingsStore.setState({ loading: false, fetchProfile: vi.fn() })
       renderWithRouter('/settings')
       expect(screen.getByText('⚙️ 設定')).toBeInTheDocument()
     })

--- a/frontend/src/test/SettingsPage.test.tsx
+++ b/frontend/src/test/SettingsPage.test.tsx
@@ -116,13 +116,15 @@ describe('SettingsPage', () => {
 
     it('calls updateBudget on blur', async () => {
       const updateBudget = vi.fn()
-      useSettingsStore.setState({ updateBudget })
+      useSettingsStore.setState({ updateBudget, monthlyBudget: 0 })
       renderSettings()
 
-      const input = screen.getByLabelText('每月預算金額')
+      const input = screen.getByLabelText('每月預算金額') as HTMLInputElement
+      await userEvent.click(input)
       await userEvent.clear(input)
       await userEvent.type(input, '30000')
-      await userEvent.tab() // triggers blur
+      // Trigger blur by tabbing
+      await userEvent.tab()
       expect(updateBudget).toHaveBeenCalledWith(30000)
     })
   })

--- a/frontend/src/test/SettingsPage.test.tsx
+++ b/frontend/src/test/SettingsPage.test.tsx
@@ -1,0 +1,269 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import SettingsPage from '../pages/SettingsPage'
+import { useSettingsStore } from '../stores/settingsStore'
+
+// Mock api module
+vi.mock('../lib/api.ts', () => ({
+  default: {
+    get: vi.fn(),
+    put: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+// Mock useNavigate
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+function renderSettings() {
+  return render(
+    <MemoryRouter>
+      <SettingsPage />
+    </MemoryRouter>
+  )
+}
+
+describe('SettingsPage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+
+    // Set store to non-loading state with defaults
+    // Override fetchProfile to a no-op so mount doesn't trigger loading
+    useSettingsStore.setState({
+      persona: 'gentle',
+      aiEngine: 'gemini',
+      monthlyBudget: 20000,
+      userName: '測試使用者',
+      userEmail: 'test@example.com',
+      loading: false,
+      saving: false,
+      error: null,
+      keyValidationStatus: 'idle',
+      fetchProfile: vi.fn(),
+    })
+  })
+
+  it('renders all sections', () => {
+    renderSettings()
+    expect(screen.getByText('⚙️ 設定')).toBeInTheDocument()
+    expect(screen.getByLabelText('使用者資訊')).toBeInTheDocument()
+    expect(screen.getByLabelText('AI 人設選擇')).toBeInTheDocument()
+    expect(screen.getByLabelText('月預算設定')).toBeInTheDocument()
+    expect(screen.getByLabelText('AI 引擎設定')).toBeInTheDocument()
+    expect(screen.getByLabelText('登出')).toBeInTheDocument()
+  })
+
+  it('displays user info from store', () => {
+    renderSettings()
+    expect(screen.getByText('測試使用者')).toBeInTheDocument()
+    expect(screen.getByText('test@example.com')).toBeInTheDocument()
+  })
+
+  it('shows loading state', () => {
+    useSettingsStore.setState({ loading: true, fetchProfile: vi.fn() })
+    renderSettings()
+    expect(screen.getByText('載入設定中...')).toBeInTheDocument()
+  })
+
+  describe('PersonaSelector', () => {
+    it('renders all three persona options', () => {
+      renderSettings()
+      expect(screen.getByLabelText('選擇毒舌人設')).toBeInTheDocument()
+      expect(screen.getByLabelText('選擇溫柔人設')).toBeInTheDocument()
+      expect(screen.getByLabelText('選擇情勒人設')).toBeInTheDocument()
+    })
+
+    it('highlights selected persona (gentle by default)', () => {
+      renderSettings()
+      const gentleBtn = screen.getByLabelText('選擇溫柔人設')
+      expect(gentleBtn).toHaveAttribute('aria-pressed', 'true')
+
+      const sarcasticBtn = screen.getByLabelText('選擇毒舌人設')
+      expect(sarcasticBtn).toHaveAttribute('aria-pressed', 'false')
+    })
+
+    it('calls updatePersona when clicking a persona card', async () => {
+      const updatePersona = vi.fn()
+      useSettingsStore.setState({ updatePersona })
+      renderSettings()
+
+      await userEvent.click(screen.getByLabelText('選擇毒舌人設'))
+      expect(updatePersona).toHaveBeenCalledWith('sarcastic')
+    })
+  })
+
+  describe('BudgetEditor', () => {
+    it('shows current budget value in the input', () => {
+      renderSettings()
+      const input = screen.getByLabelText('每月預算金額') as HTMLInputElement
+      expect(input.value).toBe('20000')
+    })
+
+    it('shows formatted budget text', () => {
+      renderSettings()
+      expect(screen.getByText('目前設定：$20,000')).toBeInTheDocument()
+    })
+
+    it('calls updateBudget on blur', async () => {
+      const updateBudget = vi.fn()
+      useSettingsStore.setState({ updateBudget })
+      renderSettings()
+
+      const input = screen.getByLabelText('每月預算金額')
+      await userEvent.clear(input)
+      await userEvent.type(input, '30000')
+      await userEvent.tab() // triggers blur
+      expect(updateBudget).toHaveBeenCalledWith(30000)
+    })
+  })
+
+  describe('AIEngineSelector', () => {
+    it('renders Gemini and OpenAI options', () => {
+      renderSettings()
+      expect(screen.getByLabelText('選擇 Gemini 引擎')).toBeInTheDocument()
+      expect(screen.getByLabelText('選擇 OpenAI 引擎')).toBeInTheDocument()
+    })
+
+    it('highlights selected engine', () => {
+      renderSettings()
+      expect(screen.getByLabelText('選擇 Gemini 引擎')).toHaveAttribute('aria-pressed', 'true')
+      expect(screen.getByLabelText('選擇 OpenAI 引擎')).toHaveAttribute('aria-pressed', 'false')
+    })
+
+    it('calls updateAIEngine when clicking', async () => {
+      const updateAIEngine = vi.fn()
+      useSettingsStore.setState({ updateAIEngine })
+      renderSettings()
+
+      await userEvent.click(screen.getByLabelText('選擇 OpenAI 引擎'))
+      expect(updateAIEngine).toHaveBeenCalledWith('openai')
+    })
+  })
+
+  describe('APIKeyInput', () => {
+    it('stores API key only in localStorage, not on server', async () => {
+      renderSettings()
+
+      const input = screen.getByLabelText('API Key 輸入')
+      await userEvent.type(input, 'test-api-key-123')
+
+      expect(localStorage.getItem('llm_api_key')).toBe('test-api-key-123')
+    })
+
+    it('loads existing API key from localStorage', () => {
+      localStorage.setItem('llm_api_key', 'existing-key')
+      // Re-render picks up the initial state
+      useSettingsStore.setState({ loading: false })
+      renderSettings()
+
+      const input = screen.getByLabelText('API Key 輸入') as HTMLInputElement
+      // Input type is password by default
+      expect(input.type).toBe('password')
+    })
+
+    it('toggles visibility of API key', async () => {
+      renderSettings()
+
+      const input = screen.getByLabelText('API Key 輸入') as HTMLInputElement
+      expect(input.type).toBe('password')
+
+      await userEvent.click(screen.getByLabelText('顯示 API Key'))
+      expect(input.type).toBe('text')
+
+      await userEvent.click(screen.getByLabelText('隱藏 API Key'))
+      expect(input.type).toBe('password')
+    })
+
+    it('calls validateApiKey when clicking validate button', async () => {
+      const validateApiKey = vi.fn().mockResolvedValue(true)
+      useSettingsStore.setState({ validateApiKey })
+      renderSettings()
+
+      const input = screen.getByLabelText('API Key 輸入')
+      await userEvent.type(input, 'my-key')
+
+      await userEvent.click(screen.getByLabelText('驗證 API Key'))
+      expect(validateApiKey).toHaveBeenCalledWith('my-key')
+    })
+
+    it('shows validation status', () => {
+      useSettingsStore.setState({ keyValidationStatus: 'valid' })
+      renderSettings()
+      expect(screen.getByText('✅ 金鑰有效')).toBeInTheDocument()
+    })
+
+    it('shows invalid status', () => {
+      useSettingsStore.setState({ keyValidationStatus: 'invalid' })
+      renderSettings()
+      expect(screen.getByText('❌ 金鑰無效')).toBeInTheDocument()
+    })
+  })
+
+  describe('Logout', () => {
+    it('calls logout and navigates to /login', async () => {
+      const logoutFn = vi.fn()
+
+      // Need to mock authStore's logout
+      const { useAuthStore } = await import('../stores/authStore')
+      useAuthStore.setState({ logout: logoutFn })
+
+      renderSettings()
+      await userEvent.click(screen.getByLabelText('登出'))
+
+      expect(logoutFn).toHaveBeenCalled()
+      expect(mockNavigate).toHaveBeenCalledWith('/login')
+    })
+  })
+
+  describe('Error handling', () => {
+    it('displays error message and dismiss button', async () => {
+      const clearError = vi.fn()
+      useSettingsStore.setState({ error: '更新失敗', clearError })
+      renderSettings()
+
+      expect(screen.getByText('更新失敗')).toBeInTheDocument()
+      await userEvent.click(screen.getByLabelText('關閉錯誤'))
+      expect(clearError).toHaveBeenCalled()
+    })
+  })
+})
+
+describe('settingsStore', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+    useSettingsStore.setState({
+      persona: 'gentle',
+      aiEngine: 'gemini',
+      monthlyBudget: 0,
+      userName: '',
+      userEmail: '',
+      loading: false,
+      saving: false,
+      error: null,
+      keyValidationStatus: 'idle',
+    })
+  })
+
+  it('API key is stored only in localStorage, never sent to profile API', async () => {
+    // This test verifies the architectural decision:
+    // API key is ONLY in localStorage, never in the settings store state
+    const store = useSettingsStore.getState()
+    // The store should not have an apiKey field
+    expect('apiKey' in store).toBe(false)
+
+    // Setting in localStorage should work
+    localStorage.setItem('llm_api_key', 'secret-key')
+    expect(localStorage.getItem('llm_api_key')).toBe('secret-key')
+  })
+})


### PR DESCRIPTION
## 變更摘要
將設定頁面從靜態 mockup 改為功能完整頁面：人設切換、月預算設定、AI 引擎選擇、API Key 管理、登出功能。

## 關聯 Issue
Closes #15

## 變更清單
- `SettingsPage.tsx` — 五大功能區段（人設/預算/AI引擎/API Key/登出）
- `settingsStore.ts` — 新增 Zustand store（profile CRUD、optimistic update + rollback）
- `SettingsPage.test.tsx` — 21 個測試
- `App.test.tsx` — 適配 loading 狀態

## 設計決策
- API Key 僅存 localStorage，不上傳伺服器
- Optimistic update：先更新 UI，API 失敗時自動 rollback
- 人設切換即時生效，解決 M2 驗收門待辦項

## 測試結果
- 前端測試：✅ 全部通過（96/96）
- TypeScript + Vite build：✅ 通過