### PR TITLE
fix(frontend): 修復頁面刷新後登入狀態遺失 (#60)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react'
 import { Routes, Route, useLocation } from 'react-router-dom'
 import Layout from './components/Layout.tsx'
 import ProtectedRoute from './components/ProtectedRoute.tsx'
@@ -8,16 +7,10 @@ import HistoryPage from './pages/HistoryPage.tsx'
 import SettingsPage from './pages/SettingsPage.tsx'
 import LoginPage from './pages/LoginPage.tsx'
 import RegisterPage from './pages/RegisterPage.tsx'
-import { useAuthStore } from './stores/authStore.ts'
 
 function App() {
   const location = useLocation()
   const hideTabBar = ['/login', '/register'].includes(location.pathname)
-  const restoreSession = useAuthStore((state) => state.restoreSession)
-
-  useEffect(() => {
-    restoreSession()
-  }, [restoreSession])
 
   return (
     <Routes>

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -11,7 +11,12 @@ interface ProtectedRouteProps {
  */
 function ProtectedRoute({ children }: ProtectedRouteProps) {
   const token = useAuthStore((state) => state.token)
+  const isInitialized = useAuthStore((state) => state.isInitialized)
   const location = useLocation()
+
+  if (!isInitialized) {
+    return null
+  }
 
   if (!token) {
     return <Navigate to="/login" state={{ from: location.pathname }} replace />

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -17,6 +17,8 @@ interface AuthState {
   loading: boolean
   /** 錯誤訊息 */
   error: string | null
+  /** Session 是否已初始化（從 localStorage 恢復完成） */
+  isInitialized: boolean
 
   /** 登入 */
   login: (email: string, password: string) => Promise<void>
@@ -30,11 +32,30 @@ interface AuthState {
   clearError: () => void
 }
 
+/** 同步從 localStorage 恢復 session，用於 store 初始化 */
+function restoreFromLocalStorage(): { user: User | null; token: string | null } {
+  const token = localStorage.getItem('auth_token')
+  const userJson = localStorage.getItem('auth_user')
+  if (token && userJson) {
+    try {
+      const user = JSON.parse(userJson) as User
+      return { user, token }
+    } catch {
+      localStorage.removeItem('auth_token')
+      localStorage.removeItem('auth_user')
+    }
+  }
+  return { user: null, token: null }
+}
+
+const initialSession = restoreFromLocalStorage()
+
 export const useAuthStore = create<AuthState>((set) => ({
-  user: null,
-  token: null,
+  user: initialSession.user,
+  token: initialSession.token,
   loading: false,
   error: null,
+  isInitialized: true,
 
   login: async (email: string, password: string) => {
     set({ loading: true, error: null })
@@ -80,17 +101,8 @@ export const useAuthStore = create<AuthState>((set) => ({
   },
 
   restoreSession: () => {
-    const token = localStorage.getItem('auth_token')
-    const userJson = localStorage.getItem('auth_user')
-    if (token && userJson) {
-      try {
-        const user = JSON.parse(userJson) as User
-        set({ user, token })
-      } catch {
-        localStorage.removeItem('auth_token')
-        localStorage.removeItem('auth_user')
-      }
-    }
+    const restored = restoreFromLocalStorage()
+    set({ user: restored.user, token: restored.token, isInitialized: true })
   },
 
   clearError: () => {

--- a/frontend/src/test/ProtectedRoute.test.tsx
+++ b/frontend/src/test/ProtectedRoute.test.tsx
@@ -29,6 +29,7 @@ describe('ProtectedRoute', () => {
       token: null,
       loading: false,
       error: null,
+      isInitialized: true,
     })
   })
 
@@ -77,5 +78,17 @@ describe('ProtectedRoute', () => {
 
     renderWithRouter('/dashboard')
     expect(screen.getByText('Login Page')).toBeInTheDocument()
+  })
+
+  it('renders nothing when isInitialized is false (session restoring)', () => {
+    useAuthStore.setState({
+      token: null,
+      user: null,
+      isInitialized: false,
+    })
+
+    renderWithRouter('/dashboard')
+    expect(screen.queryByText('Login Page')).not.toBeInTheDocument()
+    expect(screen.queryByText('Dashboard Content')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/test/authStore.test.ts
+++ b/frontend/src/test/authStore.test.ts
@@ -24,6 +24,7 @@ describe('Auth Store', () => {
       token: null,
       loading: false,
       error: null,
+      isInitialized: true,
     })
     // Clear localStorage
     localStorage.clear()
@@ -31,12 +32,13 @@ describe('Auth Store', () => {
   })
 
   describe('initial state', () => {
-    it('starts with null user and token', () => {
+    it('starts with null user and token when localStorage is empty', () => {
       const state = useAuthStore.getState()
       expect(state.user).toBeNull()
       expect(state.token).toBeNull()
       expect(state.loading).toBe(false)
       expect(state.error).toBeNull()
+      expect(state.isInitialized).toBe(true)
     })
   })
 
@@ -215,6 +217,14 @@ describe('Auth Store', () => {
       expect(useAuthStore.getState().user).toBeNull()
       expect(localStorage.getItem('auth_token')).toBeNull()
       expect(localStorage.getItem('auth_user')).toBeNull()
+    })
+
+    it('sets isInitialized to true after restoreSession', () => {
+      useAuthStore.setState({ isInitialized: false })
+
+      useAuthStore.getState().restoreSession()
+
+      expect(useAuthStore.getState().isInitialized).toBe(true)
     })
   })
 


### PR DESCRIPTION
## Summary
- 修復頁面刷新後登入狀態遺失、跳回登入頁面的 bug
- authStore 在 store 建立時同步從 localStorage 恢復 session，避免 useEffect 異步執行造成的 race condition
- ProtectedRoute 新增 `isInitialized` 檢查，在 session 未恢復完成前不重定向

## Changes
- `frontend/src/stores/authStore.ts` — 新增 `isInitialized` 狀態，store 初始化時同步讀取 localStorage
- `frontend/src/components/ProtectedRoute.tsx` — 在 `isInitialized` 為 false 時 return null（不重定向）
- `frontend/src/App.tsx` — 移除不再需要的 `useEffect` restoreSession 呼叫
- `frontend/src/test/authStore.test.ts` — 更新測試覆蓋 `isInitialized` 邏輯
- `frontend/src/test/ProtectedRoute.test.tsx` — 新增 `isInitialized=false` 時不重定向的測試

## Test plan
- [x] TypeScript 型別檢查通過 (`tsc --noEmit`)
- [x] ESLint 檢查通過
- [x] 123 個單元測試全部通過
- [x] Production build 成功

Closes #60