### PR TITLE
fix(frontend): 語音輸入重複修正與按鈕切換模式 (#69, #70)

### DIFF
--- a/frontend/src/components/VoiceInput.tsx
+++ b/frontend/src/components/VoiceInput.tsx
@@ -29,7 +29,7 @@ function VoiceInput({ onSubmit, disabled = false }: VoiceInputProps) {
     errorTimerRef.current = setTimeout(() => setShowError(false), 3000)
   }, [])
 
-  const { status, errorMessage, startRecording, stopRecording } =
+  const { status, errorMessage, toggleRecording } =
     useVoiceRecognition({
       lang: 'zh-TW',
       onResult: handleVoiceResult,
@@ -65,14 +65,10 @@ function VoiceInput({ onSubmit, disabled = false }: VoiceInputProps) {
     [handleSubmit]
   )
 
-  const handleMicPointerDown = useCallback(() => {
+  const handleMicToggle = useCallback(() => {
     if (disabled) return
-    startRecording()
-  }, [startRecording, disabled])
-
-  const handleMicPointerUp = useCallback(() => {
-    stopRecording()
-  }, [stopRecording])
+    toggleRecording()
+  }, [toggleRecording, disabled])
 
   const getPlaceholder = () => {
     if (isRecording) return '正在聆聽...'
@@ -119,39 +115,54 @@ function VoiceInput({ onSubmit, disabled = false }: VoiceInputProps) {
         {isSupported && (
           <button
             type="button"
-            onPointerDown={handleMicPointerDown}
-            onPointerUp={handleMicPointerUp}
-            onPointerLeave={handleMicPointerUp}
+            onClick={handleMicToggle}
             disabled={disabled}
-            className={`relative w-9 h-9 flex items-center justify-center rounded-full transition-colors duration-[var(--transition-fast)] select-none touch-none ${
-              isActive ? 'text-primary' : 'text-text-secondary'
+            className={`relative w-9 h-9 flex items-center justify-center rounded-full transition-colors duration-[var(--transition-fast)] select-none ${
+              isActive
+                ? 'bg-danger text-surface'
+                : 'text-text-secondary'
             } disabled:opacity-40`}
-            aria-label="語音輸入"
+            aria-label={isActive ? '停止語音輸入' : '開始語音輸入'}
             aria-pressed={isActive}
           >
-            {/* Pulse rings animation */}
-            {isRecording && (
+            {/* Pulse rings animation when recording */}
+            {isActive && (
               <>
                 <span className="voice-pulse-ring voice-pulse-ring-1" />
                 <span className="voice-pulse-ring voice-pulse-ring-2" />
               </>
             )}
-            <svg
-              width="20"
-              height="20"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="relative z-10"
-              aria-hidden="true"
-            >
-              <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
-              <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
-              <line x1="12" x2="12" y1="19" y2="22" />
-            </svg>
+            {isActive ? (
+              /* Stop icon (square) when recording */
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="relative z-10"
+                aria-hidden="true"
+              >
+                <rect x="4" y="4" width="16" height="16" rx="2" />
+              </svg>
+            ) : (
+              /* Mic icon when idle */
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="relative z-10"
+                aria-hidden="true"
+              >
+                <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
+                <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+                <line x1="12" x2="12" y1="19" y2="22" />
+              </svg>
+            )}
           </button>
         )}
 

--- a/frontend/src/hooks/useVoiceRecognition.ts
+++ b/frontend/src/hooks/useVoiceRecognition.ts
@@ -17,6 +17,7 @@ interface UseVoiceRecognitionReturn {
   errorMessage: string
   startRecording: () => void
   stopRecording: () => void
+  toggleRecording: () => void
 }
 
 // Feature Detection: check SpeechRecognition support
@@ -42,6 +43,8 @@ export function useVoiceRecognition(
 
   const recognitionRef = useRef<SpeechRecognition | null>(null)
   const callbacksRef = useRef({ onResult, onInterimResult, onError })
+  // Track accumulated final transcript to avoid duplication (#69)
+  const finalTranscriptRef = useRef('')
 
   // Keep callbacks ref updated
   useEffect(() => {
@@ -58,6 +61,9 @@ export function useVoiceRecognition(
       recognitionRef.current = null
     }
 
+    // Reset accumulated final transcript
+    finalTranscriptRef.current = ''
+
     const recognition = new SpeechRecognitionClass()
     recognition.lang = lang
     recognition.interimResults = true
@@ -72,20 +78,27 @@ export function useVoiceRecognition(
     }
 
     recognition.onresult = (event: SpeechRecognitionEvent) => {
-      let finalTranscript = ''
-      let interim = ''
+      // Fix #69: Properly accumulate final results without duplication.
+      // Each result in event.results transitions from interim to final exactly once.
+      // We rebuild the full text from all results on every event to avoid
+      // double-counting previously finalized segments.
+      let finalText = ''
+      let interimText = ''
 
       for (let i = 0; i < event.results.length; i++) {
         const result = event.results[i]
         if (result.isFinal) {
-          finalTranscript += result[0].transcript
+          finalText += result[0].transcript
         } else {
-          interim += result[0].transcript
+          interimText += result[0].transcript
         }
       }
 
-      // In continuous mode, show combined final + interim as live feedback
-      const liveText = finalTranscript + interim
+      // Store the accumulated final transcript for delivery on stop
+      finalTranscriptRef.current = finalText
+
+      // Show combined final + interim as live feedback
+      const liveText = finalText + interimText
       if (liveText) {
         setInterimTranscript(liveText)
         setStatus('recognizing')
@@ -93,15 +106,9 @@ export function useVoiceRecognition(
       }
     }
 
-    // When stop() is called, onend fires — deliver accumulated result
-    recognition.onspeechend = () => {
-      // Collect all final results
-      const recognition_ = recognitionRef.current
-      if (!recognition_) return
-      // The final result will be delivered via onresult before onend
-    }
-
     recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+      // Ignore 'no-speech' errors during continuous recording — they are harmless
+      if (event.error === 'no-speech') return
       const message = getErrorMessage(event.error)
       setErrorMessage(message)
       setStatus('error')
@@ -120,16 +127,29 @@ export function useVoiceRecognition(
   const stopRecording = useCallback(() => {
     if (recognitionRef.current) {
       recognitionRef.current.stop()
-      // Deliver whatever we have as final result
+      // Deliver the accumulated final transcript (or interim if no finals yet)
+      const finalText = finalTranscriptRef.current
       setInterimTranscript((current) => {
-        if (current) {
-          setTranscript(current)
-          callbacksRef.current.onResult?.(current)
+        // Prefer accumulated final results; fall back to whatever interim we have
+        const deliverText = finalText || current
+        if (deliverText) {
+          setTranscript(deliverText)
+          callbacksRef.current.onResult?.(deliverText)
         }
         return ''
       })
+      finalTranscriptRef.current = ''
     }
   }, [])
+
+  // Toggle recording: start if idle, stop if active (#70)
+  const toggleRecording = useCallback(() => {
+    if (recognitionRef.current) {
+      stopRecording()
+    } else {
+      startRecording()
+    }
+  }, [startRecording, stopRecording])
 
   // Cleanup on unmount
   useEffect(() => {
@@ -149,6 +169,7 @@ export function useVoiceRecognition(
     errorMessage,
     startRecording,
     stopRecording,
+    toggleRecording,
   }
 }
 

--- a/frontend/src/test/VoiceInput.test.tsx
+++ b/frontend/src/test/VoiceInput.test.tsx
@@ -28,7 +28,7 @@ describe('VoiceInput', () => {
     }
 
     render(<VoiceInput onSubmit={mockOnSubmit} />)
-    expect(screen.getByLabelText('語音輸入')).toBeInTheDocument()
+    expect(screen.getByLabelText('開始語音輸入')).toBeInTheDocument()
   })
 
   it('hides mic button when SpeechRecognition is not supported', () => {
@@ -36,7 +36,8 @@ describe('VoiceInput', () => {
     delete (window as unknown as Record<string, unknown>).webkitSpeechRecognition
 
     render(<VoiceInput onSubmit={mockOnSubmit} />)
-    expect(screen.queryByLabelText('語音輸入')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('開始語音輸入')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('停止語音輸入')).not.toBeInTheDocument()
   })
 
   it('calls onSubmit when send button is clicked with text', async () => {

--- a/frontend/src/test/useVoiceRecognition.test.ts
+++ b/frontend/src/test/useVoiceRecognition.test.ts
@@ -163,12 +163,30 @@ describe('useVoiceRecognition', () => {
     })
 
     act(() => {
-      mockRecognition.onerror?.({ error: 'no-speech' })
+      mockRecognition.onerror?.({ error: 'not-allowed' })
     })
 
     expect(result.current.status).toBe('error')
-    expect(result.current.errorMessage).toBe('未偵測到語音，請再試一次')
+    expect(result.current.errorMessage).toBe('麥克風權限被拒絕，請在瀏覽器設定中允許麥克風存取')
     expect(onError).toHaveBeenCalled()
+  })
+
+  it('ignores no-speech errors during continuous recording', () => {
+    const onError = vi.fn()
+    const { result } = renderHook(() => useVoiceRecognition({ onError }))
+
+    act(() => {
+      result.current.startRecording()
+      mockRecognition.onstart?.()
+    })
+
+    act(() => {
+      mockRecognition.onerror?.({ error: 'no-speech' })
+    })
+
+    // Should remain in recording state, not error
+    expect(result.current.status).toBe('recording')
+    expect(onError).not.toHaveBeenCalled()
   })
 
   it('returns to idle after recognition ends normally', () => {
@@ -240,5 +258,91 @@ describe('useVoiceRecognition', () => {
     })
 
     expect(result.current.status).toBe('idle')
+  })
+
+  it('toggleRecording starts when idle and stops when active', () => {
+    const onResult = vi.fn()
+    const { result } = renderHook(() => useVoiceRecognition({ onResult }))
+
+    // Toggle on — should start
+    act(() => {
+      result.current.toggleRecording()
+    })
+    expect(mockRecognition.start).toHaveBeenCalledOnce()
+
+    // Simulate onstart
+    act(() => {
+      mockRecognition.onstart?.()
+    })
+    expect(result.current.status).toBe('recording')
+
+    // Simulate some interim result
+    act(() => {
+      mockRecognition.onresult?.({
+        results: [{ 0: { transcript: '測試' }, isFinal: false, length: 1 }],
+        resultIndex: 0,
+      } as unknown)
+    })
+
+    // Toggle off — should stop
+    act(() => {
+      result.current.toggleRecording()
+    })
+    expect(mockRecognition.stop).toHaveBeenCalledOnce()
+  })
+
+  it('does not duplicate final results across multiple onresult events (#69)', () => {
+    const onInterimResult = vi.fn()
+    const onResult = vi.fn()
+    const { result } = renderHook(() =>
+      useVoiceRecognition({ onInterimResult, onResult })
+    )
+
+    act(() => {
+      result.current.startRecording()
+      mockRecognition.onstart?.()
+    })
+
+    // First event: interim "週一的時候"
+    act(() => {
+      mockRecognition.onresult?.({
+        results: [
+          { 0: { transcript: '週一的時候' }, isFinal: false, length: 1 },
+        ],
+        resultIndex: 0,
+      } as unknown)
+    })
+    expect(onInterimResult).toHaveBeenLastCalledWith('週一的時候')
+
+    // Second event: first segment finalized, new interim appears
+    act(() => {
+      mockRecognition.onresult?.({
+        results: [
+          { 0: { transcript: '週一的時候' }, isFinal: true, length: 1 },
+          { 0: { transcript: 'Michael還我錢' }, isFinal: false, length: 1 },
+        ],
+        resultIndex: 0,
+      } as unknown)
+    })
+    // Should NOT be "週一的時候週一的時候Michael還我錢"
+    expect(onInterimResult).toHaveBeenLastCalledWith('週一的時候Michael還我錢')
+
+    // Third event: both finalized
+    act(() => {
+      mockRecognition.onresult?.({
+        results: [
+          { 0: { transcript: '週一的時候' }, isFinal: true, length: 1 },
+          { 0: { transcript: 'Michael還我錢10000塊' }, isFinal: true, length: 1 },
+        ],
+        resultIndex: 0,
+      } as unknown)
+    })
+    expect(onInterimResult).toHaveBeenLastCalledWith('週一的時候Michael還我錢10000塊')
+
+    // Stop recording — deliver final
+    act(() => {
+      result.current.stopRecording()
+    })
+    expect(onResult).toHaveBeenCalledWith('週一的時候Michael還我錢10000塊')
   })
 })


### PR DESCRIPTION
## Summary
- **Issue #69**：修正語音辨識停頓時重複拼接前詞的問題。每次 `onresult` 事件從 index 0 重新遍歷所有 results，使用 `finalTranscriptRef` 追蹤已確認文本，避免重複拼接。
- **Issue #70**：語音按鈕從「按住錄音」改為「點擊切換」模式。點擊一下開始錄音（紅色背景 + 停止圖標 + 脈衝動畫），再點擊一下停止錄音。
- 新增 `toggleRecording()` API，continuous 模式下忽略 `no-speech` 錯誤避免意外中斷。

Closes #69
Closes #70

## 修改檔案
- `frontend/src/hooks/useVoiceRecognition.ts` — 修正 result 拼接邏輯、新增 toggleRecording
- `frontend/src/components/VoiceInput.tsx` — 按鈕改為 onClick toggle、錄音中視覺狀態
- `frontend/src/test/useVoiceRecognition.test.ts` — 新增重複拼接與 toggle 測試
- `frontend/src/test/VoiceInput.test.tsx` — 更新 aria-label 測試

## Test Plan
- [x] TypeScript 編譯通過 (`tsc --noEmit`)
- [x] ESLint 通過 (`npm run lint`)
- [x] 單元測試全部通過 (128 tests, 11 suites)
- [x] Production build 成功 (`npm run build`)