### PR TITLE
feat: 統計頁面區分收入/支出頁籤 (#68)

### DIFF
--- a/backend/src/routes/statsRoutes.test.ts
+++ b/backend/src/routes/statsRoutes.test.ts
@@ -131,6 +131,7 @@ describe('Stats Routes', () => {
           merchant: null,
           rawText: 'test',
           note: null,
+          type: 'expense',
           transactionDate: new Date('2026-01-15'),
           createdAt: new Date(),
           updatedAt: new Date(),
@@ -141,6 +142,100 @@ describe('Stats Routes', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.data.month).toBe('2026-01');
+    });
+
+    it('should filter by type=expense', async () => {
+      mockedPrisma.transaction.findMany.mockResolvedValue([
+        {
+          id: 't1',
+          userId: 'test-user-id',
+          amount: new Prisma.Decimal(5000),
+          category: 'food',
+          type: 'expense',
+          merchant: null,
+          rawText: '午餐',
+          note: null,
+          transactionDate: new Date(),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+
+      const res = await request(app).get('/api/v1/stats/distribution?type=expense');
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.total).toBe(5000);
+      expect(res.body.data.distribution).toHaveLength(1);
+      expect(res.body.data.distribution[0].category).toBe('food');
+
+      // Verify prisma was called with type filter
+      expect(mockedPrisma.transaction.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ type: 'expense' }),
+        }),
+      );
+    });
+
+    it('should filter by type=income', async () => {
+      mockedPrisma.transaction.findMany.mockResolvedValue([
+        {
+          id: 't1',
+          userId: 'test-user-id',
+          amount: new Prisma.Decimal(50000),
+          category: 'salary',
+          type: 'income',
+          merchant: null,
+          rawText: '薪水',
+          note: null,
+          transactionDate: new Date(),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 't2',
+          userId: 'test-user-id',
+          amount: new Prisma.Decimal(3000),
+          category: 'investment',
+          type: 'income',
+          merchant: null,
+          rawText: '股票收益',
+          note: null,
+          transactionDate: new Date(),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+
+      const res = await request(app).get('/api/v1/stats/distribution?type=income');
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.total).toBe(53000);
+      expect(res.body.data.distribution).toHaveLength(2);
+      expect(res.body.data.distribution[0].category).toBe('salary');
+
+      expect(mockedPrisma.transaction.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ type: 'income' }),
+        }),
+      );
+    });
+
+    it('should return all transactions when type is not specified', async () => {
+      mockedPrisma.transaction.findMany.mockResolvedValue([]);
+
+      await request(app).get('/api/v1/stats/distribution');
+
+      const calledWith = mockedPrisma.transaction.findMany.mock.calls[0][0];
+      expect(calledWith?.where).not.toHaveProperty('type');
+    });
+
+    it('should ignore invalid type parameter', async () => {
+      mockedPrisma.transaction.findMany.mockResolvedValue([]);
+
+      await request(app).get('/api/v1/stats/distribution?type=invalid');
+
+      const calledWith = mockedPrisma.transaction.findMany.mock.calls[0][0];
+      expect(calledWith?.where).not.toHaveProperty('type');
     });
   });
 });

--- a/backend/src/routes/statsRoutes.ts
+++ b/backend/src/routes/statsRoutes.ts
@@ -24,14 +24,24 @@ router.get('/distribution', authMiddleware, async (req: AuthRequest, res: Respon
       month = now.getMonth();
     }
 
+    // Support optional type query param (income | expense)
+    const typeParam = req.query.type as string | undefined;
+    const validTypes = ['income', 'expense'];
+    const typeFilter = typeParam && validTypes.includes(typeParam) ? typeParam : undefined;
+
     const monthStart = new Date(year, month, 1);
     const monthEnd = new Date(year, month + 1, 0, 23, 59, 59, 999);
 
+    const whereClause: Record<string, unknown> = {
+      userId,
+      transactionDate: { gte: monthStart, lte: monthEnd },
+    };
+    if (typeFilter) {
+      whereClause.type = typeFilter;
+    }
+
     const transactions = await prisma.transaction.findMany({
-      where: {
-        userId,
-        transactionDate: { gte: monthStart, lte: monthEnd },
-      },
+      where: whereClause,
     });
 
     const total = transactions.reduce((sum, t) => sum + Number(t.amount), 0);

--- a/docs/API_Spec.yaml
+++ b/docs/API_Spec.yaml
@@ -701,7 +701,7 @@ paths:
   /stats/distribution:
     get:
       tags: [Stats]
-      summary: 取得消費類別分佈
+      summary: 取得類別分佈統計
       operationId: getDistribution
       security:
         - BearerAuth: []
@@ -712,6 +712,12 @@ paths:
           schema:
             type: string
             pattern: '^\d{4}-\d{2}$'
+        - name: type
+          in: query
+          description: 篩選交易類型（income 或 expense），不傳則返回全部
+          schema:
+            type: string
+            enum: [income, expense]
       responses:
         '200':
           description: 成功

--- a/frontend/src/components/DistributionChart.tsx
+++ b/frontend/src/components/DistributionChart.tsx
@@ -10,15 +10,16 @@ export interface DistributionItem {
 interface DistributionChartProps {
   data: DistributionItem[]
   totalSpent: number
+  emptyMessage?: string
 }
 
-function DistributionChart({ data, totalSpent }: DistributionChartProps) {
+function DistributionChart({ data, totalSpent, emptyMessage = '本月尚無消費記錄' }: DistributionChartProps) {
   if (data.length === 0) {
     return (
       <div className="text-center py-3xl" data-testid="distribution-chart-empty">
         <div className="w-[200px] h-[200px] mx-auto border-2 border-dashed border-text-tertiary rounded-full flex items-center justify-center mb-lg">
           <p className="text-body text-text-tertiary">
-            本月尚無消費記錄
+            {emptyMessage}
           </p>
         </div>
       </div>

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -14,48 +14,67 @@ interface BudgetSummaryData {
 }
 
 type TimeFilter = 'week' | 'month' | 'custom'
+type TypeTab = 'expense' | 'income'
 
 function StatsPage() {
   const [timeFilter, setTimeFilter] = useState<TimeFilter>('month')
+  const [typeTab, setTypeTab] = useState<TypeTab>('expense')
   const [budgetSummary, setBudgetSummary] = useState<BudgetSummaryData | null>(null)
   const [distribution, setDistribution] = useState<DistributionItem[]>([])
+  const [totalAmount, setTotalAmount] = useState(0)
   const [loading, setLoading] = useState(true)
 
   const fetchData = useCallback(async () => {
     setLoading(true)
     try {
-      const [budgetRes, distRes] = await Promise.all([
-        api.get('/budget/summary'),
-        api.get('/stats/distribution', { params: { period: timeFilter } }),
-      ])
+      const requests: Promise<unknown>[] = [
+        api.get('/stats/distribution', { params: { period: timeFilter, type: typeTab } }),
+      ]
 
-      const b = budgetRes.data.data
-      setBudgetSummary({
-        month: b.month,
-        monthlyBudget: b.monthly_budget,
-        totalSpent: b.total_spent,
-        remaining: b.remaining,
-        usedRatio: b.used_ratio,
-      })
+      // Only fetch budget summary for expense tab
+      if (typeTab === 'expense') {
+        requests.push(api.get('/budget/summary'))
+      }
 
+      const results = await Promise.all(requests)
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const distRes = results[0] as any
       const rawDist = (distRes.data.data.distribution ?? distRes.data.data.categories ?? []) as Array<{
         category: string
         amount: number
         ratio?: number
         percentage?: number
       }>
+      const total = rawDist.reduce((sum, c) => sum + c.amount, 0)
       const items: DistributionItem[] = rawDist.map((c) => ({
         category: c.category,
         amount: c.amount,
         percentage: c.percentage ?? Math.round((c.ratio ?? 0) * 100),
       }))
       setDistribution(items)
+      setTotalAmount(total)
+
+      if (typeTab === 'expense' && results[1]) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const budgetRes = results[1] as any
+        const b = budgetRes.data.data
+        setBudgetSummary({
+          month: b.month,
+          monthlyBudget: b.monthly_budget,
+          totalSpent: b.total_spent,
+          remaining: b.remaining,
+          usedRatio: b.used_ratio,
+        })
+      } else {
+        setBudgetSummary(null)
+      }
     } catch {
       // Silently fail - show empty state
     } finally {
       setLoading(false)
     }
-  }, [timeFilter])
+  }, [timeFilter, typeTab])
 
   useEffect(() => {
     void fetchData()
@@ -68,6 +87,8 @@ function StatsPage() {
   const ranked = [...distribution].sort((a, b) => b.amount - a.amount)
   const maxAmount = ranked.length > 0 ? ranked[0].amount : 0
 
+  const isExpense = typeTab === 'expense'
+
   return (
     <div className="p-2xl pb-[100px]">
       {/* Header */}
@@ -76,6 +97,32 @@ function StatsPage() {
           📊 統計
         </h1>
       </header>
+
+      {/* Income / Expense Tab */}
+      <div className="flex mb-xl bg-surface rounded-lg shadow-card overflow-hidden" role="tablist">
+        {([
+          { key: 'expense' as const, label: '支出' },
+          { key: 'income' as const, label: '收入' },
+        ]).map(({ key, label }) => (
+          <button
+            key={key}
+            type="button"
+            role="tab"
+            aria-selected={typeTab === key}
+            data-testid={`tab-${key}`}
+            onClick={() => setTypeTab(key)}
+            className={`flex-1 py-sm text-body font-semibold transition-colors ${
+              typeTab === key
+                ? key === 'expense'
+                  ? 'bg-danger text-surface'
+                  : 'bg-success text-surface'
+                : 'bg-surface text-text-secondary'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
 
       {/* Time filter */}
       <div className="flex gap-sm mb-xl">
@@ -108,34 +155,37 @@ function StatsPage() {
         </div>
       ) : (
         <>
-          {/* Budget summary card */}
+          {/* Total amount card */}
           <section
             className="bg-surface rounded-lg shadow-card p-lg mb-xl"
-            aria-label="本月總支出"
+            aria-label={isExpense ? '本月總支出' : '本月總收入'}
           >
             <div className="flex justify-between items-baseline mb-sm">
               <p className="text-caption text-text-secondary">
-                本月總支出
+                {isExpense ? '本月總支出' : '本月總收入'}
               </p>
-              {budgetSummary && budgetSummary.monthlyBudget > 0 && (
+              {isExpense && budgetSummary && budgetSummary.monthlyBudget > 0 && (
                 <p className="text-small text-text-secondary">
                   目標：{formatMoney(budgetSummary.monthlyBudget)}
                 </p>
               )}
             </div>
-            <p className="text-headline font-bold text-danger mb-md">
-              {budgetSummary ? formatMoney(budgetSummary.totalSpent) : '$0'}
+            <p className={`text-headline font-bold mb-md ${isExpense ? 'text-danger' : 'text-success'}`}>
+              {isExpense
+                ? formatMoney(budgetSummary?.totalSpent ?? totalAmount)
+                : formatMoney(totalAmount)}
             </p>
-            {budgetSummary && budgetSummary.monthlyBudget > 0 && (
+            {isExpense && budgetSummary && budgetSummary.monthlyBudget > 0 && (
               <BudgetBar usedRatio={budgetSummary.usedRatio} />
             )}
           </section>
 
           {/* Distribution chart */}
-          <section aria-label="消費分佈" className="mb-xl">
+          <section aria-label={isExpense ? '支出分佈' : '收入分佈'} className="mb-xl">
             <DistributionChart
               data={distribution}
-              totalSpent={budgetSummary?.totalSpent ?? 0}
+              totalSpent={isExpense ? (budgetSummary?.totalSpent ?? totalAmount) : totalAmount}
+              emptyMessage={isExpense ? '本月尚無支出記錄' : '本月尚無收入記錄'}
             />
           </section>
 

--- a/frontend/src/test/StatsPage.test.tsx
+++ b/frontend/src/test/StatsPage.test.tsx
@@ -1,0 +1,237 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import StatsPage from '../pages/StatsPage'
+
+// Mock recharts
+vi.mock('recharts', () => {
+  const MockResponsiveContainer = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  )
+  const MockPieChart = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="pie-chart">{children}</div>
+  )
+  const MockPie = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="pie">{children}</div>
+  )
+  const MockCell = ({ fill }: { fill: string }) => (
+    <div data-testid="cell" data-fill={fill} />
+  )
+  const MockTooltip = () => <div data-testid="tooltip" />
+
+  return {
+    ResponsiveContainer: MockResponsiveContainer,
+    PieChart: MockPieChart,
+    Pie: MockPie,
+    Cell: MockCell,
+    Tooltip: MockTooltip,
+  }
+})
+
+// Mock api module
+const mockGet = vi.fn()
+vi.mock('../lib/api.ts', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    put: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+function renderStatsPage() {
+  return render(
+    <MemoryRouter>
+      <StatsPage />
+    </MemoryRouter>,
+  )
+}
+
+const mockDistributionResponse = (items: Array<{ category: string; amount: number; ratio: number }>) => ({
+  data: {
+    code: 200,
+    data: {
+      month: '2026-03',
+      total: items.reduce((sum, i) => sum + i.amount, 0),
+      distribution: items,
+    },
+  },
+})
+
+const mockBudgetResponse = (budget = 50000, spent = 30000) => ({
+  data: {
+    code: 200,
+    data: {
+      month: '2026-03',
+      monthly_budget: budget,
+      total_spent: spent,
+      remaining: budget - spent,
+      used_ratio: spent / budget,
+    },
+  },
+})
+
+describe('StatsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders expense tab as default with budget bar', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/stats/distribution') {
+        return Promise.resolve(mockDistributionResponse([
+          { category: 'food', amount: 7000, ratio: 0.7 },
+          { category: 'transport', amount: 3000, ratio: 0.3 },
+        ]))
+      }
+      if (url === '/budget/summary') {
+        return Promise.resolve(mockBudgetResponse())
+      }
+      return Promise.resolve({ data: { data: {} } })
+    })
+
+    renderStatsPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('本月總支出')).toBeInTheDocument()
+    })
+
+    // Expense tab should be selected
+    const expenseTab = screen.getByTestId('tab-expense')
+    expect(expenseTab).toHaveAttribute('aria-selected', 'true')
+
+    // Budget bar should be present
+    expect(screen.getByTestId('budget-bar')).toBeInTheDocument()
+
+    // Distribution chart should render
+    expect(screen.getByTestId('distribution-chart')).toBeInTheDocument()
+
+    // API should be called with type=expense
+    expect(mockGet).toHaveBeenCalledWith('/stats/distribution', expect.objectContaining({
+      params: expect.objectContaining({ type: 'expense' }),
+    }))
+  })
+
+  it('switches to income tab and hides budget bar', async () => {
+    const user = userEvent.setup()
+
+    mockGet.mockImplementation((url: string, config?: { params?: { type?: string } }) => {
+      const type = config?.params?.type
+      if (url === '/stats/distribution' && type === 'expense') {
+        return Promise.resolve(mockDistributionResponse([
+          { category: 'food', amount: 7000, ratio: 1.0 },
+        ]))
+      }
+      if (url === '/stats/distribution' && type === 'income') {
+        return Promise.resolve(mockDistributionResponse([
+          { category: 'salary', amount: 50000, ratio: 0.9 },
+          { category: 'investment', amount: 5000, ratio: 0.1 },
+        ]))
+      }
+      if (url === '/budget/summary') {
+        return Promise.resolve(mockBudgetResponse())
+      }
+      return Promise.resolve({ data: { data: {} } })
+    })
+
+    renderStatsPage()
+
+    // Wait for initial load
+    await waitFor(() => {
+      expect(screen.getByText('本月總支出')).toBeInTheDocument()
+    })
+
+    // Click income tab
+    const incomeTab = screen.getByTestId('tab-income')
+    await user.click(incomeTab)
+
+    await waitFor(() => {
+      expect(screen.getByText('本月總收入')).toBeInTheDocument()
+    })
+
+    // Income tab should be selected
+    expect(incomeTab).toHaveAttribute('aria-selected', 'true')
+
+    // Budget bar should NOT be present
+    expect(screen.queryByTestId('budget-bar')).not.toBeInTheDocument()
+
+    // Budget summary should NOT have been requested for income tab
+    const incomeCalls = mockGet.mock.calls.filter(
+      (call) => call[0] === '/budget/summary' && call[1]?.params?.type === 'income',
+    )
+    expect(incomeCalls).toHaveLength(0)
+  })
+
+  it('shows empty state message for income tab when no data', async () => {
+    mockGet.mockImplementation((url: string, config?: { params?: { type?: string } }) => {
+      const type = config?.params?.type
+      if (url === '/stats/distribution' && type === 'expense') {
+        return Promise.resolve(mockDistributionResponse([]))
+      }
+      if (url === '/stats/distribution' && type === 'income') {
+        return Promise.resolve(mockDistributionResponse([]))
+      }
+      if (url === '/budget/summary') {
+        return Promise.resolve(mockBudgetResponse(0, 0))
+      }
+      return Promise.resolve({ data: { data: {} } })
+    })
+
+    const user = userEvent.setup()
+    renderStatsPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('本月尚無支出記錄')).toBeInTheDocument()
+    })
+
+    // Switch to income
+    await user.click(screen.getByTestId('tab-income'))
+
+    await waitFor(() => {
+      expect(screen.getByText('本月尚無收入記錄')).toBeInTheDocument()
+    })
+  })
+
+  it('displays income total in green and expense total in red', async () => {
+    mockGet.mockImplementation((url: string, config?: { params?: { type?: string } }) => {
+      const type = config?.params?.type
+      if (url === '/stats/distribution' && type === 'expense') {
+        return Promise.resolve(mockDistributionResponse([
+          { category: 'food', amount: 5000, ratio: 1.0 },
+        ]))
+      }
+      if (url === '/stats/distribution' && type === 'income') {
+        return Promise.resolve(mockDistributionResponse([
+          { category: 'salary', amount: 50000, ratio: 1.0 },
+        ]))
+      }
+      if (url === '/budget/summary') {
+        return Promise.resolve(mockBudgetResponse(50000, 5000))
+      }
+      return Promise.resolve({ data: { data: {} } })
+    })
+
+    const user = userEvent.setup()
+    renderStatsPage()
+
+    // Expense tab - red headline
+    await waitFor(() => {
+      const section = screen.getByLabelText('本月總支出')
+      const headline = section.querySelector('.text-headline')
+      expect(headline).not.toBeNull()
+      expect(headline!.className).toContain('text-danger')
+      expect(headline!.textContent).toBe('$5,000')
+    })
+
+    // Switch to income tab - green headline
+    await user.click(screen.getByTestId('tab-income'))
+
+    await waitFor(() => {
+      const section = screen.getByLabelText('本月總收入')
+      const headline = section.querySelector('.text-headline')
+      expect(headline).not.toBeNull()
+      expect(headline!.className).toContain('text-success')
+      expect(headline!.textContent).toBe('$50,000')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- 後端 `GET /stats/distribution` 增加 `?type=income|expense` query 參數，依交易類型篩選統計分佈
- 前端 `StatsPage` 增加「支出 / 收入」頁籤切換 UI
  - **支出頁籤**：預算血條 + 支出圓餅圖 + 支出總額（紅色系）
  - **收入頁籤**：收入圓餅圖 + 收入總額（綠色系），無預算血條
- `DistributionChart` 新增 `emptyMessage` prop 支援不同空白提示
- 更新 `docs/API_Spec.yaml`

Closes #68

## Test plan
- [x] 後端：type=expense 篩選測試
- [x] 後端：type=income 篩選測試
- [x] 後端：無 type 參數向後相容測試
- [x] 後端：無效 type 參數忽略測試
- [x] 前端：預設顯示支出 Tab + 預算血條
- [x] 前端：切換收入 Tab 隱藏預算血條
- [x] 前端：空資料顯示對應空白訊息
- [x] 前端：收入/支出金額顏色區分