### PR TITLE
feat: 帳目類別區分收入/支出類型與顏色 (#64, #67)

### DIFF
--- a/backend/prisma/migrations/20260319214633_add_type_to_category_budget/migration.sql
+++ b/backend/prisma/migrations/20260319214633_add_type_to_category_budget/migration.sql
@@ -1,0 +1,21 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_category_budgets" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "user_id" TEXT NOT NULL,
+    "category" TEXT NOT NULL,
+    "type" TEXT NOT NULL DEFAULT 'expense',
+    "budget_limit" DECIMAL NOT NULL DEFAULT 0,
+    "is_custom" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" DATETIME NOT NULL,
+    CONSTRAINT "category_budgets_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_category_budgets" ("budget_limit", "category", "created_at", "id", "is_custom", "updated_at", "user_id") SELECT "budget_limit", "category", "created_at", "id", "is_custom", "updated_at", "user_id" FROM "category_budgets";
+DROP TABLE "category_budgets";
+ALTER TABLE "new_category_budgets" RENAME TO "category_budgets";
+CREATE INDEX "category_budgets_user_id_idx" ON "category_budgets"("user_id");
+CREATE UNIQUE INDEX "category_budgets_user_id_category_key" ON "category_budgets"("user_id", "category");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -33,6 +33,7 @@ model CategoryBudget {
   id          String   @id @default(uuid())
   userId      String   @map("user_id")
   category    String
+  type        String   @default("expense") // income, expense
   budgetLimit Decimal  @default(0) @map("budget_limit")
   isCustom    Boolean  @default(false) @map("is_custom")
   createdAt   DateTime @default(now()) @map("created_at")

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -3,14 +3,21 @@ import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
 
 const DEFAULT_CATEGORIES = [
-  { category: 'food', budgetLimit: 8000 },
-  { category: 'transport', budgetLimit: 3000 },
-  { category: 'entertainment', budgetLimit: 3000 },
-  { category: 'shopping', budgetLimit: 3000 },
-  { category: 'daily', budgetLimit: 2000 },
-  { category: 'medical', budgetLimit: 2000 },
-  { category: 'education', budgetLimit: 2000 },
-  { category: 'other', budgetLimit: 0 },
+  // 支出類別
+  { category: 'food', type: 'expense', budgetLimit: 8000 },
+  { category: 'transport', type: 'expense', budgetLimit: 3000 },
+  { category: 'entertainment', type: 'expense', budgetLimit: 3000 },
+  { category: 'shopping', type: 'expense', budgetLimit: 3000 },
+  { category: 'daily', type: 'expense', budgetLimit: 2000 },
+  { category: 'medical', type: 'expense', budgetLimit: 2000 },
+  { category: 'education', type: 'expense', budgetLimit: 2000 },
+  { category: 'other', type: 'expense', budgetLimit: 0 },
+  // 收入類別
+  { category: 'salary', type: 'income', budgetLimit: 0 },
+  { category: 'investment', type: 'income', budgetLimit: 0 },
+  { category: 'pension', type: 'income', budgetLimit: 0 },
+  { category: 'insurance', type: 'income', budgetLimit: 0 },
+  { category: 'other_income', type: 'income', budgetLimit: 0 },
 ];
 
 async function main() {
@@ -47,6 +54,7 @@ async function main() {
       create: {
         userId: testUser.id,
         category: cat.category,
+        type: cat.type,
         budgetLimit: cat.budgetLimit,
         isCustom: false,
       },

--- a/backend/src/routes/budgetRoutes.test.ts
+++ b/backend/src/routes/budgetRoutes.test.ts
@@ -49,13 +49,14 @@ describe('Budget Routes', () => {
   // POST /budget/categories
   // ==========================================
   describe('POST /api/v1/budget/categories', () => {
-    it('should create a new category', async () => {
+    it('should create a new category with default type expense', async () => {
       mockedPrisma.categoryBudget.count.mockResolvedValue(5);
       mockedPrisma.categoryBudget.findUnique.mockResolvedValue(null);
       mockedPrisma.categoryBudget.create.mockResolvedValue({
         id: 'cat-1',
         userId: 'test-user-id',
         category: 'food',
+        type: 'expense',
         budgetLimit: new Prisma.Decimal(0),
         isCustom: true,
         createdAt: new Date(),
@@ -68,6 +69,39 @@ describe('Budget Routes', () => {
 
       expect(res.status).toBe(201);
       expect(res.body.data.category).toBe('food');
+      expect(res.body.data.type).toBe('expense');
+    });
+
+    it('should create an income category with type income', async () => {
+      mockedPrisma.categoryBudget.count.mockResolvedValue(5);
+      mockedPrisma.categoryBudget.findUnique.mockResolvedValue(null);
+      mockedPrisma.categoryBudget.create.mockResolvedValue({
+        id: 'cat-income-1',
+        userId: 'test-user-id',
+        category: 'salary',
+        type: 'income',
+        budgetLimit: new Prisma.Decimal(0),
+        isCustom: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const res = await request(app)
+        .post('/api/v1/budget/categories')
+        .send({ category: 'salary', type: 'income' });
+
+      expect(res.status).toBe(201);
+      expect(res.body.data.category).toBe('salary');
+      expect(res.body.data.type).toBe('income');
+    });
+
+    it('should reject invalid type value', async () => {
+      const res = await request(app)
+        .post('/api/v1/budget/categories')
+        .send({ category: 'test', type: 'invalid' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.message).toContain('type');
     });
 
     it('should create a category with budget_limit', async () => {
@@ -77,6 +111,7 @@ describe('Budget Routes', () => {
         id: 'cat-2',
         userId: 'test-user-id',
         category: 'transport',
+        type: 'expense',
         budgetLimit: new Prisma.Decimal(5000),
         isCustom: true,
         createdAt: new Date(),
@@ -97,6 +132,7 @@ describe('Budget Routes', () => {
         id: 'cat-1',
         userId: 'test-user-id',
         category: 'food',
+        type: 'expense',
         budgetLimit: new Prisma.Decimal(0),
         isCustom: true,
         createdAt: new Date(),
@@ -132,6 +168,49 @@ describe('Budget Routes', () => {
   });
 
   // ==========================================
+  // GET /budget/categories with type filter
+  // ==========================================
+  describe('GET /api/v1/budget/categories', () => {
+    it('should return all categories when no type filter', async () => {
+      mockedPrisma.categoryBudget.findMany.mockResolvedValue([
+        { id: 'cb1', userId: 'test-user-id', category: 'food', type: 'expense', budgetLimit: new Prisma.Decimal(8000), isCustom: false, createdAt: new Date(), updatedAt: new Date() },
+        { id: 'cb2', userId: 'test-user-id', category: 'salary', type: 'income', budgetLimit: new Prisma.Decimal(0), isCustom: false, createdAt: new Date(), updatedAt: new Date() },
+      ]);
+
+      const res = await request(app).get('/api/v1/budget/categories');
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(2);
+    });
+
+    it('should filter by type=expense', async () => {
+      mockedPrisma.categoryBudget.findMany.mockResolvedValue([
+        { id: 'cb1', userId: 'test-user-id', category: 'food', type: 'expense', budgetLimit: new Prisma.Decimal(8000), isCustom: false, createdAt: new Date(), updatedAt: new Date() },
+      ]);
+
+      const res = await request(app).get('/api/v1/budget/categories?type=expense');
+
+      expect(res.status).toBe(200);
+      expect(mockedPrisma.categoryBudget.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { userId: 'test-user-id', type: 'expense' } })
+      );
+    });
+
+    it('should filter by type=income', async () => {
+      mockedPrisma.categoryBudget.findMany.mockResolvedValue([
+        { id: 'cb2', userId: 'test-user-id', category: 'salary', type: 'income', budgetLimit: new Prisma.Decimal(0), isCustom: false, createdAt: new Date(), updatedAt: new Date() },
+      ]);
+
+      const res = await request(app).get('/api/v1/budget/categories?type=income');
+
+      expect(res.status).toBe(200);
+      expect(mockedPrisma.categoryBudget.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { userId: 'test-user-id', type: 'income' } })
+      );
+    });
+  });
+
+  // ==========================================
   // PUT /budget/categories
   // ==========================================
   describe('PUT /api/v1/budget/categories', () => {
@@ -140,6 +219,7 @@ describe('Budget Routes', () => {
         id: 'cat-1',
         userId: 'test-user-id',
         category: 'food',
+        type: 'expense',
         budgetLimit: new Prisma.Decimal(0),
         isCustom: true,
         createdAt: new Date(),
@@ -149,6 +229,7 @@ describe('Budget Routes', () => {
         id: 'cat-1',
         userId: 'test-user-id',
         category: 'food',
+        type: 'expense',
         budgetLimit: new Prisma.Decimal(8000),
         isCustom: true,
         createdAt: new Date(),
@@ -206,6 +287,7 @@ describe('Budget Routes', () => {
         id: 'cat-1',
         userId: 'test-user-id',
         category: 'snacks',
+        type: 'expense',
         budgetLimit: new Prisma.Decimal(0),
         isCustom: true,
         createdAt: new Date(),
@@ -216,6 +298,7 @@ describe('Budget Routes', () => {
         id: 'cat-1',
         userId: 'test-user-id',
         category: 'snacks',
+        type: 'expense',
         budgetLimit: new Prisma.Decimal(0),
         isCustom: true,
         createdAt: new Date(),
@@ -240,6 +323,7 @@ describe('Budget Routes', () => {
         id: 'cat-sys',
         userId: 'test-user-id',
         category: 'food',
+        type: 'expense',
         budgetLimit: new Prisma.Decimal(0),
         isCustom: false,
         createdAt: new Date(),
@@ -285,6 +369,7 @@ describe('Budget Routes', () => {
         {
           id: 't1',
           userId: 'test-user-id',
+          type: 'expense',
           amount: new Prisma.Decimal(5000),
           category: 'food',
           merchant: null,
@@ -297,6 +382,7 @@ describe('Budget Routes', () => {
         {
           id: 't2',
           userId: 'test-user-id',
+          type: 'expense',
           amount: new Prisma.Decimal(3000),
           category: 'transport',
           merchant: null,
@@ -313,6 +399,7 @@ describe('Budget Routes', () => {
           id: 'cb1',
           userId: 'test-user-id',
           category: 'food',
+          type: 'expense',
           budgetLimit: new Prisma.Decimal(8000),
           isCustom: false,
           createdAt: new Date(),
@@ -322,6 +409,7 @@ describe('Budget Routes', () => {
           id: 'cb2',
           userId: 'test-user-id',
           category: 'transport',
+          type: 'expense',
           budgetLimit: new Prisma.Decimal(5000),
           isCustom: false,
           createdAt: new Date(),

--- a/backend/src/routes/budgetRoutes.ts
+++ b/backend/src/routes/budgetRoutes.ts
@@ -12,13 +12,19 @@ const MAX_CATEGORIES = 20;
 router.post('/categories', authMiddleware, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     const userId = req.userId!;
-    const { category, budget_limit } = req.body;
+    const { category, budget_limit, type } = req.body;
 
     if (!category || typeof category !== 'string' || !category.trim()) {
       throw new AppError('請提供類別名稱', 400);
     }
 
     const trimmed = category.trim();
+
+    // Validate type
+    const categoryType = type || 'expense';
+    if (categoryType !== 'income' && categoryType !== 'expense') {
+      throw new AppError('type 必須為 income 或 expense', 400);
+    }
 
     // Check category count limit
     const count = await prisma.categoryBudget.count({ where: { userId } });
@@ -44,15 +50,16 @@ router.post('/categories', authMiddleware, async (req: AuthRequest, res: Respons
       data: {
         userId,
         category: trimmed,
+        type: categoryType,
         isCustom: true,
         budgetLimit,
       },
     });
 
-    const response: ApiResponse<{ id: string; category: string; budget_limit: number }> = {
+    const response: ApiResponse<{ id: string; category: string; type: string; budget_limit: number }> = {
       code: 201,
       message: '類別新增成功',
-      data: { id: created.id, category: created.category, budget_limit: Number(created.budgetLimit) },
+      data: { id: created.id, category: created.category, type: created.type, budget_limit: Number(created.budgetLimit) },
       timestamp: new Date().toISOString(),
     };
 
@@ -66,8 +73,15 @@ router.post('/categories', authMiddleware, async (req: AuthRequest, res: Respons
 router.get('/categories', authMiddleware, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     const userId = req.userId!;
+    const typeFilter = req.query.type as string | undefined;
+
+    const where: { userId: string; type?: string } = { userId };
+    if (typeFilter && (typeFilter === 'income' || typeFilter === 'expense')) {
+      where.type = typeFilter;
+    }
+
     const categories = await prisma.categoryBudget.findMany({
-      where: { userId },
+      where,
       orderBy: { createdAt: 'asc' },
     });
 

--- a/docs/API_Spec.yaml
+++ b/docs/API_Spec.yaml
@@ -537,6 +537,13 @@ paths:
       operationId: getCategoryBudgets
       security:
         - BearerAuth: []
+      parameters:
+        - name: type
+          in: query
+          description: 篩選類別類型（income 或 expense）
+          schema:
+            type: string
+            enum: [income, expense]
       responses:
         '200':
           description: 成功
@@ -575,6 +582,11 @@ paths:
                   minLength: 2
                   maxLength: 50
                   example: 寵物
+                type:
+                  type: string
+                  enum: [income, expense]
+                  default: expense
+                  description: 類別類型（收入或支出）
                 budget_limit:
                   type: number
                   format: decimal
@@ -961,6 +973,11 @@ components:
       properties:
         category:
           type: string
+        type:
+          type: string
+          enum: [income, expense]
+          default: expense
+          description: 類別類型（收入或支出）
         budget_limit:
           type: number
           format: decimal

--- a/frontend/src/components/ParsedResultCard.tsx
+++ b/frontend/src/components/ParsedResultCard.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
-import type { ParsedResult, TransactionType } from '../stores/dashboardStore'
+import type { ParsedResult, TransactionType, CategoryInfo } from '../stores/dashboardStore'
+import { getCategoryName, getCategoryTypeColorClass } from '../lib/categoryUtils'
 
 interface ParsedResultCardProps {
   result: ParsedResult
@@ -12,17 +13,7 @@ interface ParsedResultCardProps {
   }) => void
   onCancel: () => void
   categories: string[]
-}
-
-const categoryNames: Record<string, string> = {
-  food: '飲食',
-  transport: '交通',
-  entertainment: '娛樂',
-  shopping: '購物',
-  daily: '日用品',
-  medical: '醫療',
-  education: '教育',
-  other: '其他',
+  categoryInfoList?: CategoryInfo[]
 }
 
 const typeLabels: Record<TransactionType, string> = {
@@ -35,6 +26,7 @@ function ParsedResultCard({
   onConfirm,
   onCancel,
   categories,
+  categoryInfoList = [],
 }: ParsedResultCardProps) {
   // Issue #59: default to edit mode
   const [type, setType] = useState<TransactionType>(result.type ?? 'expense')
@@ -42,6 +34,20 @@ function ParsedResultCard({
   const [category, setCategory] = useState(result.category ?? 'other')
   const [merchant, setMerchant] = useState(result.merchant ?? '')
   const [date, setDate] = useState(result.date ?? new Date().toISOString().split('T')[0])
+
+  // Filter categories by the selected transaction type
+  const filteredCategories = categoryInfoList.length > 0
+    ? categoryInfoList.filter((c) => c.type === type).map((c) => c.category)
+    : categories
+
+  const handleTypeChange = (newType: TransactionType) => {
+    setType(newType)
+    // Reset category to first matching category of the new type
+    const matchingCats = categoryInfoList.filter((c) => c.type === newType)
+    if (matchingCats.length > 0 && !matchingCats.some((c) => c.category === category)) {
+      setCategory(matchingCats[0].category)
+    }
+  }
 
   const handleConfirm = () => {
     const parsedAmount = parseFloat(amount)
@@ -76,7 +82,7 @@ function ParsedResultCard({
           <div className="flex gap-sm" role="radiogroup" aria-label="交易類型">
             <button
               type="button"
-              onClick={() => setType('expense')}
+              onClick={() => handleTypeChange('expense')}
               className={`px-md py-xs rounded-md text-caption font-semibold transition-colors ${
                 type === 'expense'
                   ? 'bg-danger text-surface'
@@ -90,7 +96,7 @@ function ParsedResultCard({
             </button>
             <button
               type="button"
-              onClick={() => setType('income')}
+              onClick={() => handleTypeChange('income')}
               className={`px-md py-xs rounded-md text-caption font-semibold transition-colors ${
                 type === 'income'
                   ? 'bg-success text-surface'
@@ -133,12 +139,12 @@ function ParsedResultCard({
           <select
             value={category}
             onChange={(e) => setCategory(e.target.value)}
-            className="flex-1 h-9 rounded-md border border-border px-sm text-body"
+            className={`flex-1 h-9 rounded-md border border-border px-sm text-body ${getCategoryTypeColorClass(type)}`}
             aria-label="類別"
           >
-            {categories.map((cat) => (
+            {filteredCategories.map((cat) => (
               <option key={cat} value={cat}>
-                {categoryNames[cat] ?? cat}
+                {getCategoryName(cat)}
               </option>
             ))}
           </select>

--- a/frontend/src/components/RecentTransactions.tsx
+++ b/frontend/src/components/RecentTransactions.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react'
 import type { Transaction } from '../stores/index'
 import { useDashboardStore } from '../stores/dashboardStore'
+import { getCategoryName, getCategoryTypeColorClass } from '../lib/categoryUtils'
 
 interface RecentTransactionsProps {
   transactions: Transaction[]
@@ -16,17 +17,11 @@ const categoryIcons: Record<string, string> = {
   medical: '🏥',
   education: '📚',
   other: '📦',
-}
-
-const categoryNames: Record<string, string> = {
-  food: '飲食',
-  transport: '交通',
-  entertainment: '娛樂',
-  shopping: '購物',
-  daily: '日用品',
-  medical: '醫療',
-  education: '教育',
-  other: '其他',
+  salary: '💰',
+  investment: '📈',
+  pension: '🏦',
+  insurance: '🛡️',
+  other_income: '💵',
 }
 
 function formatTime(dateStr: string): string {
@@ -127,7 +122,7 @@ function RecentTransactions({ transactions, categories = defaultCategories }: Re
                   onClick={() => handleToggle(tx.id)}
                   className="w-full flex items-center gap-md py-md hover:bg-bg transition-colors"
                 >
-                  <div className="w-10 h-10 rounded-md bg-danger-light flex items-center justify-center text-lg shrink-0">
+                  <div className={`w-10 h-10 rounded-md ${tx.type === 'income' ? 'bg-success-light' : 'bg-danger-light'} flex items-center justify-center text-lg shrink-0`}>
                     {categoryIcons[tx.category] ?? '📦'}
                   </div>
                   <div className="flex-1 min-w-0 text-left">
@@ -135,8 +130,8 @@ function RecentTransactions({ transactions, categories = defaultCategories }: Re
                       {tx.merchant || tx.category}
                     </p>
                     <div className="flex items-center gap-xs">
-                      <span className="text-small text-text-secondary bg-[#F0F0F0] rounded-sm px-2 py-0.5">
-                        {categoryNames[tx.category] ?? tx.category}
+                      <span className={`text-small ${getCategoryTypeColorClass(tx.type ?? 'expense')} bg-[#F0F0F0] rounded-sm px-2 py-0.5`}>
+                        {getCategoryName(tx.category)}
                       </span>
                       <span className="text-small text-text-secondary">
                         · {formatTime(tx.createdAt)}
@@ -199,11 +194,11 @@ function RecentTransactions({ transactions, categories = defaultCategories }: Re
                           <select
                             value={editForm.category}
                             onChange={(e) => setEditForm((f) => ({ ...f, category: e.target.value }))}
-                            className="flex-1 h-9 rounded-md border border-border px-sm text-body"
+                            className={`flex-1 h-9 rounded-md border border-border px-sm text-body ${getCategoryTypeColorClass(tx.type ?? 'expense')}`}
                           >
                             {categories.map((cat) => (
                               <option key={cat} value={cat}>
-                                {categoryIcons[cat] ?? '📦'} {categoryNames[cat] ?? cat}
+                                {categoryIcons[cat] ?? '📦'} {getCategoryName(cat)}
                               </option>
                             ))}
                             {/* 若目前類別不在列表中，也顯示 */}
@@ -264,12 +259,12 @@ function RecentTransactions({ transactions, categories = defaultCategories }: Re
                         <div className="space-y-sm mb-lg">
                           <div className="flex items-center gap-md">
                             <span className="text-caption text-text-secondary w-[50px] shrink-0">金額</span>
-                            <span className="text-body text-danger font-semibold">${tx.amount.toLocaleString()}</span>
+                            <span className={`text-body font-semibold ${tx.type === 'income' ? 'text-success' : 'text-danger'}`}>${tx.amount.toLocaleString()}</span>
                           </div>
                           <div className="flex items-center gap-md">
                             <span className="text-caption text-text-secondary w-[50px] shrink-0">類別</span>
-                            <span className="text-body text-text-primary">
-                              {categoryIcons[tx.category] ?? '📦'} {categoryNames[tx.category] ?? tx.category}
+                            <span className={`text-body ${getCategoryTypeColorClass(tx.type ?? 'expense')}`}>
+                              {categoryIcons[tx.category] ?? '📦'} {getCategoryName(tx.category)}
                             </span>
                           </div>
                           <div className="flex items-center gap-md">

--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react'
 import type { Transaction } from '../stores/index'
+import { getCategoryName, getCategoryTypeColorClass } from '../lib/categoryUtils'
 
 interface TransactionItemProps {
   transaction: Transaction
@@ -18,17 +19,11 @@ const categoryIcons: Record<string, string> = {
   medical: '🏥',
   education: '📚',
   other: '📦',
-}
-
-const categoryNames: Record<string, string> = {
-  food: '飲食',
-  transport: '交通',
-  entertainment: '娛樂',
-  shopping: '購物',
-  daily: '日用品',
-  medical: '醫療',
-  education: '教育',
-  other: '其他',
+  salary: '💰',
+  investment: '📈',
+  pension: '🏦',
+  insurance: '🛡️',
+  other_income: '💵',
 }
 
 function formatTime(dateStr: string): string {
@@ -80,7 +75,7 @@ function TransactionItem({
         className="w-full flex items-center gap-md py-md hover:bg-bg transition-colors"
         aria-expanded={isExpanded}
       >
-        <div className="w-10 h-10 rounded-md bg-danger-light flex items-center justify-center text-lg shrink-0">
+        <div className={`w-10 h-10 rounded-md ${tx.type === 'income' ? 'bg-success-light' : 'bg-danger-light'} flex items-center justify-center text-lg shrink-0`}>
           {categoryIcons[tx.category] ?? '📦'}
         </div>
         <div className="flex-1 min-w-0 text-left">
@@ -88,8 +83,8 @@ function TransactionItem({
             {tx.merchant || tx.category}
           </p>
           <div className="flex items-center gap-xs">
-            <span className="text-small text-text-secondary bg-[#F0F0F0] rounded-sm px-2 py-0.5">
-              {categoryNames[tx.category] ?? tx.category}
+            <span className={`text-small ${getCategoryTypeColorClass(tx.type ?? 'expense')} bg-[#F0F0F0] rounded-sm px-2 py-0.5`}>
+              {getCategoryName(tx.category)}
             </span>
             <span className="text-small text-text-secondary">
               · {formatTime(tx.createdAt)}
@@ -140,12 +135,12 @@ function TransactionItem({
               <div className="space-y-sm mb-lg">
                 <div className="flex items-center gap-md">
                   <span className="text-caption text-text-secondary w-[50px] shrink-0">金額</span>
-                  <span className="text-body text-danger font-semibold">${tx.amount.toLocaleString()}</span>
+                  <span className={`text-body font-semibold ${tx.type === 'income' ? 'text-success' : 'text-danger'}`}>${tx.amount.toLocaleString()}</span>
                 </div>
                 <div className="flex items-center gap-md">
                   <span className="text-caption text-text-secondary w-[50px] shrink-0">類別</span>
-                  <span className="text-body text-text-primary">
-                    {categoryIcons[tx.category] ?? '📦'} {categoryNames[tx.category] ?? tx.category}
+                  <span className={`text-body ${getCategoryTypeColorClass(tx.type ?? 'expense')}`}>
+                    {categoryIcons[tx.category] ?? '📦'} {getCategoryName(tx.category)}
                   </span>
                 </div>
                 <div className="flex items-center gap-md">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -13,6 +13,7 @@
   --color-danger-light: #FFE8EA;
   --color-warning: #FFA502;
   --color-success: #00C896;
+  --color-success-light: #E6FAF3;
 
   /* Neutral Colors */
   --color-bg: #F5F5F5;

--- a/frontend/src/lib/categoryUtils.ts
+++ b/frontend/src/lib/categoryUtils.ts
@@ -8,6 +8,12 @@ export const CATEGORY_COLORS: Record<string, string> = {
   medical: '#FD79A8',
   education: '#6C5CE7',
   other: '#B2BEC3',
+  // 收入類別
+  salary: '#22C55E',
+  investment: '#10B981',
+  pension: '#059669',
+  insurance: '#047857',
+  other_income: '#6EE7B7',
 }
 
 /** Fallback colors for custom categories */
@@ -23,6 +29,25 @@ export const CATEGORY_NAMES: Record<string, string> = {
   medical: '醫療',
   education: '教育',
   other: '其他',
+  // 收入類別
+  salary: '薪資收入',
+  investment: '投資收益',
+  pension: '退休金',
+  insurance: '保險理賠',
+  other_income: '其他收入',
+}
+
+/** 收入類別集合 */
+export const INCOME_CATEGORIES = new Set(['salary', 'investment', 'pension', 'insurance', 'other_income'])
+
+/** 根據類別判斷是否為收入類別 */
+export function isIncomeCategory(category: string): boolean {
+  return INCOME_CATEGORIES.has(category)
+}
+
+/** 根據類別類型回傳對應的 CSS 顏色 class (#67) */
+export function getCategoryTypeColorClass(categoryType: 'income' | 'expense' | string): string {
+  return categoryType === 'income' ? 'text-success' : 'text-danger'
 }
 
 export function getCategoryColor(category: string, index: number): string {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -22,6 +22,7 @@ function DashboardPage() {
     budgetSummary,
     recentTransactions,
     categories,
+    categoryInfoList,
     errorMessage,
     lastFeedbackText,
     parseInput,
@@ -194,6 +195,7 @@ function DashboardPage() {
             onConfirm={handleConfirmTransaction}
             onCancel={resetParsedResult}
             categories={categories}
+            categoryInfoList={categoryInfoList}
           />
         )}
 

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -8,6 +8,7 @@ import { getCategoryName } from '../lib/categoryUtils'
 const CATEGORY_ICONS: Record<string, string> = {
   food: '🍽️', transport: '🚌', entertainment: '🎬', shopping: '🛍️',
   daily: '🧴', medical: '🏥', education: '📚', other: '📦',
+  salary: '💰', investment: '📈', pension: '🏦', insurance: '🛡️', other_income: '💵',
 }
 
 function formatGroupDate(dateStr: string): string {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -2,7 +2,10 @@ import { useEffect, useState, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuthStore } from '../stores/authStore.ts'
 import { useSettingsStore } from '../stores/settingsStore.ts'
+import { useDashboardStore } from '../stores/dashboardStore.ts'
+import type { CategoryInfo } from '../stores/dashboardStore.ts'
 import type { Persona, AIEngine, KeyValidationStatus } from '../stores/settingsStore.ts'
+import { getCategoryName, getCategoryTypeColorClass } from '../lib/categoryUtils.ts'
 
 /** 人設選項定義 */
 const PERSONA_OPTIONS: { value: Persona; label: string; emoji: string }[] = [
@@ -93,6 +96,35 @@ function SettingsPage() {
     saveApiKeys(apiKeys)
     await validateApiKey(currentApiKey)
   }, [currentApiKey, apiKeys, saveApiKeys, validateApiKey])
+
+  // Category management state (#64)
+  const categoryInfoList = useDashboardStore((s) => s.categoryInfoList)
+  const fetchCategories = useDashboardStore((s) => s.fetchCategories)
+  const createCategoryAction = useDashboardStore((s) => s.createCategory)
+
+  const [newCategoryName, setNewCategoryName] = useState('')
+  const [newCategoryType, setNewCategoryType] = useState<'income' | 'expense'>('expense')
+  const [categoryAdding, setCategoryAdding] = useState(false)
+
+  useEffect(() => {
+    fetchCategories()
+  }, [fetchCategories])
+
+  const expenseCategories = categoryInfoList.filter((c: CategoryInfo) => c.type === 'expense')
+  const incomeCategories = categoryInfoList.filter((c: CategoryInfo) => c.type === 'income')
+
+  const handleAddCategory = useCallback(async () => {
+    if (!newCategoryName.trim()) return
+    setCategoryAdding(true)
+    try {
+      await createCategoryAction(newCategoryName.trim(), newCategoryType)
+      setNewCategoryName('')
+    } catch {
+      // Error handled by store
+    } finally {
+      setCategoryAdding(false)
+    }
+  }, [newCategoryName, newCategoryType, createCategoryAction])
 
   const handleLogout = useCallback(() => {
     logout()
@@ -302,6 +334,79 @@ function SettingsPage() {
               {keyStatusText(keyValidationStatus)}
             </p>
           )}
+        </div>
+      </section>
+
+      {/* 類別管理 (#64) */}
+      <section className="bg-surface rounded-lg shadow-card p-lg mb-xl" aria-label="類別管理">
+        <h2 className="text-caption text-text-secondary mb-md">
+          類別管理
+        </h2>
+
+        {/* 支出類別 */}
+        <div className="mb-lg">
+          <h3 className="text-body font-semibold text-danger mb-sm">支出類別</h3>
+          <div className="flex flex-wrap gap-sm">
+            {expenseCategories.map((c: CategoryInfo) => (
+              <span
+                key={c.category}
+                className={`px-md py-xs rounded-md text-caption ${getCategoryTypeColorClass('expense')} bg-[#FFF0F0]`}
+              >
+                {getCategoryName(c.category)}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {/* 收入類別 */}
+        <div className="mb-lg">
+          <h3 className="text-body font-semibold text-success mb-sm">收入類別</h3>
+          <div className="flex flex-wrap gap-sm">
+            {incomeCategories.map((c: CategoryInfo) => (
+              <span
+                key={c.category}
+                className={`px-md py-xs rounded-md text-caption ${getCategoryTypeColorClass('income')} bg-[#F0FFF0]`}
+              >
+                {getCategoryName(c.category)}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {/* 新增自訂類別 */}
+        <div className="border-t border-border pt-md">
+          <p className="text-caption text-text-secondary mb-sm">新增自訂類別</p>
+          <div className="flex gap-sm items-center">
+            <select
+              value={newCategoryType}
+              onChange={(e) => setNewCategoryType(e.target.value as 'income' | 'expense')}
+              className="h-9 rounded-md border border-border px-sm text-caption"
+              aria-label="新類別類型"
+            >
+              <option value="expense">支出</option>
+              <option value="income">收入</option>
+            </select>
+            <input
+              type="text"
+              value={newCategoryName}
+              onChange={(e) => setNewCategoryName(e.target.value)}
+              placeholder="類別名稱"
+              className="flex-1 h-9 rounded-md border border-border px-sm text-body"
+              aria-label="新類別名稱"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleAddCategory()
+              }}
+            />
+            <button
+              type="button"
+              onClick={handleAddCategory}
+              disabled={categoryAdding || !newCategoryName.trim()}
+              className="h-9 px-lg rounded-md bg-primary text-white text-caption font-semibold disabled:opacity-50"
+              aria-label="新增類別"
+            >
+              {categoryAdding ? '新增中...' : '新增'}
+            </button>
+          </div>
         </div>
       </section>
 

--- a/frontend/src/stores/dashboardStore.ts
+++ b/frontend/src/stores/dashboardStore.ts
@@ -62,6 +62,11 @@ export type DashboardStatus =
   | 'saving'
   | 'error'
 
+export interface CategoryInfo {
+  category: string
+  type: 'income' | 'expense'
+}
+
 interface DashboardState {
   status: DashboardStatus
   parsedResult: ParsedResult | null
@@ -70,6 +75,7 @@ interface DashboardState {
   budgetSummary: BudgetSummary | null
   recentTransactions: Transaction[]
   categories: string[]
+  categoryInfoList: CategoryInfo[]
   errorMessage: string
   lastFeedbackText: string
   lastPersona: string
@@ -87,7 +93,7 @@ interface DashboardState {
     note?: string | null
     feedback?: AIFeedbackContent
   }) => Promise<void>
-  createCategory: (category: string) => Promise<void>
+  createCategory: (category: string, type?: 'income' | 'expense') => Promise<void>
   updateTransaction: (id: string, data: { amount: number; category: string; merchant: string; date: string; note?: string }) => Promise<void>
   deleteTransaction: (id: string) => Promise<void>
   fetchBudgetSummary: () => Promise<void>
@@ -104,6 +110,16 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
   budgetSummary: null,
   recentTransactions: [],
   categories: ['food', 'transport', 'entertainment', 'shopping', 'daily', 'medical', 'education', 'other'],
+  categoryInfoList: [
+    { category: 'food', type: 'expense' },
+    { category: 'transport', type: 'expense' },
+    { category: 'entertainment', type: 'expense' },
+    { category: 'shopping', type: 'expense' },
+    { category: 'daily', type: 'expense' },
+    { category: 'medical', type: 'expense' },
+    { category: 'education', type: 'expense' },
+    { category: 'other', type: 'expense' },
+  ],
   errorMessage: '',
   lastFeedbackText: '',
   lastPersona: useSettingsStore.getState().persona || 'gentle',
@@ -111,8 +127,13 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
   fetchCategories: async () => {
     try {
       const res = await api.get('/budget/categories')
-      const cats = (res.data.data as Array<{ category: string }>).map((c) => c.category)
-      if (cats.length > 0) set({ categories: cats })
+      const rawCats = res.data.data as Array<{ category: string; type?: string }>
+      const cats = rawCats.map((c) => c.category)
+      const infoList: CategoryInfo[] = rawCats.map((c) => ({
+        category: c.category,
+        type: (c.type as 'income' | 'expense') || 'expense',
+      }))
+      if (cats.length > 0) set({ categories: cats, categoryInfoList: infoList })
     } catch {
       // Keep default categories
     }
@@ -215,9 +236,9 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
     }
   },
 
-  createCategory: async (category: string) => {
+  createCategory: async (category: string, type?: 'income' | 'expense') => {
     try {
-      await api.post('/budget/categories', { category })
+      await api.post('/budget/categories', { category, type: type || 'expense' })
       await get().fetchCategories()
     } catch (err: unknown) {
       const message =


### PR DESCRIPTION
## Summary
- **DB**: `CategoryBudget` 新增 `type` 欄位（`income` / `expense`），預設值 `expense`，含 migration
- **Seed**: 新增 5 個收入類別（薪資收入、投資收益、退休金、保險理賠、其他收入）
- **API**: `GET /budget/categories` 支援 `?type=income|expense` 篩選；`POST /budget/categories` 支援 `type` 欄位
- **前端 ParsedResultCard**: 切換收入/支出時僅顯示對應類型的類別選單，類別文字根據類型上色
- **前端設定頁面**: 新增類別管理區塊，分別顯示「支出類別」與「收入類別」，可新增自訂類別並指定類型
- **前端所有元件 (#67)**: TransactionItem、RecentTransactions、HistoryPage 等類別名稱套用收入綠色 (`text-success`) / 支出紅色 (`text-danger`)
- 更新 `API_Spec.yaml`、`categoryUtils.ts`（含新收入類別中文名稱）、後端測試

Closes #64
Closes #67

## Test plan
- [x] 後端 TypeScript 型別檢查通過
- [x] 後端 lint 通過
- [x] 後端 91 個測試全部通過（含新增 type 篩選測試、收入類別建立測試、無效 type 拒絕測試）
- [x] 前端 TypeScript 型別檢查通過
- [x] 前端 lint 通過
- [x] 前端 125 個測試全部通過
- [x] 前後端 build 成功