### PR TITLE
feat: 首頁新增總資產區塊與預算並排顯示 (#80)

### DIFF
--- a/backend/src/routes/budgetRoutes.ts
+++ b/backend/src/routes/budgetRoutes.ts
@@ -230,6 +230,10 @@ router.get('/summary', authMiddleware, async (req: AuthRequest, res: Response, n
     const remaining = monthlyBudget - totalSpent;
     const usedRatio = monthlyBudget > 0 ? Math.round((totalSpent / monthlyBudget) * 100) / 100 : 0;
 
+    // Calculate total asset: income (positive) + expense (negative)
+    const totalIncome = transactions.filter(t => t.type === 'income').reduce((sum, t) => sum + Number(t.amount), 0);
+    const totalAsset = totalIncome - totalSpent;
+
     // Build category breakdown
     const categoryBudgets = await prisma.categoryBudget.findMany({
       where: { userId },
@@ -269,6 +273,8 @@ router.get('/summary', authMiddleware, async (req: AuthRequest, res: Response, n
         total_spent: totalSpent,
         remaining,
         used_ratio: usedRatio,
+        total_income: totalIncome,
+        total_asset: totalAsset,
         transaction_count: transactions.length,
         categories: categoriesDetail,
       },

--- a/docs/API_Spec.yaml
+++ b/docs/API_Spec.yaml
@@ -958,6 +958,12 @@ components:
           type: number
         used_ratio:
           type: number
+        total_income:
+          type: number
+          description: 當月總收入
+        total_asset:
+          type: number
+          description: 當月總資產（收入 - 支出）
         transaction_count:
           type: integer
         category_summary:

--- a/frontend/src/components/AssetCard.tsx
+++ b/frontend/src/components/AssetCard.tsx
@@ -1,0 +1,59 @@
+import type { BudgetSummary } from '../stores/dashboardStore'
+
+interface AssetCardProps {
+  summary: BudgetSummary | null
+}
+
+function AssetCard({ summary }: AssetCardProps) {
+  const formatMoney = (n: number) =>
+    `$${Math.abs(n).toLocaleString('zh-TW', { maximumFractionDigits: 0 })}`
+
+  if (!summary) {
+    return (
+      <section
+        className="bg-surface rounded-lg shadow-card p-lg flex-1 min-w-0"
+        aria-label="總資產"
+      >
+        <h2 className="text-caption text-text-secondary mb-sm">
+          總資產
+        </h2>
+        <p className="text-display font-bold text-text-primary">
+          --
+        </p>
+        <p className="text-caption text-text-secondary mt-sm">
+          尚無交易紀錄
+        </p>
+      </section>
+    )
+  }
+
+  const { totalAsset, totalIncome, totalSpent } = summary
+  const isPositive = totalAsset >= 0
+
+  return (
+    <section
+      className="bg-surface rounded-lg shadow-card p-lg flex-1 min-w-0"
+      aria-label="總資產"
+    >
+      <p className="text-caption text-text-secondary mb-xs">
+        總資產
+      </p>
+      <p
+        className={`text-display font-bold ${isPositive ? 'text-primary' : 'text-danger'}`}
+        aria-live="polite"
+      >
+        {isPositive ? '+' : '-'}{formatMoney(totalAsset)}
+      </p>
+      <div className="flex justify-between mt-sm">
+        <span className="text-small text-text-secondary">
+          收入 {formatMoney(totalIncome)}
+        </span>
+        <span className="text-small text-text-secondary">
+          支出 {formatMoney(totalSpent)}
+        </span>
+      </div>
+    </section>
+  )
+}
+
+export default AssetCard

--- a/frontend/src/components/BudgetCard.tsx
+++ b/frontend/src/components/BudgetCard.tsx
@@ -3,13 +3,18 @@ import BudgetBar from './BudgetBar'
 
 interface BudgetCardProps {
   summary: BudgetSummary | null
+  compact?: boolean
 }
 
-function BudgetCard({ summary }: BudgetCardProps) {
+function BudgetCard({ summary, compact }: BudgetCardProps) {
+  const baseClass = compact
+    ? 'bg-surface rounded-lg shadow-card p-lg flex-1 min-w-0'
+    : 'bg-surface rounded-lg shadow-card p-lg mx-2xl mb-xl'
+
   if (!summary || summary.monthlyBudget <= 0) {
     return (
       <section
-        className="bg-surface rounded-lg shadow-card p-lg mx-2xl mb-xl"
+        className={baseClass}
         aria-label="預算概覽"
       >
         <h2 className="text-caption text-text-secondary mb-sm">
@@ -42,9 +47,42 @@ function BudgetCard({ summary }: BudgetCardProps) {
   const formatMoney = (n: number) =>
     `$${n.toLocaleString('zh-TW', { maximumFractionDigits: 0 })}`
 
+  if (compact) {
+    return (
+      <section
+        className={baseClass}
+        aria-label="預算概覽"
+      >
+        <p className="text-caption text-text-secondary mb-xs">
+          預算剩餘
+        </p>
+        <p
+          className={`text-display font-bold ${getPercentColor()}`}
+          aria-live="polite"
+        >
+          {isOverBudget ? '超支' : `${remainingPercent}%`}
+        </p>
+
+        {/* Progress bar */}
+        <div className="my-sm">
+          <BudgetBar usedRatio={usedRatio} />
+        </div>
+
+        <div className="flex justify-between">
+          <span className="text-small text-text-secondary">
+            支出 {formatMoney(totalSpent)}
+          </span>
+          <span className="text-small text-text-secondary">
+            目標 {formatMoney(monthlyBudget)}
+          </span>
+        </div>
+      </section>
+    )
+  }
+
   return (
     <section
-      className="bg-surface rounded-lg shadow-card p-lg mx-2xl mb-xl"
+      className={baseClass}
       aria-label="預算概覽"
     >
       <div className="flex justify-between items-start mb-sm">

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useDashboardStore } from '../stores/dashboardStore'
 import VoiceInput from '../components/VoiceInput'
+import AssetCard from '../components/AssetCard'
 import BudgetCard from '../components/BudgetCard'
 import AIFeedbackCard from '../components/AIFeedbackCard'
 import RecentTransactions from '../components/RecentTransactions'
@@ -155,8 +156,11 @@ function DashboardPage() {
           </button>
         </header>
 
-        {/* Budget Card */}
-        <BudgetCard summary={budgetSummary} />
+        {/* Asset & Budget Cards */}
+        <div className="flex gap-md mx-2xl mb-xl">
+          <AssetCard summary={budgetSummary} />
+          <BudgetCard summary={budgetSummary} compact />
+        </div>
 
         {/* AI Feedback Card */}
         <AIFeedbackCard

--- a/frontend/src/stores/dashboardStore.ts
+++ b/frontend/src/stores/dashboardStore.ts
@@ -51,6 +51,8 @@ export interface BudgetSummary {
   totalSpent: number
   remaining: number
   usedRatio: number
+  totalIncome: number
+  totalAsset: number
   transactionCount: number
 }
 
@@ -260,6 +262,8 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
           totalSpent: d.total_spent,
           remaining: d.remaining,
           usedRatio: d.used_ratio,
+          totalIncome: d.total_income ?? 0,
+          totalAsset: d.total_asset ?? 0,
           transactionCount: d.transaction_count,
         },
       })

--- a/frontend/src/test/dashboardComponents.test.tsx
+++ b/frontend/src/test/dashboardComponents.test.tsx
@@ -23,6 +23,8 @@ describe('BudgetCard', () => {
       totalSpent: 5000,
       remaining: 15000,
       usedRatio: 0.25,
+      totalIncome: 10000,
+      totalAsset: 5000,
       transactionCount: 10,
     }
     render(<BudgetCard summary={summary} />)
@@ -38,6 +40,8 @@ describe('BudgetCard', () => {
       totalSpent: 18000,
       remaining: 2000,
       usedRatio: 0.9,
+      totalIncome: 20000,
+      totalAsset: 2000,
       transactionCount: 30,
     }
     render(<BudgetCard summary={summary} />)
@@ -51,6 +55,8 @@ describe('BudgetCard', () => {
       totalSpent: 22000,
       remaining: -2000,
       usedRatio: 1.1,
+      totalIncome: 20000,
+      totalAsset: -2000,
       transactionCount: 40,
     }
     render(<BudgetCard summary={summary} />)

--- a/frontend/src/test/dashboardStore.test.ts
+++ b/frontend/src/test/dashboardStore.test.ts
@@ -113,6 +113,8 @@ describe('dashboardStore', () => {
           totalSpent: 5000,
           remaining: 15000,
           usedRatio: 0.25,
+          totalIncome: 10000,
+          totalAsset: 5000,
           transactionCount: 10,
         },
       })


### PR DESCRIPTION
## Summary
- 在首頁上方新增「總資產」卡片（AssetCard），與現有「預算」卡片並排顯示
- 後端 `GET /budget/summary` API 回應新增 `total_income`、`total_asset` 欄位
- BudgetCard 支援 compact 模式，雙欄等寬排列
- 資產正值顯示綠色，負值顯示紅色，隨帳目增減即時更新

## Changes
- **後端**：`budgetRoutes.ts` — 計算 totalIncome / totalAsset 並回傳
- **前端**：新增 `AssetCard.tsx` 組件
- **前端**：`BudgetCard.tsx` — 新增 compact prop 支援緊湊模式
- **前端**：`DashboardPage.tsx` — 上方改為 flex 雙欄佈局
- **前端**：`dashboardStore.ts` — BudgetSummary 型別增加 totalIncome / totalAsset
- **文件**：`API_Spec.yaml` — BudgetSummary schema 新增欄位
- **測試**：更新 mock 資料以符合新型別

## Test plan
- [x] 後端 TypeScript 編譯通過
- [x] 後端 96 tests 全部通過
- [x] 前端 TypeScript 編譯通過
- [x] 前端 136 tests 全部通過
- [x] 前後端 build 成功

Closes #80