### PR TITLE
fix: 修正 LLM 解析容錯、收入類別識別與帳目持久化 (#77)

### DIFF
--- a/backend/src/prompts/dataExtractorPrompt.ts
+++ b/backend/src/prompts/dataExtractorPrompt.ts
@@ -1,18 +1,34 @@
 import { DataExtractorInput } from '../types/llm';
 
 export function buildDataExtractorPrompt(input: DataExtractorInput): string {
-  const categoriesList = input.categories.join(', ');
+  // Build categorized list if available, otherwise use flat list
+  let categorySection: string;
+  if (input.categoriesWithType && input.categoriesWithType.length > 0) {
+    const expenseCats = input.categoriesWithType
+      .filter((c) => c.type === 'expense')
+      .map((c) => c.category);
+    const incomeCats = input.categoriesWithType
+      .filter((c) => c.type === 'income')
+      .map((c) => c.category);
+    categorySection = `   - 消費類別：[${expenseCats.join(', ')}]\n   - 收入類別：[${incomeCats.join(', ')}]`;
+  } else {
+    categorySection = `   [${input.categories.join(', ')}]`;
+  }
 
   return `你是一個記帳助手，負責將使用者的自然語言輸入轉換為結構化的 JSON 資料。
 
 ## 規則
 1. 從使用者輸入中萃取：交易類型、金額、類別、商家、日期
 2. **交易類型（type）**：判斷是收入（income）還是消費（expense）
-   - 收入關鍵字：薪水、薪資、獎金、紅包、退款、利息、收入、入帳、進帳、賣出、兼職、稿費、股息等
+   - 收入關鍵字：薪水、薪資、獎金、紅包、退款、利息、收入、入帳、進帳、賣出、兼職、稿費、股息、投資獲利、賺、中獎等
    - 消費關鍵字：買、吃、喝、搭、付、花、繳、租、訂閱等（或任何花錢行為）
    - 若無法明確判斷收入或消費，設 type 為 "expense"（預設為消費）
 3. 金額必須為正數。若無法辨識金額，回傳 amount 為 null
-4. 類別必須從以下清單中選擇：[${categoriesList}]
+4. **類別選擇**：根據判斷的交易類型（type），從對應的類別清單中選擇：
+${categorySection}
+   - 若 type 為 "income"，**必須**從收入類別中選擇最匹配的項目
+   - 若 type 為 "expense"，**必須**從消費類別中選擇最匹配的項目
+   - 例如：投資股票賺錢 → type: "income", category: "investment"；領薪水 → type: "income", category: "salary"
 5. 「other」僅用於真正無法歸類的雜項消費。若消費有明確主題（如寵物、健身、才藝、育兒等），不應歸入 other，而應設 is_new_category 為 true，並在 suggested_category 中填入建議的新類別名稱（使用中文）
 6. 偵測相似類別名稱（如「咖啡」與「飲料」），避免重複建立，優先歸入現有類別
 7. 若未提及商家，根據消費內容推測合理的商家名稱

--- a/backend/src/services/llm/geminiProvider.ts
+++ b/backend/src/services/llm/geminiProvider.ts
@@ -91,9 +91,10 @@ export class GeminiProvider implements LLMProvider {
     // Strip thinking tags (e.g. <think>...</think>)
     cleaned = cleaned.replace(/<think>[\s\S]*?<\/think>/gi, '').trim();
 
-    // Strip markdown code blocks if present
-    if (cleaned.startsWith('```')) {
-      cleaned = cleaned.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '');
+    // Strip markdown code blocks anywhere in the text (not just at start)
+    const codeBlockMatch = cleaned.match(/```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/);
+    if (codeBlockMatch) {
+      cleaned = codeBlockMatch[1].trim();
     }
 
     // Try direct parse first

--- a/backend/src/services/llm/openaiProvider.ts
+++ b/backend/src/services/llm/openaiProvider.ts
@@ -74,9 +74,10 @@ export class OpenAIProvider implements LLMProvider {
     // Strip thinking tags
     cleaned = cleaned.replace(/<think>[\s\S]*?<\/think>/gi, '').trim();
 
-    // Strip markdown code blocks
-    if (cleaned.startsWith('```')) {
-      cleaned = cleaned.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '');
+    // Strip markdown code blocks anywhere in the text (not just at start)
+    const codeBlockMatch = cleaned.match(/```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/);
+    if (codeBlockMatch) {
+      cleaned = codeBlockMatch[1].trim();
     }
 
     try {

--- a/backend/src/services/llmService.ts
+++ b/backend/src/services/llmService.ts
@@ -30,14 +30,19 @@ export async function parseTransaction(
   const persona = user.persona as Persona;
   const provider = getProvider(engine);
 
-  // Build category list for prompt
+  // Build category list for prompt (with type info for correct income/expense mapping)
   const categories = user.categoryBudgets.map((cb) => cb.category);
+  const categoriesWithType = user.categoryBudgets.map((cb) => ({
+    category: cb.category,
+    type: (cb.type || 'expense') as 'income' | 'expense',
+  }));
   const currentDate = new Date().toISOString().split('T')[0];
 
   // 1. Data extraction
   const extractorPrompt = buildDataExtractorPrompt({
     rawText,
     categories,
+    categoriesWithType,
     currentDate,
   });
 

--- a/backend/src/types/llm.ts
+++ b/backend/src/types/llm.ts
@@ -29,9 +29,15 @@ export interface BudgetContext {
   category_limit: number;
 }
 
+export interface CategoryWithType {
+  category: string;
+  type: 'income' | 'expense';
+}
+
 export interface DataExtractorInput {
   rawText: string;
   categories: string[];
+  categoriesWithType?: CategoryWithType[];
   currentDate: string;
 }
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -18,6 +18,7 @@ function DashboardPage() {
   const {
     status,
     parsedResult,
+    lastRawText,
     aiFeedback,
     budgetSummary,
     recentTransactions,
@@ -58,13 +59,13 @@ function DashboardPage() {
     }) => {
       await confirmTransaction({
         ...data,
-        rawText: parsedResult?.merchant ?? data.merchant,
+        rawText: lastRawText || data.merchant,
         note: parsedResult?.note,
         feedback: aiFeedback ?? undefined,
       })
       fetchBudgetSummary()
     },
-    [confirmTransaction, parsedResult, aiFeedback, fetchBudgetSummary]
+    [confirmTransaction, lastRawText, parsedResult, aiFeedback, fetchBudgetSummary]
   )
 
   const handleNewCategoryConfirm = useCallback(
@@ -78,7 +79,7 @@ function DashboardPage() {
             category: categoryName,
             merchant: parsedResult.merchant,
             date: parsedResult.date,
-            rawText: parsedResult.merchant,
+            rawText: lastRawText || parsedResult.merchant,
             note: parsedResult.note,
             feedback: aiFeedback ?? undefined,
           })
@@ -92,6 +93,7 @@ function DashboardPage() {
       createCategory,
       confirmTransaction,
       parsedResult,
+      lastRawText,
       aiFeedback,
       fetchBudgetSummary,
     ]
@@ -106,14 +108,14 @@ function DashboardPage() {
           category,
           merchant: parsedResult.merchant,
           date: parsedResult.date,
-          rawText: parsedResult.merchant,
+          rawText: lastRawText || parsedResult.merchant,
           note: parsedResult.note,
           feedback: aiFeedback ?? undefined,
         })
         fetchBudgetSummary()
       }
     },
-    [confirmTransaction, parsedResult, aiFeedback, fetchBudgetSummary]
+    [confirmTransaction, parsedResult, lastRawText, aiFeedback, fetchBudgetSummary]
   )
 
   const isParsing = status === 'parsing'

--- a/frontend/src/stores/dashboardStore.ts
+++ b/frontend/src/stores/dashboardStore.ts
@@ -70,6 +70,7 @@ export interface CategoryInfo {
 interface DashboardState {
   status: DashboardStatus
   parsedResult: ParsedResult | null
+  lastRawText: string
   aiFeedback: AIFeedbackContent | null
   budgetContext: BudgetContext | null
   budgetSummary: BudgetSummary | null
@@ -105,6 +106,7 @@ interface DashboardState {
 export const useDashboardStore = create<DashboardState>((set, get) => ({
   status: 'idle',
   parsedResult: null,
+  lastRawText: '',
   aiFeedback: null,
   budgetContext: null,
   budgetSummary: null,
@@ -140,7 +142,7 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
   },
 
   parseInput: async (rawText: string) => {
-    set({ status: 'parsing', errorMessage: '' })
+    set({ status: 'parsing', errorMessage: '', lastRawText: rawText })
     try {
       const llmApiKey = getActiveApiKey()
       const res = await api.post(
@@ -334,7 +336,7 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
   },
 
   resetParsedResult: () => {
-    set({ status: 'idle', parsedResult: null, errorMessage: '' })
+    set({ status: 'idle', parsedResult: null, lastRawText: '', errorMessage: '' })
   },
 
   setError: (message: string) => {


### PR DESCRIPTION
## Summary

- **LLM 解析容錯**：改善 `parseJSON` 對 markdown code fences 的處理邏輯，支援 code block 出現在回傳文字中間（非開頭）的情況，降低偶發性「LLM 回傳格式異常」錯誤
- **收入類別識別**：將 prompt 中的類別清單依 income/expense 分組顯示，並明確指示 LLM 根據交易類型從對應類別中選擇，解決所有收入都被歸類為「薪資」的問題
- **帳目持久化**：修正前端 `DashboardPage` 中 `confirmTransaction` 使用 merchant 作為 `rawText` 的錯誤，改為在 store 中保存使用者原始輸入文字，確保 `POST /transactions` 的 `raw_text` 欄位傳遞正確值

## Changed Files

| 檔案 | 變更說明 |
|------|----------|
| `backend/src/services/llm/geminiProvider.ts` | 改善 parseJSON code fence 處理 |
| `backend/src/services/llm/openaiProvider.ts` | 同上 |
| `backend/src/prompts/dataExtractorPrompt.ts` | 將類別清單依收入/支出分組顯示 |
| `backend/src/types/llm.ts` | 新增 `CategoryWithType` 介面 |
| `backend/src/services/llmService.ts` | 傳遞帶有 type 的類別列表至 prompt |
| `frontend/src/stores/dashboardStore.ts` | 新增 `lastRawText` state 保存原始輸入 |
| `frontend/src/pages/DashboardPage.tsx` | 使用 `lastRawText` 替代 merchant 作為 rawText |

## Test Plan

- [x] `backend`: tsc --noEmit, lint, test (96 passed), build
- [x] `frontend`: tsc --noEmit, lint, test (136 passed), build

Closes #77