### PR TITLE
fix(frontend): 修正設定頁面新增按鈕超出邊界 (#89)

### DIFF
--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -406,11 +406,11 @@ function SettingsPage() {
         {/* 新增自訂類別 */}
         <div className="border-t border-border pt-md">
           <p className="text-caption text-text-secondary mb-sm">新增自訂類別</p>
-          <div className="flex gap-sm items-center">
+          <div className="flex gap-sm items-center overflow-hidden">
             <select
               value={newCategoryType}
               onChange={(e) => setNewCategoryType(e.target.value as 'income' | 'expense')}
-              className="h-9 rounded-md border border-border px-sm text-caption"
+              className="h-9 flex-shrink-0 rounded-md border border-border px-sm text-caption"
               aria-label="新類別類型"
             >
               <option value="expense">支出</option>
@@ -421,7 +421,7 @@ function SettingsPage() {
               value={newCategoryName}
               onChange={(e) => setNewCategoryName(e.target.value)}
               placeholder="類別名稱"
-              className="flex-1 h-9 rounded-md border border-border px-sm text-body"
+              className="flex-1 min-w-0 h-9 rounded-md border border-border px-sm text-body"
               aria-label="新類別名稱"
               onKeyDown={(e) => {
                 if (e.key === 'Enter') handleAddCategory()
@@ -431,7 +431,7 @@ function SettingsPage() {
               type="button"
               onClick={handleAddCategory}
               disabled={categoryAdding || !newCategoryName.trim()}
-              className="h-9 px-lg min-w-[80px] whitespace-nowrap rounded-md bg-primary text-white text-caption font-semibold disabled:opacity-50"
+              className="h-9 px-lg flex-shrink-0 min-w-[80px] whitespace-nowrap rounded-md bg-primary text-white text-caption font-semibold disabled:opacity-50"
               aria-label="新增類別"
             >
               {categoryAdding ? '新增中...' : '新增'}


### PR DESCRIPTION
## Summary
- 修正設定頁面類別管理的「新增」按鈕在小螢幕下超出容器邊界的問題
- 外層 flex 容器加 `overflow-hidden` 防止溢出
- 輸入框加 `min-w-0` 確保在空間不足時可收縮
- select 和按鈕加 `flex-shrink-0` 保持固定寬度不被壓縮

Closes #89

## Test plan
- [x] TypeScript 型別檢查通過
- [x] ESLint 檢查通過
- [x] 136 個測試全部通過
- [x] Build 成功
- [ ] 在小螢幕裝置上確認新增按鈕不再超出邊界