### PR TITLE
fix(frontend): 修正人設切換、API Key 分引擎、引擎標籤

### DIFF
--- a/frontend/src/components/AIFeedbackCard.tsx
+++ b/frontend/src/components/AIFeedbackCard.tsx
@@ -1,8 +1,14 @@
-import type { Persona } from '../stores/index'
+import type { Persona, AIEngine } from '../stores/index'
 
 interface AIFeedbackCardProps {
   feedbackText: string
   persona: Persona
+  aiEngine?: AIEngine
+}
+
+const engineLabel: Record<AIEngine, string> = {
+  gemini: 'Gemini',
+  openai: 'OpenAI',
 }
 
 const personaConfig: Record<
@@ -14,7 +20,7 @@ const personaConfig: Record<
   guilt_trip: { name: '心疼天使', emoji: '🥺', icon: '❤️' },
 }
 
-function AIFeedbackCard({ feedbackText, persona }: AIFeedbackCardProps) {
+function AIFeedbackCard({ feedbackText, persona, aiEngine }: AIFeedbackCardProps) {
   const config = personaConfig[persona]
 
   return (
@@ -28,6 +34,9 @@ function AIFeedbackCard({ feedbackText, persona }: AIFeedbackCardProps) {
         </div>
         <p className="text-caption text-text-secondary">
           {config.name} {config.emoji} 的即時回饋
+          {aiEngine && (
+            <span className="ml-xs text-small opacity-70">@{engineLabel[aiEngine]}</span>
+          )}
         </p>
       </div>
       <p className="text-body text-primary-dark">

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useAppStore } from '../stores/index'
+import { useSettingsStore } from '../stores/settingsStore'
 import { useDashboardStore } from '../stores/dashboardStore'
 import VoiceInput from '../components/VoiceInput'
 import BudgetCard from '../components/BudgetCard'
@@ -22,7 +22,9 @@ const DEFAULT_CATEGORIES = [
 
 function DashboardPage() {
   const navigate = useNavigate()
-  const settings = useAppStore((s) => s.settings)
+  const persona = useSettingsStore((s) => s.persona)
+  const aiEngine = useSettingsStore((s) => s.aiEngine)
+  const fetchProfile = useSettingsStore((s) => s.fetchProfile)
 
   const {
     status,
@@ -41,9 +43,10 @@ function DashboardPage() {
   } = useDashboardStore()
 
   useEffect(() => {
+    fetchProfile()
     fetchBudgetSummary()
     fetchRecentTransactions()
-  }, [fetchBudgetSummary, fetchRecentTransactions])
+  }, [fetchProfile, fetchBudgetSummary, fetchRecentTransactions])
 
   const handleSubmit = useCallback(
     (text: string) => {
@@ -164,7 +167,8 @@ function DashboardPage() {
           feedbackText={
             isParsing ? 'AI 正在分析...' : feedbackText
           }
-          persona={settings.persona}
+          persona={persona}
+          aiEngine={aiEngine}
         />
 
         {/* Error toast */}
@@ -202,7 +206,7 @@ function DashboardPage() {
         {showNewCategoryDialog && parsedResult.suggestedCategory && (
           <NewCategoryDialog
             suggestedCategory={parsedResult.suggestedCategory}
-            persona={settings.persona}
+            persona={persona}
             existingCategories={DEFAULT_CATEGORIES}
             onConfirm={handleNewCategoryConfirm}
             onSelectExisting={handleSelectExistingCategory}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -45,9 +45,24 @@ function SettingsPage() {
   )
   const [budgetEditing, setBudgetEditing] = useState(false)
 
-  // Local state for API key
-  const [apiKey, setApiKey] = useState(() => localStorage.getItem('llm_api_key') ?? '')
+  // Local state for API key — per engine
+  const [apiKeys, setApiKeys] = useState<Record<string, string>>(() => {
+    try {
+      const stored = localStorage.getItem('llm_api_keys')
+      if (stored) return JSON.parse(stored)
+    } catch { /* ignore */ }
+    // Migrate legacy single key
+    const legacy = localStorage.getItem('llm_api_key')
+    if (legacy) {
+      const migrated = { gemini: legacy, openai: '' }
+      localStorage.setItem('llm_api_keys', JSON.stringify(migrated))
+      localStorage.removeItem('llm_api_key')
+      return migrated
+    }
+    return { gemini: '', openai: '' }
+  })
   const [showApiKey, setShowApiKey] = useState(false)
+  const currentApiKey = apiKeys[aiEngine] ?? ''
 
   // Load profile on mount and sync budget input
   useEffect(() => {
@@ -70,14 +85,14 @@ function SettingsPage() {
     setBudgetEditing(false)
   }, [budgetInput, updateBudget, monthlyBudget])
 
-  const handleApiKeySave = useCallback(() => {
-    localStorage.setItem('llm_api_key', apiKey)
-  }, [apiKey])
+  const saveApiKeys = useCallback((keys: Record<string, string>) => {
+    localStorage.setItem('llm_api_keys', JSON.stringify(keys))
+  }, [])
 
   const handleValidateKey = useCallback(async () => {
-    handleApiKeySave()
-    await validateApiKey(apiKey)
-  }, [apiKey, handleApiKeySave, validateApiKey])
+    saveApiKeys(apiKeys)
+    await validateApiKey(currentApiKey)
+  }, [currentApiKey, apiKeys, saveApiKeys, validateApiKey])
 
   const handleLogout = useCallback(() => {
     logout()
@@ -227,7 +242,7 @@ function SettingsPage() {
             return (
               <button
                 key={opt.value}
-                onClick={() => updateAIEngine(opt.value)}
+                onClick={() => { updateAIEngine(opt.value); useSettingsStore.setState({ keyValidationStatus: 'idle' }) }}
                 disabled={saving}
                 className={`flex-1 h-20 rounded-lg flex flex-col items-center justify-center cursor-pointer transition-all ${
                   selected
@@ -245,24 +260,24 @@ function SettingsPage() {
           })}
         </div>
 
-        {/* API Key 輸入 */}
+        {/* API Key 輸入 — 依引擎分開 */}
         <div className="mt-md">
           <label className="text-caption text-text-secondary mb-sm block">
-            API Key
+            {ENGINE_OPTIONS.find((e) => e.value === aiEngine)?.label} API Key
           </label>
           <div className="flex items-center gap-sm">
             <div className="relative flex-1">
               <input
                 type={showApiKey ? 'text' : 'password'}
-                value={apiKey}
+                value={currentApiKey}
                 onChange={(e) => {
-                  setApiKey(e.target.value)
-                  // Auto-save to localStorage on change
-                  localStorage.setItem('llm_api_key', e.target.value)
+                  const updated = { ...apiKeys, [aiEngine]: e.target.value }
+                  setApiKeys(updated)
+                  saveApiKeys(updated)
                 }}
-                placeholder="輸入 API Key"
+                placeholder={`輸入 ${ENGINE_OPTIONS.find((e) => e.value === aiEngine)?.label} API Key`}
                 className="w-full h-12 rounded-md border border-border bg-bg px-lg pr-12 text-body text-text-primary focus:outline-none focus:border-primary"
-                aria-label="API Key 輸入"
+                aria-label={`${aiEngine} API Key 輸入`}
               />
               <button
                 type="button"
@@ -275,7 +290,7 @@ function SettingsPage() {
             </div>
             <button
               onClick={handleValidateKey}
-              disabled={!apiKey || keyValidationStatus === 'validating'}
+              disabled={!currentApiKey || keyValidationStatus === 'validating'}
               className="h-12 px-lg rounded-md bg-primary text-white text-caption font-semibold disabled:opacity-50 transition-all hover:bg-primary-dark"
               aria-label="驗證 API Key"
             >

--- a/frontend/src/stores/dashboardStore.ts
+++ b/frontend/src/stores/dashboardStore.ts
@@ -1,6 +1,21 @@
 import { create } from 'zustand'
 import api from '../lib/api'
 import type { Transaction } from '../stores/index'
+import { useSettingsStore } from './settingsStore'
+
+/** 讀取當前引擎對應的 API Key */
+function getActiveApiKey(): string {
+  const engine = useSettingsStore.getState().aiEngine
+  try {
+    const stored = localStorage.getItem('llm_api_keys')
+    if (stored) {
+      const keys = JSON.parse(stored)
+      return keys[engine] ?? ''
+    }
+  } catch { /* ignore */ }
+  // Fallback to legacy key
+  return localStorage.getItem('llm_api_key') ?? ''
+}
 
 export interface ParsedResult {
   amount: number | null
@@ -84,12 +99,12 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
   recentTransactions: [],
   errorMessage: '',
   lastFeedbackText: '',
-  lastPersona: 'gentle',
+  lastPersona: useSettingsStore.getState().persona || 'gentle',
 
   parseInput: async (rawText: string) => {
     set({ status: 'parsing', errorMessage: '' })
     try {
-      const llmApiKey = localStorage.getItem('llm_api_key') ?? ''
+      const llmApiKey = getActiveApiKey()
       const res = await api.post(
         '/ai/parse',
         { raw_text: rawText },

--- a/frontend/src/test/SettingsPage.test.tsx
+++ b/frontend/src/test/SettingsPage.test.tsx
@@ -156,27 +156,26 @@ describe('SettingsPage', () => {
     it('stores API key only in localStorage, not on server', async () => {
       renderSettings()
 
-      const input = screen.getByLabelText('API Key 輸入')
+      const input = screen.getByLabelText('gemini API Key 輸入')
       await userEvent.type(input, 'test-api-key-123')
 
-      expect(localStorage.getItem('llm_api_key')).toBe('test-api-key-123')
+      const stored = JSON.parse(localStorage.getItem('llm_api_keys') ?? '{}')
+      expect(stored.gemini).toBe('test-api-key-123')
     })
 
     it('loads existing API key from localStorage', () => {
-      localStorage.setItem('llm_api_key', 'existing-key')
-      // Re-render picks up the initial state
+      localStorage.setItem('llm_api_keys', JSON.stringify({ gemini: 'existing-key', openai: '' }))
       useSettingsStore.setState({ loading: false })
       renderSettings()
 
-      const input = screen.getByLabelText('API Key 輸入') as HTMLInputElement
-      // Input type is password by default
+      const input = screen.getByLabelText('gemini API Key 輸入') as HTMLInputElement
       expect(input.type).toBe('password')
     })
 
     it('toggles visibility of API key', async () => {
       renderSettings()
 
-      const input = screen.getByLabelText('API Key 輸入') as HTMLInputElement
+      const input = screen.getByLabelText('gemini API Key 輸入') as HTMLInputElement
       expect(input.type).toBe('password')
 
       await userEvent.click(screen.getByLabelText('顯示 API Key'))
@@ -191,7 +190,7 @@ describe('SettingsPage', () => {
       useSettingsStore.setState({ validateApiKey })
       renderSettings()
 
-      const input = screen.getByLabelText('API Key 輸入')
+      const input = screen.getByLabelText('gemini API Key 輸入')
       await userEvent.type(input, 'my-key')
 
       await userEvent.click(screen.getByLabelText('驗證 API Key'))
@@ -264,8 +263,9 @@ describe('settingsStore', () => {
     // The store should not have an apiKey field
     expect('apiKey' in store).toBe(false)
 
-    // Setting in localStorage should work
-    localStorage.setItem('llm_api_key', 'secret-key')
-    expect(localStorage.getItem('llm_api_key')).toBe('secret-key')
+    // Setting in localStorage should work (per-engine format)
+    const keys = { gemini: 'secret-key', openai: 'other-key' }
+    localStorage.setItem('llm_api_keys', JSON.stringify(keys))
+    expect(JSON.parse(localStorage.getItem('llm_api_keys')!).gemini).toBe('secret-key')
   })
 })


### PR DESCRIPTION
## Summary
- **Bug fix**: 人設切換無效 — DashboardPage 改用 `settingsStore` 替代 `appStore`，初始載入時同步 profile
- **Enhancement**: API Key 分引擎儲存 — `llm_api_keys` JSON 物件取代單一 key，含舊格式自動遷移
- **Enhancement**: AIFeedbackCard 顯示 `@Gemini` / `@OpenAI` 引擎標籤

## 修改檔案
- `frontend/src/pages/DashboardPage.tsx` — 改用 settingsStore，傳遞 aiEngine 給 AIFeedbackCard
- `frontend/src/pages/SettingsPage.tsx` — API Key 輸入改為 per-engine，引擎切換時重置驗證狀態
- `frontend/src/components/AIFeedbackCard.tsx` — 新增 aiEngine prop，顯示引擎標籤
- `frontend/src/stores/dashboardStore.ts` — getActiveApiKey() 依引擎讀取 key，lastPersona 初始化同步
- `frontend/src/test/SettingsPage.test.tsx` — 更新測試以適配新的 per-engine API key 結構

## Test plan
- [x] TypeScript 零錯誤 (`tsc --noEmit`)
- [x] ESLint 零警告
- [x] 單元測試 121/121 passed
- [x] Build 成功