### PR TITLE
feat(frontend): T-303 交易記錄列表（篩選/刪除/詳情）

### DIFF
--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -1,0 +1,197 @@
+import { useState, useCallback } from 'react'
+import type { Transaction } from '../stores/index'
+
+interface TransactionItemProps {
+  transaction: Transaction
+  isExpanded: boolean
+  onToggle: () => void
+  onDelete: (id: string) => Promise<void>
+  isDeleting: boolean
+}
+
+const categoryIcons: Record<string, string> = {
+  food: '🍽️',
+  transport: '🚌',
+  entertainment: '🎬',
+  shopping: '🛍️',
+  daily: '🧴',
+  medical: '🏥',
+  education: '📚',
+  other: '📦',
+}
+
+const categoryNames: Record<string, string> = {
+  food: '飲食',
+  transport: '交通',
+  entertainment: '娛樂',
+  shopping: '購物',
+  daily: '日用品',
+  medical: '醫療',
+  education: '教育',
+  other: '其他',
+}
+
+function formatTime(dateStr: string): string {
+  const date = new Date(dateStr)
+  const hours = date.getHours()
+  const minutes = date.getMinutes().toString().padStart(2, '0')
+  const period = hours < 12 ? '上午' : '下午'
+  const displayHour = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours
+  return `${period}${displayHour.toString().padStart(2, '0')}:${minutes}`
+}
+
+function formatDate(dateStr: string): string {
+  if (!dateStr) return '--'
+  return dateStr.split('T')[0]
+}
+
+function TransactionItem({
+  transaction: tx,
+  isExpanded,
+  onToggle,
+  onDelete,
+  isDeleting,
+}: TransactionItemProps) {
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+
+  const handleDeleteClick = useCallback(() => {
+    setShowDeleteConfirm(true)
+  }, [])
+
+  const handleCancelDelete = useCallback(() => {
+    setShowDeleteConfirm(false)
+  }, [])
+
+  const handleConfirmDelete = useCallback(async () => {
+    try {
+      await onDelete(tx.id)
+      setShowDeleteConfirm(false)
+    } catch {
+      // Error handled by store
+    }
+  }, [onDelete, tx.id])
+
+  return (
+    <div className="border-b border-border last:border-b-0" data-testid={`transaction-item-${tx.id}`}>
+      {/* Summary row */}
+      <button
+        type="button"
+        onClick={onToggle}
+        className="w-full flex items-center gap-md py-md hover:bg-bg transition-colors"
+        aria-expanded={isExpanded}
+      >
+        <div className="w-10 h-10 rounded-md bg-danger-light flex items-center justify-center text-lg shrink-0">
+          {categoryIcons[tx.category] ?? '📦'}
+        </div>
+        <div className="flex-1 min-w-0 text-left">
+          <p className="text-body font-semibold text-text-primary truncate">
+            {tx.merchant || tx.category}
+          </p>
+          <div className="flex items-center gap-xs">
+            <span className="text-small text-text-secondary bg-[#F0F0F0] rounded-sm px-2 py-0.5">
+              {categoryNames[tx.category] ?? tx.category}
+            </span>
+            <span className="text-small text-text-secondary">
+              · {formatTime(tx.createdAt)}
+            </span>
+          </div>
+        </div>
+        <p className="text-title font-semibold text-danger shrink-0">
+          -${tx.amount.toLocaleString()}
+        </p>
+        <span className={`text-text-tertiary text-sm transition-transform ${isExpanded ? 'rotate-180' : ''}`}>
+          ▼
+        </span>
+      </button>
+
+      {/* Expanded detail */}
+      {isExpanded && (
+        <div className="pb-md pl-14 pr-md animate-slide-down">
+          {showDeleteConfirm ? (
+            <div className="bg-danger-light rounded-md p-lg text-center" data-testid="delete-confirm-dialog">
+              <p className="text-body text-danger font-semibold mb-md">
+                確定要刪除這筆帳目嗎？
+              </p>
+              <p className="text-caption text-text-secondary mb-lg">
+                {tx.merchant} -${tx.amount.toLocaleString()}
+              </p>
+              <div className="flex gap-sm">
+                <button
+                  type="button"
+                  onClick={handleCancelDelete}
+                  className="flex-1 h-9 rounded-sm border border-border text-text-secondary text-body"
+                  disabled={isDeleting}
+                >
+                  取消
+                </button>
+                <button
+                  type="button"
+                  onClick={handleConfirmDelete}
+                  className="flex-1 h-9 rounded-sm bg-danger text-surface font-semibold text-body"
+                  disabled={isDeleting}
+                  data-testid="confirm-delete-btn"
+                >
+                  {isDeleting ? '刪除中...' : '確認刪除'}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <>
+              <div className="space-y-sm mb-lg">
+                <div className="flex items-center gap-md">
+                  <span className="text-caption text-text-secondary w-[50px] shrink-0">金額</span>
+                  <span className="text-body text-danger font-semibold">${tx.amount.toLocaleString()}</span>
+                </div>
+                <div className="flex items-center gap-md">
+                  <span className="text-caption text-text-secondary w-[50px] shrink-0">類別</span>
+                  <span className="text-body text-text-primary">
+                    {categoryIcons[tx.category] ?? '📦'} {categoryNames[tx.category] ?? tx.category}
+                  </span>
+                </div>
+                <div className="flex items-center gap-md">
+                  <span className="text-caption text-text-secondary w-[50px] shrink-0">商家</span>
+                  <span className="text-body text-text-primary">{tx.merchant || '--'}</span>
+                </div>
+                <div className="flex items-center gap-md">
+                  <span className="text-caption text-text-secondary w-[50px] shrink-0">日期</span>
+                  <span className="text-body text-text-primary">{formatDate(tx.transactionDate)}</span>
+                </div>
+                {tx.note && (
+                  <div className="flex items-start gap-md">
+                    <span className="text-caption text-text-secondary w-[50px] shrink-0">備註</span>
+                    <span className="text-caption text-text-secondary">{tx.note}</span>
+                  </div>
+                )}
+                {tx.rawText && (
+                  <div className="flex items-start gap-md">
+                    <span className="text-caption text-text-secondary w-[50px] shrink-0">原始輸入</span>
+                    <span className="text-caption text-text-secondary">{tx.rawText}</span>
+                  </div>
+                )}
+              </div>
+              <div className="flex gap-sm">
+                <button
+                  type="button"
+                  onClick={onToggle}
+                  className="flex-1 h-9 rounded-sm border border-border text-text-secondary text-body"
+                >
+                  收合
+                </button>
+                <button
+                  type="button"
+                  onClick={handleDeleteClick}
+                  className="flex-1 h-9 rounded-sm border border-danger text-danger text-body"
+                  data-testid="delete-btn"
+                >
+                  刪除
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default TransactionItem

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -1,26 +1,230 @@
+import { useEffect, useState, useCallback, useMemo } from 'react'
+import { useHistoryStore } from '../stores/historyStore'
+import TransactionItem from '../components/TransactionItem'
+import type { Transaction } from '../stores/index'
+
+const categoryOptions: { value: string; label: string }[] = [
+  { value: '', label: '全部類別' },
+  { value: 'food', label: '🍽️ 飲食' },
+  { value: 'transport', label: '🚌 交通' },
+  { value: 'entertainment', label: '🎬 娛樂' },
+  { value: 'shopping', label: '🛍️ 購物' },
+  { value: 'daily', label: '🧴 日用品' },
+  { value: 'medical', label: '🏥 醫療' },
+  { value: 'education', label: '📚 教育' },
+  { value: 'other', label: '📦 其他' },
+]
+
+function formatGroupDate(dateStr: string): string {
+  const today = new Date()
+  const todayStr = today.toISOString().split('T')[0]
+
+  const yesterday = new Date(today)
+  yesterday.setDate(yesterday.getDate() - 1)
+  const yesterdayStr = yesterday.toISOString().split('T')[0]
+
+  const d = dateStr.split('T')[0]
+  if (d === todayStr) return `${d}（今天）`
+  if (d === yesterdayStr) return `${d}（昨天）`
+  return d
+}
+
+function groupByDate(transactions: Transaction[]): Map<string, Transaction[]> {
+  const groups = new Map<string, Transaction[]>()
+  for (const tx of transactions) {
+    const dateKey = tx.transactionDate.split('T')[0]
+    const existing = groups.get(dateKey)
+    if (existing) {
+      existing.push(tx)
+    } else {
+      groups.set(dateKey, [tx])
+    }
+  }
+  return groups
+}
+
 function HistoryPage() {
+  const {
+    transactions,
+    filters,
+    hasMore,
+    isLoading,
+    isDeleting,
+    errorMessage,
+    fetchTransactions,
+    loadMore,
+    setFilters,
+    resetFilters,
+    deleteTransaction,
+  } = useHistoryStore()
+
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchTransactions(true)
+  }, [fetchTransactions])
+
+  const handleCategoryChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      setFilters({ category: e.target.value })
+      // Trigger re-fetch after state update
+      setTimeout(() => useHistoryStore.getState().fetchTransactions(true), 0)
+    },
+    [setFilters]
+  )
+
+  const handleStartDateChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setFilters({ startDate: e.target.value })
+      setTimeout(() => useHistoryStore.getState().fetchTransactions(true), 0)
+    },
+    [setFilters]
+  )
+
+  const handleEndDateChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setFilters({ endDate: e.target.value })
+      setTimeout(() => useHistoryStore.getState().fetchTransactions(true), 0)
+    },
+    [setFilters]
+  )
+
+  const handleResetFilters = useCallback(() => {
+    resetFilters()
+    setTimeout(() => useHistoryStore.getState().fetchTransactions(true), 0)
+  }, [resetFilters])
+
+  const handleToggle = useCallback((id: string) => {
+    setExpandedId((prev) => (prev === id ? null : id))
+  }, [])
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      await deleteTransaction(id)
+      setExpandedId(null)
+    },
+    [deleteTransaction]
+  )
+
+  const grouped = useMemo(() => groupByDate(transactions), [transactions])
+
+  const hasActiveFilters = filters.category || filters.startDate || filters.endDate
+
   return (
-    <div className="p-2xl">
+    <div className="p-2xl pb-32">
       <header className="h-14 flex items-center justify-between mb-lg">
         <h1 className="text-title font-semibold text-text-primary">
           📋 記錄
         </h1>
       </header>
 
-      <div className="flex gap-sm mb-xl">
-        <button className="px-lg py-sm bg-bg rounded-xl text-caption text-text-secondary">
-          全部類別
-        </button>
-        <button className="px-lg py-sm bg-bg rounded-xl text-caption text-text-secondary">
-          本月
-        </button>
+      {/* Filter section */}
+      <div className="space-y-sm mb-xl" data-testid="filter-section">
+        <div className="flex gap-sm items-center flex-wrap">
+          <select
+            value={filters.category}
+            onChange={handleCategoryChange}
+            className="px-lg py-sm bg-bg rounded-xl text-caption text-text-secondary border-0 outline-none cursor-pointer"
+            aria-label="類別篩選"
+            data-testid="category-filter"
+          >
+            {categoryOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+
+          <input
+            type="date"
+            value={filters.startDate}
+            onChange={handleStartDateChange}
+            className="px-lg py-sm bg-bg rounded-xl text-caption text-text-secondary border-0 outline-none"
+            aria-label="開始日期"
+            data-testid="start-date-filter"
+          />
+          <span className="text-text-tertiary text-caption">至</span>
+          <input
+            type="date"
+            value={filters.endDate}
+            onChange={handleEndDateChange}
+            className="px-lg py-sm bg-bg rounded-xl text-caption text-text-secondary border-0 outline-none"
+            aria-label="結束日期"
+            data-testid="end-date-filter"
+          />
+
+          {hasActiveFilters && (
+            <button
+              type="button"
+              onClick={handleResetFilters}
+              className="px-lg py-sm bg-danger-light rounded-xl text-caption text-danger"
+              data-testid="reset-filters-btn"
+            >
+              清除篩選
+            </button>
+          )}
+        </div>
       </div>
 
-      <div className="text-center py-3xl">
-        <p className="text-body text-text-tertiary">
-          還沒有記帳紀錄，開始記帳吧！
-        </p>
-      </div>
+      {/* Error message */}
+      {errorMessage && (
+        <div className="mb-lg p-md bg-danger-light rounded-md text-danger text-body text-center" data-testid="error-message">
+          {errorMessage}
+        </div>
+      )}
+
+      {/* Transaction list */}
+      {transactions.length === 0 && !isLoading ? (
+        <div className="text-center py-3xl" data-testid="empty-state">
+          <p className="text-body text-text-tertiary">
+            還沒有記帳紀錄，開始記帳吧！
+          </p>
+        </div>
+      ) : (
+        <div data-testid="transaction-list">
+          {Array.from(grouped.entries()).map(([dateKey, txList]) => (
+            <div key={dateKey} className="mb-lg">
+              <div className="sticky top-0 bg-bg py-sm px-2xl -mx-2xl text-caption text-text-secondary z-10">
+                {formatGroupDate(dateKey)}
+              </div>
+              <div className="bg-surface rounded-lg shadow-card">
+                {txList.map((tx) => (
+                  <TransactionItem
+                    key={tx.id}
+                    transaction={tx}
+                    isExpanded={expandedId === tx.id}
+                    onToggle={() => handleToggle(tx.id)}
+                    onDelete={handleDelete}
+                    isDeleting={isDeleting === tx.id}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+
+          {/* Load more */}
+          {hasMore && (
+            <div className="text-center py-lg">
+              <button
+                type="button"
+                onClick={loadMore}
+                disabled={isLoading}
+                className="px-xl py-sm bg-primary text-surface rounded-lg text-body font-semibold disabled:opacity-50"
+                data-testid="load-more-btn"
+              >
+                {isLoading ? '載入中...' : '載入更多'}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Loading indicator for initial load */}
+      {isLoading && transactions.length === 0 && (
+        <div className="text-center py-3xl" data-testid="loading-state">
+          <p className="text-body text-text-secondary">載入中...</p>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/stores/historyStore.ts
+++ b/frontend/src/stores/historyStore.ts
@@ -1,0 +1,126 @@
+import { create } from 'zustand'
+import api from '../lib/api'
+import type { Transaction } from '../stores/index'
+
+export interface HistoryFilters {
+  category: string
+  startDate: string
+  endDate: string
+}
+
+interface HistoryState {
+  transactions: Transaction[]
+  filters: HistoryFilters
+  page: number
+  hasMore: boolean
+  isLoading: boolean
+  isDeleting: string | null
+  errorMessage: string
+
+  // Actions
+  fetchTransactions: (reset?: boolean) => Promise<void>
+  loadMore: () => Promise<void>
+  setFilters: (filters: Partial<HistoryFilters>) => void
+  resetFilters: () => void
+  deleteTransaction: (id: string) => Promise<void>
+}
+
+const PAGE_SIZE = 20
+
+const defaultFilters: HistoryFilters = {
+  category: '',
+  startDate: '',
+  endDate: '',
+}
+
+export const useHistoryStore = create<HistoryState>((set, get) => ({
+  transactions: [],
+  filters: { ...defaultFilters },
+  page: 1,
+  hasMore: true,
+  isLoading: false,
+  isDeleting: null,
+  errorMessage: '',
+
+  fetchTransactions: async (reset = true) => {
+    const state = get()
+    if (state.isLoading) return
+
+    const page = reset ? 1 : state.page
+    set({ isLoading: true, errorMessage: '' })
+
+    try {
+      const params: Record<string, string | number> = {
+        page,
+        limit: PAGE_SIZE,
+        sort: 'desc',
+      }
+      if (state.filters.category) params.category = state.filters.category
+      if (state.filters.startDate) params.start_date = state.filters.startDate
+      if (state.filters.endDate) params.end_date = state.filters.endDate
+
+      const res = await api.get('/transactions', { params })
+      const items: Transaction[] = res.data.data.items.map(
+        (t: Record<string, unknown>) => ({
+          id: t.id as string,
+          amount: t.amount as number,
+          category: t.category as string,
+          merchant: t.merchant as string,
+          rawText: (t.raw_text as string) ?? '',
+          note: (t.note as string) ?? undefined,
+          transactionDate: t.transaction_date as string,
+          createdAt: t.created_at as string,
+        })
+      )
+
+      const hasMore = items.length >= PAGE_SIZE
+
+      if (reset) {
+        set({ transactions: items, page: 2, hasMore, isLoading: false })
+      } else {
+        set((s) => ({
+          transactions: [...s.transactions, ...items],
+          page: s.page + 1,
+          hasMore,
+          isLoading: false,
+        }))
+      }
+    } catch (err: unknown) {
+      const message =
+        (err as { response?: { data?: { message?: string } } })?.response?.data
+          ?.message ?? '載入交易記錄失敗'
+      set({ isLoading: false, errorMessage: message })
+    }
+  },
+
+  loadMore: async () => {
+    const state = get()
+    if (state.isLoading || !state.hasMore) return
+    await get().fetchTransactions(false)
+  },
+
+  setFilters: (filters) => {
+    set((s) => ({ filters: { ...s.filters, ...filters } }))
+  },
+
+  resetFilters: () => {
+    set({ filters: { ...defaultFilters } })
+  },
+
+  deleteTransaction: async (id: string) => {
+    set({ isDeleting: id, errorMessage: '' })
+    try {
+      await api.delete(`/transactions/${id}`)
+      set((s) => ({
+        transactions: s.transactions.filter((tx) => tx.id !== id),
+        isDeleting: null,
+      }))
+    } catch (err: unknown) {
+      const message =
+        (err as { response?: { data?: { message?: string } } })?.response?.data
+          ?.message ?? '刪除失敗，請稍後重試'
+      set({ isDeleting: null, errorMessage: message })
+      throw err
+    }
+  },
+}))

--- a/frontend/src/test/HistoryPage.test.tsx
+++ b/frontend/src/test/HistoryPage.test.tsx
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import HistoryPage from '../pages/HistoryPage'
+import { useHistoryStore } from '../stores/historyStore'
+
+// Mock api module
+vi.mock('../lib/api', () => ({
+  default: {
+    get: vi.fn().mockResolvedValue({ data: { data: { items: [] } } }),
+    delete: vi.fn().mockResolvedValue({}),
+    interceptors: {
+      request: { use: vi.fn() },
+      response: { use: vi.fn() },
+    },
+  },
+}))
+
+const mockTransactions = [
+  {
+    id: 'tx-1',
+    amount: 250,
+    category: 'food',
+    merchant: '拉麵店',
+    rawText: '午餐吃拉麵 250',
+    note: '很好吃',
+    transactionDate: '2026-03-19',
+    createdAt: '2026-03-19T13:07:00Z',
+  },
+  {
+    id: 'tx-2',
+    amount: 35,
+    category: 'transport',
+    merchant: '捷運',
+    rawText: '搭捷運 35',
+    transactionDate: '2026-03-19',
+    createdAt: '2026-03-19T08:30:00Z',
+  },
+  {
+    id: 'tx-3',
+    amount: 500,
+    category: 'shopping',
+    merchant: '百貨公司',
+    rawText: '買衣服 500',
+    transactionDate: '2026-03-18',
+    createdAt: '2026-03-18T14:00:00Z',
+  },
+]
+
+// Override fetchTransactions to be a no-op in tests (we set state directly)
+function setStoreState(overrides: Partial<ReturnType<typeof useHistoryStore.getState>>) {
+  useHistoryStore.setState({
+    ...overrides,
+    // Override fetchTransactions to avoid API calls during render
+    fetchTransactions: vi.fn(),
+    loadMore: vi.fn(),
+    deleteTransaction: vi.fn().mockResolvedValue(undefined),
+  })
+}
+
+describe('HistoryPage', () => {
+  beforeEach(() => {
+    setStoreState({
+      transactions: [],
+      filters: { category: '', startDate: '', endDate: '' },
+      page: 1,
+      hasMore: true,
+      isLoading: false,
+      isDeleting: null,
+      errorMessage: '',
+    })
+  })
+
+  it('renders empty state when no transactions', () => {
+    setStoreState({
+      transactions: [],
+      hasMore: false,
+      isLoading: false,
+    })
+    render(<HistoryPage />)
+    expect(screen.getByText('還沒有記帳紀錄，開始記帳吧！')).toBeInTheDocument()
+  })
+
+  it('renders transaction list with correct data', () => {
+    setStoreState({
+      transactions: mockTransactions,
+      hasMore: false,
+      isLoading: false,
+    })
+    render(<HistoryPage />)
+
+    expect(screen.getByText('拉麵店')).toBeInTheDocument()
+    expect(screen.getByText('捷運')).toBeInTheDocument()
+    expect(screen.getByText('百貨公司')).toBeInTheDocument()
+    expect(screen.getByText('-$250')).toBeInTheDocument()
+    expect(screen.getByText('-$35')).toBeInTheDocument()
+    expect(screen.getByText('-$500')).toBeInTheDocument()
+  })
+
+  it('renders filter controls', () => {
+    setStoreState({ transactions: [], hasMore: false, isLoading: false })
+    render(<HistoryPage />)
+
+    expect(screen.getByLabelText('類別篩選')).toBeInTheDocument()
+    expect(screen.getByLabelText('開始日期')).toBeInTheDocument()
+    expect(screen.getByLabelText('結束日期')).toBeInTheDocument()
+  })
+
+  it('shows category filter options', () => {
+    setStoreState({ transactions: [], hasMore: false, isLoading: false })
+    render(<HistoryPage />)
+
+    const select = screen.getByLabelText('類別篩選') as HTMLSelectElement
+    const options = select.querySelectorAll('option')
+    expect(options.length).toBe(9) // 全部 + 8 categories
+  })
+
+  it('shows load more button when hasMore is true', () => {
+    setStoreState({
+      transactions: mockTransactions,
+      hasMore: true,
+      isLoading: false,
+    })
+    render(<HistoryPage />)
+    expect(screen.getByTestId('load-more-btn')).toBeInTheDocument()
+    expect(screen.getByText('載入更多')).toBeInTheDocument()
+  })
+
+  it('hides load more button when hasMore is false', () => {
+    setStoreState({
+      transactions: mockTransactions,
+      hasMore: false,
+      isLoading: false,
+    })
+    render(<HistoryPage />)
+    expect(screen.queryByTestId('load-more-btn')).not.toBeInTheDocument()
+  })
+
+  it('shows error message when errorMessage is set', () => {
+    setStoreState({
+      transactions: [],
+      hasMore: false,
+      isLoading: false,
+      errorMessage: '載入失敗',
+    })
+    render(<HistoryPage />)
+    expect(screen.getByTestId('error-message')).toBeInTheDocument()
+    expect(screen.getByText('載入失敗')).toBeInTheDocument()
+  })
+
+  it('shows loading state', () => {
+    setStoreState({
+      transactions: [],
+      hasMore: true,
+      isLoading: true,
+    })
+    render(<HistoryPage />)
+    expect(screen.getByTestId('loading-state')).toBeInTheDocument()
+  })
+
+  it('shows reset filters button when filters are active', () => {
+    setStoreState({
+      transactions: [],
+      hasMore: false,
+      isLoading: false,
+      filters: { category: 'food', startDate: '', endDate: '' },
+    })
+    render(<HistoryPage />)
+    expect(screen.getByTestId('reset-filters-btn')).toBeInTheDocument()
+  })
+
+  it('does not show reset filters button when no filters active', () => {
+    setStoreState({
+      transactions: [],
+      hasMore: false,
+      isLoading: false,
+      filters: { category: '', startDate: '', endDate: '' },
+    })
+    render(<HistoryPage />)
+    expect(screen.queryByTestId('reset-filters-btn')).not.toBeInTheDocument()
+  })
+})
+
+describe('TransactionItem interactions', () => {
+  beforeEach(() => {
+    setStoreState({
+      transactions: mockTransactions,
+      filters: { category: '', startDate: '', endDate: '' },
+      page: 1,
+      hasMore: false,
+      isLoading: false,
+      isDeleting: null,
+      errorMessage: '',
+    })
+  })
+
+  it('expands transaction details on click', async () => {
+    const user = userEvent.setup()
+    render(<HistoryPage />)
+
+    const txButton = screen.getByText('拉麵店').closest('button')!
+    await user.click(txButton)
+
+    // Should show expanded details
+    expect(screen.getByText('$250')).toBeInTheDocument()
+    expect(screen.getByText('很好吃')).toBeInTheDocument()
+    expect(screen.getByText('午餐吃拉麵 250')).toBeInTheDocument()
+  })
+
+  it('collapses on second click (accordion)', async () => {
+    const user = userEvent.setup()
+    render(<HistoryPage />)
+
+    const txButton = screen.getByText('拉麵店').closest('button')!
+    await user.click(txButton)
+    expect(screen.getByText('$250')).toBeInTheDocument()
+
+    await user.click(txButton)
+    expect(screen.queryByText('午餐吃拉麵 250')).not.toBeInTheDocument()
+  })
+
+  it('shows delete confirmation dialog', async () => {
+    const user = userEvent.setup()
+    render(<HistoryPage />)
+
+    const txButton = screen.getByText('拉麵店').closest('button')!
+    await user.click(txButton)
+
+    const deleteBtn = screen.getByTestId('delete-btn')
+    await user.click(deleteBtn)
+
+    expect(screen.getByTestId('delete-confirm-dialog')).toBeInTheDocument()
+    expect(screen.getByText('確定要刪除這筆帳目嗎？')).toBeInTheDocument()
+  })
+
+  it('cancels delete confirmation', async () => {
+    const user = userEvent.setup()
+    render(<HistoryPage />)
+
+    const txButton = screen.getByText('拉麵店').closest('button')!
+    await user.click(txButton)
+
+    const deleteBtn = screen.getByTestId('delete-btn')
+    await user.click(deleteBtn)
+
+    const cancelBtn = screen.getByText('取消')
+    await user.click(cancelBtn)
+
+    expect(screen.queryByTestId('delete-confirm-dialog')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## 變更摘要
將交易記錄頁面從靜態 mockup 改為完整功能頁面：按日期分組顯示、類別/日期篩選、手風琴展開詳情、刪除二次確認、分頁載入更多。

## 關聯 Issue
Closes #14

## 變更清單
- `HistoryPage.tsx` — 完整交易記錄頁（篩選/分組/分頁）
- `TransactionItem.tsx` — 可重用交易項目組件（展開/刪除確認）
- `historyStore.ts` — Zustand store（分頁/篩選/刪除）
- `HistoryPage.test.tsx` — 14 個測試（渲染/篩選/載入更多/展開/刪除）

## 測試結果
- 前端測試：✅ 全部通過（110/110）
- Build：✅ TypeScript 編譯通過
- Lint：✅ 零錯誤