### PR TITLE
fix(frontend): 記錄頁面新增修改功能與金額格式修正 (#78)

### DIFF
--- a/frontend/src/components/TransactionItem.test.tsx
+++ b/frontend/src/components/TransactionItem.test.tsx
@@ -24,7 +24,9 @@ describe('TransactionItem', () => {
         isExpanded={false}
         onToggle={() => {}}
         onDelete={vi.fn()}
+        onUpdate={vi.fn()}
         isDeleting={false}
+        isUpdating={false}
       />
     )
     const amountEl = screen.getByText(/-\$500/)
@@ -39,7 +41,9 @@ describe('TransactionItem', () => {
         isExpanded={false}
         onToggle={() => {}}
         onDelete={vi.fn()}
+        onUpdate={vi.fn()}
         isDeleting={false}
+        isUpdating={false}
       />
     )
     const amountEl = screen.getByText(/\+\$500/)
@@ -54,7 +58,9 @@ describe('TransactionItem', () => {
         isExpanded={true}
         onToggle={() => {}}
         onDelete={vi.fn()}
+        onUpdate={vi.fn()}
         isDeleting={false}
+        isUpdating={false}
       />
     )
     // There are two: summary row and detail. Check that the detail one has the correct color.
@@ -73,7 +79,9 @@ describe('TransactionItem', () => {
         isExpanded={true}
         onToggle={() => {}}
         onDelete={vi.fn()}
+        onUpdate={vi.fn()}
         isDeleting={false}
+        isUpdating={false}
       />
     )
     const allAmounts = screen.getAllByText(/\+\$500/)

--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -1,13 +1,16 @@
 import { useState, useCallback } from 'react'
 import type { Transaction } from '../stores/index'
-import { getCategoryName, getCategoryTypeColorClass } from '../lib/categoryUtils'
+import { getCategoryName, getCategoryTypeColorClass, CATEGORY_NAMES, INCOME_CATEGORIES } from '../lib/categoryUtils'
+import type { UpdateTransactionInput } from '../stores/historyStore'
 
 interface TransactionItemProps {
   transaction: Transaction
   isExpanded: boolean
   onToggle: () => void
   onDelete: (id: string) => Promise<void>
+  onUpdate: (id: string, input: UpdateTransactionInput) => Promise<void>
   isDeleting: boolean
+  isUpdating: boolean
 }
 
 const categoryIcons: Record<string, string> = {
@@ -25,6 +28,9 @@ const categoryIcons: Record<string, string> = {
   insurance: '🛡️',
   other_income: '💵',
 }
+
+const EXPENSE_CATEGORIES = Object.keys(CATEGORY_NAMES).filter((c) => !INCOME_CATEGORIES.has(c))
+const INCOME_CATEGORY_LIST = Object.keys(CATEGORY_NAMES).filter((c) => INCOME_CATEGORIES.has(c))
 
 function formatTime(dateStr: string): string {
   const date = new Date(dateStr)
@@ -45,9 +51,20 @@ function TransactionItem({
   isExpanded,
   onToggle,
   onDelete,
+  onUpdate,
   isDeleting,
+  isUpdating,
 }: TransactionItemProps) {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [isEditing, setIsEditing] = useState(false)
+  const [editForm, setEditForm] = useState({
+    type: tx.type ?? 'expense',
+    amount: tx.amount,
+    category: tx.category,
+    merchant: tx.merchant,
+    transactionDate: formatDate(tx.transactionDate),
+    note: tx.note ?? '',
+  })
 
   const handleDeleteClick = useCallback(() => {
     setShowDeleteConfirm(true)
@@ -66,6 +83,53 @@ function TransactionItem({
     }
   }, [onDelete, tx.id])
 
+  const handleEditClick = useCallback(() => {
+    setEditForm({
+      type: tx.type ?? 'expense',
+      amount: tx.amount,
+      category: tx.category,
+      merchant: tx.merchant,
+      transactionDate: formatDate(tx.transactionDate),
+      note: tx.note ?? '',
+    })
+    setIsEditing(true)
+  }, [tx])
+
+  const handleCancelEdit = useCallback(() => {
+    setIsEditing(false)
+  }, [])
+
+  const handleSaveEdit = useCallback(async () => {
+    try {
+      const input: UpdateTransactionInput = {
+        type: editForm.type as 'income' | 'expense',
+        amount: Number(editForm.amount),
+        category: editForm.category,
+        merchant: editForm.merchant,
+        transaction_date: editForm.transactionDate,
+        note: editForm.note || undefined,
+      }
+      await onUpdate(tx.id, input)
+      setIsEditing(false)
+    } catch {
+      // Error handled by store
+    }
+  }, [onUpdate, tx.id, editForm])
+
+  const handleTypeChange = useCallback((newType: string) => {
+    setEditForm((prev) => {
+      const categoryList = newType === 'income' ? INCOME_CATEGORY_LIST : EXPENSE_CATEGORIES
+      const categoryStillValid = categoryList.includes(prev.category)
+      return {
+        ...prev,
+        type: newType as 'income' | 'expense',
+        category: categoryStillValid ? prev.category : categoryList[0],
+      }
+    })
+  }, [])
+
+  const txType = tx.type ?? 'expense'
+
   return (
     <div className="border-b border-border last:border-b-0" data-testid={`transaction-item-${tx.id}`}>
       {/* Summary row */}
@@ -75,7 +139,7 @@ function TransactionItem({
         className="w-full flex items-center gap-md py-md hover:bg-bg transition-colors"
         aria-expanded={isExpanded}
       >
-        <div className={`w-10 h-10 rounded-md ${tx.type === 'income' ? 'bg-success-light' : 'bg-danger-light'} flex items-center justify-center text-lg shrink-0`}>
+        <div className={`w-10 h-10 rounded-md ${txType === 'income' ? 'bg-success-light' : 'bg-danger-light'} flex items-center justify-center text-lg shrink-0`}>
           {categoryIcons[tx.category] ?? '📦'}
         </div>
         <div className="flex-1 min-w-0 text-left">
@@ -83,7 +147,7 @@ function TransactionItem({
             {tx.merchant || tx.category}
           </p>
           <div className="flex items-center gap-xs">
-            <span className={`text-small ${getCategoryTypeColorClass(tx.type ?? 'expense')} bg-[#F0F0F0] rounded-sm px-2 py-0.5`}>
+            <span className={`text-small ${getCategoryTypeColorClass(txType)} bg-[#F0F0F0] rounded-sm px-2 py-0.5`}>
               {getCategoryName(tx.category)}
             </span>
             <span className="text-small text-text-secondary">
@@ -91,8 +155,8 @@ function TransactionItem({
             </span>
           </div>
         </div>
-        <p className={`text-title font-semibold shrink-0 ${tx.type === 'income' ? 'text-success' : 'text-danger'}`}>
-          {tx.type === 'income' ? '+' : '-'}${tx.amount.toLocaleString()}
+        <p className={`text-title font-semibold shrink-0 ${txType === 'income' ? 'text-success' : 'text-danger'}`}>
+          {txType === 'income' ? '+' : '-'}${tx.amount.toLocaleString()}
         </p>
         <span className={`text-text-tertiary text-sm transition-transform ${isExpanded ? 'rotate-180' : ''}`}>
           ▼
@@ -108,7 +172,7 @@ function TransactionItem({
                 確定要刪除這筆帳目嗎？
               </p>
               <p className="text-caption text-text-secondary mb-lg">
-                {tx.merchant} {tx.type === 'income' ? '+' : '-'}${tx.amount.toLocaleString()}
+                {tx.merchant} {txType === 'income' ? '+' : '-'}${tx.amount.toLocaleString()}
               </p>
               <div className="flex gap-sm">
                 <button
@@ -130,16 +194,120 @@ function TransactionItem({
                 </button>
               </div>
             </div>
+          ) : isEditing ? (
+            <div data-testid="edit-form">
+              <div className="space-y-sm mb-lg">
+                <div className="flex items-center gap-md">
+                  <span className="text-caption text-text-secondary w-[50px] shrink-0">類型</span>
+                  <div className="flex gap-sm">
+                    <button
+                      type="button"
+                      onClick={() => handleTypeChange('expense')}
+                      className={`px-lg py-xs rounded-sm text-small font-semibold ${editForm.type === 'expense' ? 'bg-danger text-surface' : 'border border-border text-text-secondary'}`}
+                      data-testid="edit-type-expense"
+                    >
+                      支出
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleTypeChange('income')}
+                      className={`px-lg py-xs rounded-sm text-small font-semibold ${editForm.type === 'income' ? 'bg-success text-surface' : 'border border-border text-text-secondary'}`}
+                      data-testid="edit-type-income"
+                    >
+                      收入
+                    </button>
+                  </div>
+                </div>
+                <div className="flex items-center gap-md">
+                  <span className="text-caption text-text-secondary w-[50px] shrink-0">金額</span>
+                  <input
+                    type="number"
+                    value={editForm.amount}
+                    onChange={(e) => setEditForm((f) => ({ ...f, amount: Number(e.target.value) }))}
+                    className="flex-1 px-lg py-xs bg-bg rounded-sm text-body border border-border outline-none"
+                    min="0"
+                    step="1"
+                    data-testid="edit-amount"
+                  />
+                </div>
+                <div className="flex items-center gap-md">
+                  <span className="text-caption text-text-secondary w-[50px] shrink-0">類別</span>
+                  <select
+                    value={editForm.category}
+                    onChange={(e) => setEditForm((f) => ({ ...f, category: e.target.value }))}
+                    className="flex-1 px-lg py-xs bg-bg rounded-sm text-body border border-border outline-none"
+                    data-testid="edit-category"
+                  >
+                    {(editForm.type === 'income' ? INCOME_CATEGORY_LIST : EXPENSE_CATEGORIES).map((cat) => (
+                      <option key={cat} value={cat}>
+                        {categoryIcons[cat] ?? '📦'} {getCategoryName(cat)}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="flex items-center gap-md">
+                  <span className="text-caption text-text-secondary w-[50px] shrink-0">商家</span>
+                  <input
+                    type="text"
+                    value={editForm.merchant}
+                    onChange={(e) => setEditForm((f) => ({ ...f, merchant: e.target.value }))}
+                    className="flex-1 px-lg py-xs bg-bg rounded-sm text-body border border-border outline-none"
+                    placeholder="商家名稱"
+                    data-testid="edit-merchant"
+                  />
+                </div>
+                <div className="flex items-center gap-md">
+                  <span className="text-caption text-text-secondary w-[50px] shrink-0">日期</span>
+                  <input
+                    type="date"
+                    value={editForm.transactionDate}
+                    onChange={(e) => setEditForm((f) => ({ ...f, transactionDate: e.target.value }))}
+                    className="flex-1 px-lg py-xs bg-bg rounded-sm text-body border border-border outline-none"
+                    data-testid="edit-date"
+                  />
+                </div>
+                <div className="flex items-center gap-md">
+                  <span className="text-caption text-text-secondary w-[50px] shrink-0">備註</span>
+                  <input
+                    type="text"
+                    value={editForm.note}
+                    onChange={(e) => setEditForm((f) => ({ ...f, note: e.target.value }))}
+                    className="flex-1 px-lg py-xs bg-bg rounded-sm text-body border border-border outline-none"
+                    placeholder="備註"
+                    data-testid="edit-note"
+                  />
+                </div>
+              </div>
+              <div className="flex gap-sm">
+                <button
+                  type="button"
+                  onClick={handleCancelEdit}
+                  className="flex-1 h-9 rounded-sm border border-border text-text-secondary text-body"
+                  disabled={isUpdating}
+                >
+                  取消
+                </button>
+                <button
+                  type="button"
+                  onClick={handleSaveEdit}
+                  className="flex-1 h-9 rounded-sm bg-primary text-surface font-semibold text-body"
+                  disabled={isUpdating}
+                  data-testid="save-edit-btn"
+                >
+                  {isUpdating ? '儲存中...' : '儲存'}
+                </button>
+              </div>
+            </div>
           ) : (
             <>
               <div className="space-y-sm mb-lg">
                 <div className="flex items-center gap-md">
                   <span className="text-caption text-text-secondary w-[50px] shrink-0">金額</span>
-                  <span className={`text-body font-semibold ${tx.type === 'income' ? 'text-success' : 'text-danger'}`}>{tx.type === 'income' ? '+' : '-'}${tx.amount.toLocaleString()}</span>
+                  <span className={`text-body font-semibold ${txType === 'income' ? 'text-success' : 'text-danger'}`}>{txType === 'income' ? '+' : '-'}${tx.amount.toLocaleString()}</span>
                 </div>
                 <div className="flex items-center gap-md">
                   <span className="text-caption text-text-secondary w-[50px] shrink-0">類別</span>
-                  <span className={`text-body ${getCategoryTypeColorClass(tx.type ?? 'expense')}`}>
+                  <span className={`text-body ${getCategoryTypeColorClass(txType)}`}>
                     {categoryIcons[tx.category] ?? '📦'} {getCategoryName(tx.category)}
                   </span>
                 </div>
@@ -171,6 +339,14 @@ function TransactionItem({
                   className="flex-1 h-9 rounded-sm border border-border text-text-secondary text-body"
                 >
                   收合
+                </button>
+                <button
+                  type="button"
+                  onClick={handleEditClick}
+                  className="flex-1 h-9 rounded-sm border border-primary text-primary text-body"
+                  data-testid="edit-btn"
+                >
+                  修改
                 </button>
                 <button
                   type="button"

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -46,12 +46,14 @@ function HistoryPage() {
     hasMore,
     isLoading,
     isDeleting,
+    isUpdating,
     errorMessage,
     fetchTransactions,
     loadMore,
     setFilters,
     resetFilters,
     deleteTransaction,
+    updateTransaction,
   } = useHistoryStore()
 
   const storeCategories = useDashboardStore((s) => s.categories)
@@ -113,6 +115,13 @@ function HistoryPage() {
       setExpandedId(null)
     },
     [deleteTransaction]
+  )
+
+  const handleUpdate = useCallback(
+    async (id: string, input: Parameters<typeof updateTransaction>[1]) => {
+      await updateTransaction(id, input)
+    },
+    [updateTransaction]
   )
 
   const grouped = useMemo(() => groupByDate(transactions), [transactions])
@@ -204,7 +213,9 @@ function HistoryPage() {
                     isExpanded={expandedId === tx.id}
                     onToggle={() => handleToggle(tx.id)}
                     onDelete={handleDelete}
+                    onUpdate={handleUpdate}
                     isDeleting={isDeleting === tx.id}
+                    isUpdating={isUpdating === tx.id}
                   />
                 ))}
               </div>

--- a/frontend/src/stores/historyStore.ts
+++ b/frontend/src/stores/historyStore.ts
@@ -8,6 +8,15 @@ export interface HistoryFilters {
   endDate: string
 }
 
+export interface UpdateTransactionInput {
+  type?: 'income' | 'expense'
+  amount?: number
+  category?: string
+  merchant?: string
+  transaction_date?: string
+  note?: string
+}
+
 interface HistoryState {
   transactions: Transaction[]
   filters: HistoryFilters
@@ -15,6 +24,7 @@ interface HistoryState {
   hasMore: boolean
   isLoading: boolean
   isDeleting: string | null
+  isUpdating: string | null
   errorMessage: string
 
   // Actions
@@ -23,6 +33,7 @@ interface HistoryState {
   setFilters: (filters: Partial<HistoryFilters>) => void
   resetFilters: () => void
   deleteTransaction: (id: string) => Promise<void>
+  updateTransaction: (id: string, input: UpdateTransactionInput) => Promise<void>
 }
 
 const PAGE_SIZE = 20
@@ -40,6 +51,7 @@ export const useHistoryStore = create<HistoryState>((set, get) => ({
   hasMore: true,
   isLoading: false,
   isDeleting: null,
+  isUpdating: null,
   errorMessage: '',
 
   fetchTransactions: async (reset = true) => {
@@ -63,6 +75,7 @@ export const useHistoryStore = create<HistoryState>((set, get) => ({
       const items: Transaction[] = res.data.data.items.map(
         (t: Record<string, unknown>) => ({
           id: t.id as string,
+          type: (t.type as 'income' | 'expense') ?? 'expense',
           amount: t.amount as number,
           category: t.category as string,
           merchant: t.merchant as string,
@@ -120,6 +133,35 @@ export const useHistoryStore = create<HistoryState>((set, get) => ({
         (err as { response?: { data?: { message?: string } } })?.response?.data
           ?.message ?? '刪除失敗，請稍後重試'
       set({ isDeleting: null, errorMessage: message })
+      throw err
+    }
+  },
+
+  updateTransaction: async (id: string, input: UpdateTransactionInput) => {
+    set({ isUpdating: id, errorMessage: '' })
+    try {
+      const res = await api.put(`/transactions/${id}`, input)
+      const t = res.data.data.transaction as Record<string, unknown>
+      const updated: Transaction = {
+        id: t.id as string,
+        type: (t.type as 'income' | 'expense') ?? 'expense',
+        amount: t.amount as number,
+        category: t.category as string,
+        merchant: (t.merchant as string) ?? '',
+        rawText: (t.raw_text as string) ?? '',
+        note: (t.note as string) ?? undefined,
+        transactionDate: t.transaction_date as string,
+        createdAt: t.created_at as string,
+      }
+      set((s) => ({
+        transactions: s.transactions.map((tx) => (tx.id === id ? updated : tx)),
+        isUpdating: null,
+      }))
+    } catch (err: unknown) {
+      const message =
+        (err as { response?: { data?: { message?: string } } })?.response?.data
+          ?.message ?? '更新失敗，請稍後重試'
+      set({ isUpdating: null, errorMessage: message })
       throw err
     }
   },


### PR DESCRIPTION
## Summary

- **問題 1 修正**：記錄頁面帳目明細新增「修改」按鈕，點擊後進入編輯模式，可修改類型、金額、類別、商家、日期、備註，儲存時呼叫 `PUT /transactions/:id` API
- **問題 2 修正**：`historyStore` 的 `fetchTransactions` mapping 補上遺漏的 `type` 欄位，修正金額顯示邏輯——收入為 `+` 綠色、支出為 `-` 紅色，列表摘要行與展開明細一致
- 更新測試檔案以配合新增的 `onUpdate` / `isUpdating` props

## Changed files

| 檔案 | 說明 |
|------|------|
| `frontend/src/stores/historyStore.ts` | 新增 `updateTransaction` action、`isUpdating` 狀態、mapping 補 `type` |
| `frontend/src/components/TransactionItem.tsx` | 新增編輯模式 UI、修改按鈕、金額顏色修正 |
| `frontend/src/pages/HistoryPage.tsx` | 傳入 `onUpdate` / `isUpdating` props |
| `frontend/src/components/TransactionItem.test.tsx` | 補上新增 props |

## Test plan

- [x] `npx tsc --noEmit` 通過
- [x] `npx eslint .` 通過
- [x] `npm test -- --run` 136 tests 全部通過
- [x] `npm run build` 成功
- [ ] 手動測試：展開帳目 → 點「修改」→ 修改欄位 → 儲存 → 確認更新
- [ ] 手動測試：收入帳目顯示綠色 `+`、支出帳目顯示紅色 `-`

Closes #78