### PR TITLE
fix: 收入/消費金額正負值處理與解析結果卡片取消按鈕 (#58, #59)

### DIFF
--- a/backend/prisma/migrations/20260319194011_add_transaction_type/migration.sql
+++ b/backend/prisma/migrations/20260319194011_add_transaction_type/migration.sql
@@ -1,0 +1,25 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_transactions" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "user_id" TEXT NOT NULL,
+    "type" TEXT NOT NULL DEFAULT 'expense',
+    "amount" DECIMAL NOT NULL,
+    "category" TEXT NOT NULL,
+    "merchant" TEXT,
+    "raw_text" TEXT NOT NULL,
+    "note" TEXT,
+    "transaction_date" DATETIME NOT NULL,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" DATETIME NOT NULL,
+    CONSTRAINT "transactions_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_transactions" ("amount", "category", "created_at", "id", "merchant", "note", "raw_text", "transaction_date", "updated_at", "user_id") SELECT "amount", "category", "created_at", "id", "merchant", "note", "raw_text", "transaction_date", "updated_at", "user_id" FROM "transactions";
+DROP TABLE "transactions";
+ALTER TABLE "new_transactions" RENAME TO "transactions";
+CREATE INDEX "transactions_user_id_idx" ON "transactions"("user_id");
+CREATE INDEX "transactions_user_id_transaction_date_idx" ON "transactions"("user_id", "transaction_date" DESC);
+CREATE INDEX "transactions_user_id_category_idx" ON "transactions"("user_id", "category");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -48,6 +48,7 @@ model CategoryBudget {
 model Transaction {
   id              String   @id @default(uuid())
   userId          String   @map("user_id")
+  type            String   @default("expense") // income, expense
   amount          Decimal
   category        String
   merchant        String?

--- a/backend/src/controllers/aiController.test.ts
+++ b/backend/src/controllers/aiController.test.ts
@@ -29,7 +29,7 @@ const MOCK_USER = {
 };
 
 const MOCK_TRANSACTIONS = [
-  { id: 't-1', userId: MOCK_USER_ID, amount: 500, category: 'food', merchant: '便當店', rawText: '午餐便當500', note: null, transactionDate: new Date(), createdAt: new Date(), updatedAt: new Date() },
+  { id: 't-1', userId: MOCK_USER_ID, type: 'expense', amount: 500, category: 'food', merchant: '便當店', rawText: '午餐便當500', note: null, transactionDate: new Date(), createdAt: new Date(), updatedAt: new Date() },
 ];
 
 // ─── Mock JWT ──────────────────────────────────────────────────
@@ -98,6 +98,7 @@ beforeEach(() => {
 
   // Default mock responses
   mockExtractData.mockResolvedValue({
+    type: 'expense',
     amount: 180,
     category: 'food',
     merchant: '拉麵店',
@@ -126,6 +127,7 @@ describe('POST /api/v1/ai/parse', () => {
     expect(res.body.code).toBe(200);
     expect(res.body.message).toBe('解析成功');
     expect(res.body.data.parsed).toEqual({
+      type: 'expense',
       amount: 180,
       category: 'food',
       merchant: '拉麵店',
@@ -144,6 +146,7 @@ describe('POST /api/v1/ai/parse', () => {
   // --- 案例 2: 無金額 ---
   it('應處理無法辨識金額的情境（amount 為 null）', async () => {
     mockExtractData.mockResolvedValue({
+      type: 'expense',
       amount: null,
       category: 'food',
       merchant: '餐廳',
@@ -162,6 +165,7 @@ describe('POST /api/v1/ai/parse', () => {
   // --- 案例 3: 新類別偵測 ---
   it('應偵測新類別並回傳 suggested_category', async () => {
     mockExtractData.mockResolvedValue({
+      type: 'expense',
       amount: 1200,
       category: null,
       merchant: '寵物店',
@@ -181,6 +185,7 @@ describe('POST /api/v1/ai/parse', () => {
   // --- 案例 4: 模糊類別 ---
   it('應處理模糊類別並降低 confidence', async () => {
     mockExtractData.mockResolvedValue({
+      type: 'expense',
       amount: 350,
       category: 'entertainment',
       merchant: '書店',
@@ -198,6 +203,7 @@ describe('POST /api/v1/ai/parse', () => {
   // --- 案例 5: 多筆消費（只處理第一筆）---
   it('應僅處理第一筆消費', async () => {
     mockExtractData.mockResolvedValue({
+      type: 'expense',
       amount: 100,
       category: 'food',
       merchant: '早餐店',
@@ -223,6 +229,25 @@ describe('POST /api/v1/ai/parse', () => {
     expect(ctx.remaining).toBe(29500);
     expect(ctx.category_spent).toBe(500); // food category
     expect(ctx.category_limit).toBe(8000);
+  });
+
+  // --- 案例 6b: 收入類型解析 ---
+  it('應正確解析收入類型（薪水入帳）', async () => {
+    mockExtractData.mockResolvedValue({
+      type: 'income',
+      amount: 50000,
+      category: 'other',
+      merchant: '公司',
+      date: '2026-03-18',
+      confidence: 0.95,
+      is_new_category: false,
+      suggested_category: null,
+    });
+
+    const res = await postParse('薪水入帳 50000 元');
+    expect(res.status).toBe(200);
+    expect(res.body.data.parsed.type).toBe('income');
+    expect(res.body.data.parsed.amount).toBe(50000);
   });
 
   // --- 案例 7: 缺少 X-LLM-API-Key ---

--- a/backend/src/controllers/transactionController.test.ts
+++ b/backend/src/controllers/transactionController.test.ts
@@ -11,6 +11,7 @@ const now = new Date();
 const mockTransactions: Record<string, {
   id: string;
   userId: string;
+  type: string;
   amount: number;
   category: string;
   merchant: string | null;
@@ -55,6 +56,7 @@ vi.mock('../config/database', () => ({
         const txn = {
           id,
           userId: data.userId as string,
+          type: (data.type as string) || 'expense',
           amount: data.amount as number,
           category: data.category as string,
           merchant: (data.merchant as string) || null,
@@ -339,6 +341,7 @@ describe('GET /api/v1/transactions/:id', () => {
     mockTransactions[otherId] = {
       id: otherId,
       userId: OTHER_USER_ID,
+      type: 'expense',
       amount: 999,
       category: 'food',
       merchant: '別人的店',
@@ -386,6 +389,7 @@ describe('DELETE /api/v1/transactions/:id', () => {
     mockTransactions[otherId] = {
       id: otherId,
       userId: OTHER_USER_ID,
+      type: 'expense',
       amount: 500,
       category: 'food',
       merchant: '別人的店',

--- a/backend/src/prompts/dataExtractorPrompt.ts
+++ b/backend/src/prompts/dataExtractorPrompt.ts
@@ -6,19 +6,24 @@ export function buildDataExtractorPrompt(input: DataExtractorInput): string {
   return `你是一個記帳助手，負責將使用者的自然語言輸入轉換為結構化的 JSON 資料。
 
 ## 規則
-1. 從使用者輸入中萃取：金額、類別、商家、日期
-2. 金額必須為正數。若無法辨識金額，回傳 amount 為 null
-3. 類別必須從以下清單中選擇：[${categoriesList}]
-4. 「other」僅用於真正無法歸類的雜項消費。若消費有明確主題（如寵物、健身、才藝、育兒等），不應歸入 other，而應設 is_new_category 為 true，並在 suggested_category 中填入建議的新類別名稱（使用中文）
-5. 偵測相似類別名稱（如「咖啡」與「飲料」），避免重複建立，優先歸入現有類別
-6. 若未提及商家，根據消費內容推測合理的商家名稱
-7. 若未提及日期，使用今天的日期：${input.currentDate}
-8. 僅處理第一筆消費，若包含多筆，忽略後續的
-9. confidence 值介於 0 到 1 之間，反映解析的確定性
+1. 從使用者輸入中萃取：交易類型、金額、類別、商家、日期
+2. **交易類型（type）**：判斷是收入（income）還是消費（expense）
+   - 收入關鍵字：薪水、薪資、獎金、紅包、退款、利息、收入、入帳、進帳、賣出、兼職、稿費、股息等
+   - 消費關鍵字：買、吃、喝、搭、付、花、繳、租、訂閱等（或任何花錢行為）
+   - 若無法明確判斷收入或消費，設 type 為 "expense"（預設為消費）
+3. 金額必須為正數。若無法辨識金額，回傳 amount 為 null
+4. 類別必須從以下清單中選擇：[${categoriesList}]
+5. 「other」僅用於真正無法歸類的雜項消費。若消費有明確主題（如寵物、健身、才藝、育兒等），不應歸入 other，而應設 is_new_category 為 true，並在 suggested_category 中填入建議的新類別名稱（使用中文）
+6. 偵測相似類別名稱（如「咖啡」與「飲料」），避免重複建立，優先歸入現有類別
+7. 若未提及商家，根據消費內容推測合理的商家名稱
+8. 若未提及日期，使用今天的日期：${input.currentDate}
+9. 僅處理第一筆消費，若包含多筆，忽略後續的
+10. confidence 值介於 0 到 1 之間，反映解析的確定性
 
 ## 輸出格式
 僅回傳以下 JSON，不要包含任何其他文字或 markdown 標記：
 {
+  "type": "<income | expense>",
   "amount": <number | null>,
   "category": "<string | null>",
   "merchant": "<string>",

--- a/backend/src/services/transactionService.ts
+++ b/backend/src/services/transactionService.ts
@@ -5,6 +5,7 @@ import { CreateTransactionInput, ListTransactionsInput } from '../validators/tra
 export async function createTransaction(userId: string, input: CreateTransactionInput) {
   const transactionData: {
     userId: string;
+    type: string;
     amount: number;
     category: string;
     merchant: string | undefined;
@@ -21,6 +22,7 @@ export async function createTransaction(userId: string, input: CreateTransaction
     };
   } = {
     userId,
+    type: input.type ?? 'expense',
     amount: input.amount,
     category: input.category,
     merchant: input.merchant || undefined,
@@ -104,13 +106,14 @@ export async function getTransaction(userId: string, id: string) {
 export async function updateTransaction(
   userId: string,
   id: string,
-  input: { amount?: number; category?: string; merchant?: string; transaction_date?: string; note?: string }
+  input: { type?: string; amount?: number; category?: string; merchant?: string; transaction_date?: string; note?: string }
 ) {
   const transaction = await prisma.transaction.findUnique({ where: { id } });
   if (!transaction) throw new AppError('交易記錄不存在', 404);
   if (transaction.userId !== userId) throw new AppError('交易記錄不存在', 404);
 
   const data: Record<string, unknown> = {};
+  if (input.type !== undefined) data.type = input.type;
   if (input.amount !== undefined) data.amount = input.amount;
   if (input.category !== undefined) data.category = input.category;
   if (input.merchant !== undefined) data.merchant = input.merchant;
@@ -146,6 +149,7 @@ export async function deleteTransaction(userId: string, id: string) {
 
 function formatTransaction(t: {
   id: string;
+  type: string;
   amount: unknown;
   category: string;
   merchant: string | null;
@@ -165,6 +169,7 @@ function formatTransaction(t: {
   return {
     transaction: {
       id: t.id,
+      type: t.type,
       amount: Number(t.amount),
       category: t.category,
       merchant: t.merchant,
@@ -188,6 +193,7 @@ function formatTransaction(t: {
 
 function formatTransactionListItem(t: {
   id: string;
+  type: string;
   amount: unknown;
   category: string;
   merchant: string | null;
@@ -197,6 +203,7 @@ function formatTransactionListItem(t: {
 }) {
   return {
     id: t.id,
+    type: t.type,
     amount: Number(t.amount),
     category: t.category,
     merchant: t.merchant,
@@ -208,6 +215,7 @@ function formatTransactionListItem(t: {
 
 function formatTransactionDetail(t: {
   id: string;
+  type: string;
   amount: unknown;
   category: string;
   merchant: string | null;
@@ -223,6 +231,7 @@ function formatTransactionDetail(t: {
 }) {
   return {
     id: t.id,
+    type: t.type,
     amount: Number(t.amount),
     category: t.category,
     merchant: t.merchant,

--- a/backend/src/types/llm.ts
+++ b/backend/src/types/llm.ts
@@ -1,7 +1,10 @@
 export type AIEngine = 'gemini' | 'openai';
 export type Persona = 'sarcastic' | 'gentle' | 'guilt_trip';
 
+export type TransactionType = 'income' | 'expense';
+
 export interface ParsedTransaction {
+  type: TransactionType;
   amount: number | null;
   category: string | null;
   merchant: string;

--- a/backend/src/validators/transactionValidators.ts
+++ b/backend/src/validators/transactionValidators.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod';
 
 export const createTransactionSchema = z.object({
+  type: z
+    .enum(['income', 'expense'], { message: '交易類型必須為 income 或 expense' })
+    .default('expense'),
   amount: z
     .number({ error: '金額為必填' })
     .positive('金額必須為正數'),

--- a/docs/API_Spec.yaml
+++ b/docs/API_Spec.yaml
@@ -329,6 +329,11 @@ paths:
               type: object
               required: [amount, category, raw_text, transaction_date]
               properties:
+                type:
+                  type: string
+                  enum: [income, expense]
+                  default: expense
+                  description: 交易類型（收入或消費）
                 amount:
                   type: number
                   format: decimal
@@ -758,6 +763,11 @@ components:
     ParsedTransaction:
       type: object
       properties:
+        type:
+          type: string
+          enum: [income, expense]
+          default: expense
+          description: 交易類型（收入或消費）
         amount:
           type: number
           format: decimal
@@ -814,6 +824,10 @@ components:
         id:
           type: string
           format: uuid
+        type:
+          type: string
+          enum: [income, expense]
+          default: expense
         amount:
           type: number
           format: decimal
@@ -841,6 +855,10 @@ components:
         id:
           type: string
           format: uuid
+        type:
+          type: string
+          enum: [income, expense]
+          default: expense
         amount:
           type: number
           format: decimal
@@ -861,6 +879,10 @@ components:
         id:
           type: string
           format: uuid
+        type:
+          type: string
+          enum: [income, expense]
+          default: expense
         amount:
           type: number
           format: decimal

--- a/frontend/src/components/ParsedResultCard.tsx
+++ b/frontend/src/components/ParsedResultCard.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react'
-import type { ParsedResult } from '../stores/dashboardStore'
+import type { ParsedResult, TransactionType } from '../stores/dashboardStore'
 
 interface ParsedResultCardProps {
   result: ParsedResult
   onConfirm: (data: {
+    type: TransactionType
     amount: number
     category: string
     merchant: string
@@ -24,13 +25,19 @@ const categoryNames: Record<string, string> = {
   other: '其他',
 }
 
+const typeLabels: Record<TransactionType, string> = {
+  income: '收入',
+  expense: '消費',
+}
+
 function ParsedResultCard({
   result,
   onConfirm,
   onCancel,
   categories,
 }: ParsedResultCardProps) {
-  const [isEditing, setIsEditing] = useState(false)
+  // Issue #59: default to edit mode
+  const [type, setType] = useState<TransactionType>(result.type ?? 'expense')
   const [amount, setAmount] = useState(result.amount?.toString() ?? '')
   const [category, setCategory] = useState(result.category ?? 'other')
   const [merchant, setMerchant] = useState(result.merchant ?? '')
@@ -40,6 +47,7 @@ function ParsedResultCard({
     const parsedAmount = parseFloat(amount)
     if (isNaN(parsedAmount) || parsedAmount <= 0) return
     onConfirm({
+      type,
       amount: parsedAmount,
       category,
       merchant,
@@ -47,98 +55,119 @@ function ParsedResultCard({
     })
   }
 
+  const isIncome = type === 'income'
+
   return (
     <div
-      className="bg-surface rounded-lg shadow-card border-l-4 border-l-primary p-lg mx-2xl mb-md"
+      className={`bg-surface rounded-lg shadow-card border-l-4 ${isIncome ? 'border-l-success' : 'border-l-primary'} p-lg mx-2xl mb-md`}
       role="region"
       aria-label="AI 解析結果"
     >
       <h3 className="text-body font-semibold text-text-primary mb-md">
-        ✨ AI 幫你整理好了
+        AI 幫你整理好了
       </h3>
 
       <div className="space-y-sm mb-lg">
+        {/* Issue #58: Transaction type selector */}
+        <div className="flex items-center gap-md">
+          <span className="text-caption text-text-secondary w-[60px] shrink-0">
+            類型
+          </span>
+          <div className="flex gap-sm" role="radiogroup" aria-label="交易類型">
+            <button
+              type="button"
+              onClick={() => setType('expense')}
+              className={`px-md py-xs rounded-md text-caption font-semibold transition-colors ${
+                type === 'expense'
+                  ? 'bg-danger text-surface'
+                  : 'bg-bg text-text-secondary border border-border'
+              }`}
+              role="radio"
+              aria-checked={type === 'expense'}
+              aria-label="消費"
+            >
+              {typeLabels.expense}
+            </button>
+            <button
+              type="button"
+              onClick={() => setType('income')}
+              className={`px-md py-xs rounded-md text-caption font-semibold transition-colors ${
+                type === 'income'
+                  ? 'bg-success text-surface'
+                  : 'bg-bg text-text-secondary border border-border'
+              }`}
+              role="radio"
+              aria-checked={type === 'income'}
+              aria-label="收入"
+            >
+              {typeLabels.income}
+            </button>
+          </div>
+        </div>
+
+        {/* Issue #59: always editable (default edit mode) */}
         <div className="flex items-center gap-md">
           <span className="text-caption text-text-secondary w-[60px] shrink-0">
             金額
           </span>
-          {isEditing ? (
+          <div className="flex items-center flex-1 gap-xs">
+            <span className={`text-body font-semibold ${isIncome ? 'text-success' : 'text-danger'}`}>
+              {isIncome ? '+' : '-'}
+            </span>
             <input
               type="number"
               value={amount}
               onChange={(e) => setAmount(e.target.value)}
-              className="flex-1 h-9 rounded-md border border-border px-sm text-body text-danger font-semibold"
+              className={`flex-1 h-9 rounded-md border border-border px-sm text-body font-semibold ${isIncome ? 'text-success' : 'text-danger'}`}
               min="0.01"
               step="1"
               aria-label="金額"
             />
-          ) : (
-            <span className="text-body text-danger font-semibold">
-              ${result.amount?.toLocaleString() ?? '--'}
-            </span>
-          )}
+          </div>
         </div>
 
         <div className="flex items-center gap-md">
           <span className="text-caption text-text-secondary w-[60px] shrink-0">
             類別
           </span>
-          {isEditing ? (
-            <select
-              value={category}
-              onChange={(e) => setCategory(e.target.value)}
-              className="flex-1 h-9 rounded-md border border-border px-sm text-body"
-              aria-label="類別"
-            >
-              {categories.map((cat) => (
-                <option key={cat} value={cat}>
-                  {categoryNames[cat] ?? cat}
-                </option>
-              ))}
-            </select>
-          ) : (
-            <span className="text-body text-text-primary">
-              {categoryNames[result.category ?? ''] ?? result.category ?? '--'}
-            </span>
-          )}
+          <select
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+            className="flex-1 h-9 rounded-md border border-border px-sm text-body"
+            aria-label="類別"
+          >
+            {categories.map((cat) => (
+              <option key={cat} value={cat}>
+                {categoryNames[cat] ?? cat}
+              </option>
+            ))}
+          </select>
         </div>
 
         <div className="flex items-center gap-md">
           <span className="text-caption text-text-secondary w-[60px] shrink-0">
             商家
           </span>
-          {isEditing ? (
-            <input
-              type="text"
-              value={merchant}
-              onChange={(e) => setMerchant(e.target.value)}
-              className="flex-1 h-9 rounded-md border border-border px-sm text-body"
-              aria-label="商家"
-            />
-          ) : (
-            <span className="text-body text-text-primary">
-              {result.merchant || '--'}
-            </span>
-          )}
+          <input
+            type="text"
+            value={merchant}
+            onChange={(e) => setMerchant(e.target.value)}
+            className="flex-1 h-9 rounded-md border border-border px-sm text-body"
+            aria-label="商家"
+          />
         </div>
 
         <div className="flex items-center gap-md">
           <span className="text-caption text-text-secondary w-[60px] shrink-0">
             日期
           </span>
-          {isEditing ? (
-            <input
-              type="date"
-              value={date}
-              onChange={(e) => setDate(e.target.value)}
-              className="flex-1 h-9 rounded-md border border-border px-sm text-body"
-              aria-label="日期"
-            />
-          ) : (
-            <span className="text-body text-text-primary">
-              {result.date ?? '--'}
-            </span>
-          )}
+          <input
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            className="flex-1 h-9 rounded-md border border-border px-sm text-body"
+            aria-label="日期"
+          />
         </div>
 
         {result.note && (
@@ -153,27 +182,21 @@ function ParsedResultCard({
         )}
       </div>
 
+      {/* Issue #59: buttons are "Cancel" + "Confirm" (no "Edit" button) */}
       <div className="flex gap-sm">
         <button
           type="button"
-          onClick={() => {
-            if (isEditing) {
-              onCancel()
-              setIsEditing(false)
-            } else {
-              setIsEditing(true)
-            }
-          }}
+          onClick={onCancel}
           className="flex-1 h-10 rounded-sm border border-border text-text-secondary text-body transition-colors duration-[var(--transition-fast)] hover:bg-bg"
         >
-          {isEditing ? '取消' : '修改'}
+          取消
         </button>
         <button
           type="button"
           onClick={handleConfirm}
           className="flex-1 h-10 rounded-sm bg-primary text-surface font-semibold text-body transition-opacity duration-[var(--transition-fast)] hover:opacity-90"
         >
-          ✓ 確認記帳
+          確認新增
         </button>
       </div>
     </div>

--- a/frontend/src/components/RecentTransactions.tsx
+++ b/frontend/src/components/RecentTransactions.tsx
@@ -143,8 +143,8 @@ function RecentTransactions({ transactions, categories = defaultCategories }: Re
                       </span>
                     </div>
                   </div>
-                  <p className="text-title font-semibold text-danger shrink-0">
-                    -${tx.amount.toLocaleString()}
+                  <p className={`text-title font-semibold shrink-0 ${tx.type === 'income' ? 'text-success' : 'text-danger'}`}>
+                    {tx.type === 'income' ? '+' : '-'}${tx.amount.toLocaleString()}
                   </p>
                   <span className={`text-text-tertiary text-sm transition-transform ${isExpanded ? 'rotate-180' : ''}`}>
                     ▼

--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -96,8 +96,8 @@ function TransactionItem({
             </span>
           </div>
         </div>
-        <p className="text-title font-semibold text-danger shrink-0">
-          -${tx.amount.toLocaleString()}
+        <p className={`text-title font-semibold shrink-0 ${tx.type === 'income' ? 'text-success' : 'text-danger'}`}>
+          {tx.type === 'income' ? '+' : '-'}${tx.amount.toLocaleString()}
         </p>
         <span className={`text-text-tertiary text-sm transition-transform ${isExpanded ? 'rotate-180' : ''}`}>
           ▼

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -49,6 +49,7 @@ function DashboardPage() {
 
   const handleConfirmTransaction = useCallback(
     async (data: {
+      type: 'income' | 'expense'
       amount: number
       category: string
       merchant: string
@@ -71,6 +72,7 @@ function DashboardPage() {
         await createCategory(categoryName)
         if (parsedResult) {
           await confirmTransaction({
+            type: parsedResult.type ?? 'expense',
             amount: parsedResult.amount ?? 0,
             category: categoryName,
             merchant: parsedResult.merchant,
@@ -98,6 +100,7 @@ function DashboardPage() {
     async (category: string) => {
       if (parsedResult) {
         await confirmTransaction({
+          type: parsedResult.type ?? 'expense',
           amount: parsedResult.amount ?? 0,
           category,
           merchant: parsedResult.merchant,

--- a/frontend/src/stores/dashboardStore.ts
+++ b/frontend/src/stores/dashboardStore.ts
@@ -17,7 +17,10 @@ function getActiveApiKey(): string {
   return localStorage.getItem('llm_api_key') ?? ''
 }
 
+export type TransactionType = 'income' | 'expense'
+
 export interface ParsedResult {
+  type: TransactionType
   amount: number | null
   category: string | null
   merchant: string
@@ -75,6 +78,7 @@ interface DashboardState {
   fetchCategories: () => Promise<void>
   parseInput: (rawText: string) => Promise<void>
   confirmTransaction: (data: {
+    type: TransactionType
     amount: number
     category: string
     merchant: string
@@ -127,6 +131,7 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
       set({
         status: 'parsed',
         parsedResult: {
+          type: parsed.type ?? 'expense',
           amount: parsed.amount,
           category: parsed.category,
           merchant: parsed.merchant,
@@ -163,6 +168,7 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
     set({ status: 'saving', errorMessage: '' })
     try {
       const res = await api.post('/transactions', {
+        type: data.type,
         amount: data.amount,
         category: data.category,
         merchant: data.merchant,
@@ -180,6 +186,7 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
       const tx = res.data.data.transaction
       const newTransaction: Transaction = {
         id: tx.id,
+        type: tx.type ?? 'expense',
         amount: tx.amount,
         category: tx.category,
         merchant: tx.merchant,
@@ -249,6 +256,7 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
         (t: Record<string, unknown>) =>
           ({
             id: t.id as string,
+            type: (t.type as 'income' | 'expense') ?? 'expense',
             amount: t.amount as number,
             category: t.category as string,
             merchant: t.merchant as string,

--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -17,6 +17,7 @@ export interface UserSettings {
 /** 交易記錄 */
 export interface Transaction {
   id: string
+  type?: 'income' | 'expense'
   amount: number
   category: string
   merchant: string

--- a/frontend/src/test/dashboardComponents.test.tsx
+++ b/frontend/src/test/dashboardComponents.test.tsx
@@ -120,6 +120,7 @@ describe('RecentTransactions', () => {
 
 describe('ParsedResultCard', () => {
   const defaultResult = {
+    type: 'expense' as const,
     amount: 180,
     category: 'food',
     merchant: '拉麵店',
@@ -131,7 +132,7 @@ describe('ParsedResultCard', () => {
   }
   const categories = ['food', 'transport', 'entertainment', 'other']
 
-  it('renders parsed result fields', () => {
+  it('renders in default edit mode with editable fields', () => {
     render(
       <ParsedResultCard
         result={defaultResult}
@@ -140,13 +141,18 @@ describe('ParsedResultCard', () => {
         categories={categories}
       />
     )
-    expect(screen.getByText('✨ AI 幫你整理好了')).toBeInTheDocument()
-    expect(screen.getByText('$180')).toBeInTheDocument()
-    expect(screen.getByText('飲食')).toBeInTheDocument()
-    expect(screen.getByText('拉麵店')).toBeInTheDocument()
+    expect(screen.getByText('AI 幫你整理好了')).toBeInTheDocument()
+    // Should be in edit mode by default (Issue #59)
+    expect(screen.getByLabelText('金額')).toBeInTheDocument()
+    expect(screen.getByLabelText('類別')).toBeInTheDocument()
+    expect(screen.getByLabelText('商家')).toBeInTheDocument()
+    expect(screen.getByLabelText('日期')).toBeInTheDocument()
+    // Should have type selector (Issue #58)
+    expect(screen.getByLabelText('消費')).toBeInTheDocument()
+    expect(screen.getByLabelText('收入')).toBeInTheDocument()
   })
 
-  it('calls onConfirm when confirm button clicked', async () => {
+  it('calls onConfirm with type field when confirm button clicked', async () => {
     const onConfirm = vi.fn()
     const user = userEvent.setup()
     render(
@@ -157,8 +163,9 @@ describe('ParsedResultCard', () => {
         categories={categories}
       />
     )
-    await user.click(screen.getByText('✓ 確認記帳'))
+    await user.click(screen.getByText('確認新增'))
     expect(onConfirm).toHaveBeenCalledWith({
+      type: 'expense',
       amount: 180,
       category: 'food',
       merchant: '拉麵店',
@@ -166,21 +173,62 @@ describe('ParsedResultCard', () => {
     })
   })
 
-  it('enters edit mode when modify button clicked', async () => {
+  it('calls onCancel when cancel button clicked (Issue #59)', async () => {
+    const onCancel = vi.fn()
     const user = userEvent.setup()
     render(
       <ParsedResultCard
         result={defaultResult}
         onConfirm={vi.fn()}
+        onCancel={onCancel}
+        categories={categories}
+      />
+    )
+    await user.click(screen.getByText('取消'))
+    expect(onCancel).toHaveBeenCalled()
+  })
+
+  it('shows income type correctly (Issue #58)', () => {
+    const incomeResult = {
+      ...defaultResult,
+      type: 'income' as const,
+      amount: 50000,
+      merchant: '公司',
+    }
+    render(
+      <ParsedResultCard
+        result={incomeResult}
+        onConfirm={vi.fn()}
         onCancel={vi.fn()}
         categories={categories}
       />
     )
-    await user.click(screen.getByText('修改'))
-    expect(screen.getByLabelText('金額')).toBeInTheDocument()
-    expect(screen.getByLabelText('類別')).toBeInTheDocument()
-    expect(screen.getByLabelText('商家')).toBeInTheDocument()
-    expect(screen.getByText('取消')).toBeInTheDocument()
+    // Income button should be selected
+    const incomeBtn = screen.getByLabelText('收入')
+    expect(incomeBtn.getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('allows switching between income and expense types', async () => {
+    const user = userEvent.setup()
+    const onConfirm = vi.fn()
+    render(
+      <ParsedResultCard
+        result={defaultResult}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+        categories={categories}
+      />
+    )
+    // Default is expense
+    expect(screen.getByLabelText('消費').getAttribute('aria-checked')).toBe('true')
+    // Switch to income
+    await user.click(screen.getByLabelText('收入'))
+    expect(screen.getByLabelText('收入').getAttribute('aria-checked')).toBe('true')
+    // Confirm with income type
+    await user.click(screen.getByText('確認新增'))
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'income' })
+    )
   })
 })
 

--- a/frontend/src/test/dashboardStore.test.ts
+++ b/frontend/src/test/dashboardStore.test.ts
@@ -28,6 +28,7 @@ describe('dashboardStore', () => {
       useDashboardStore.setState({
         status: 'parsed',
         parsedResult: {
+          type: 'expense' as const,
           amount: 100,
           category: 'food',
           merchant: 'test',
@@ -60,6 +61,7 @@ describe('dashboardStore', () => {
       useDashboardStore.setState({
         status: 'parsed',
         parsedResult: {
+          type: 'expense',
           amount: 180,
           category: 'food',
           merchant: '拉麵店',
@@ -86,6 +88,7 @@ describe('dashboardStore', () => {
       useDashboardStore.setState({
         status: 'parsed',
         parsedResult: {
+          type: 'expense',
           amount: 1200,
           category: null,
           merchant: '獸醫',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -26,6 +26,7 @@ export interface CategoryBudget {
 export interface Transaction {
   id: string
   userId: string
+  type?: 'income' | 'expense'
   amount: number
   category: string
   merchant: string


### PR DESCRIPTION
## Summary

- **Issue #58**：新增交易類型（income/expense）辨識功能，LLM Prompt 可判斷收入或消費，前端解析結果卡片以顏色區分正負值，DB 新增 type 欄位
- **Issue #59**：解析結果卡片預設進入編輯模式，按鈕改為「確認新增」+「取消」，取消後回到 idle 狀態
- API Spec、Prisma Schema、前後端型別定義同步更新

## Changes

### Backend
- `backend/prisma/schema.prisma` — Transaction model 新增 `type` 欄位（預設 `expense`）
- `backend/prisma/migrations/` — 新增 migration
- `backend/src/types/llm.ts` — ParsedTransaction 增加 `type: TransactionType`
- `backend/src/prompts/dataExtractorPrompt.ts` — Prompt 新增交易類型判斷規則
- `backend/src/validators/transactionValidators.ts` — createTransactionSchema 新增 `type` 欄位
- `backend/src/services/transactionService.ts` — create/update/format 函式支援 `type`

### Frontend
- `frontend/src/components/ParsedResultCard.tsx` — 重寫：預設編輯模式、收入/消費切換、取消按鈕
- `frontend/src/components/RecentTransactions.tsx` — 金額顯示收入/消費正負值
- `frontend/src/components/TransactionItem.tsx` — 同上
- `frontend/src/stores/dashboardStore.ts` — ParsedResult/confirmTransaction 增加 type
- `frontend/src/pages/DashboardPage.tsx` — 傳遞 type 至 confirmTransaction

### Tests
- 後端 aiController.test.ts — 所有 mock 新增 type，新增收入解析測試
- 後端 transactionController.test.ts — mock 資料新增 type
- 前端 dashboardComponents.test.tsx — ParsedResultCard 測試更新：預設編輯、取消、收入切換
- 前端 dashboardStore.test.ts — ParsedResult 測試新增 type

## Test Plan
- [x] Backend: `npx tsc --noEmit` 通過
- [x] Backend: `npm run lint` 通過
- [x] Backend: `npm test -- --run` 86 tests 全部通過
- [x] Frontend: `npx tsc --noEmit` 通過
- [x] Frontend: `npm run lint` 通過
- [x] Frontend: `npm test -- --run` 125 tests 全部通過
- [x] Backend: `npm run build` 通過
- [x] Frontend: `npm run build` 通過

Closes #58
Closes #59