### PR TITLE
fix(frontend): 修正總資產卡片金額數字溢出 (#86)

### DIFF
--- a/frontend/src/components/AssetCard.tsx
+++ b/frontend/src/components/AssetCard.tsx
@@ -17,7 +17,7 @@ function AssetCard({ summary }: AssetCardProps) {
         <h2 className="text-caption text-text-secondary mb-sm">
           總資產
         </h2>
-        <p className="text-display font-bold text-text-primary">
+        <p className="text-headline font-bold text-text-primary truncate">
           --
         </p>
         <p className="text-caption text-text-secondary mt-sm">
@@ -39,16 +39,16 @@ function AssetCard({ summary }: AssetCardProps) {
         總資產
       </p>
       <p
-        className={`text-display font-bold ${isPositive ? 'text-primary' : 'text-danger'}`}
+        className={`text-headline font-bold truncate ${isPositive ? 'text-primary' : 'text-danger'}`}
         aria-live="polite"
       >
         {isPositive ? '+' : '-'}{formatMoney(totalAsset)}
       </p>
-      <div className="flex justify-between mt-sm">
-        <span className="text-small text-text-secondary">
+      <div className="flex justify-between mt-sm gap-sm">
+        <span className="text-small text-text-secondary truncate min-w-0">
           收入 {formatMoney(totalIncome)}
         </span>
-        <span className="text-small text-text-secondary">
+        <span className="text-small text-text-secondary truncate min-w-0 text-right">
           支出 {formatMoney(totalSpent)}
         </span>
       </div>

--- a/frontend/src/components/BudgetCard.tsx
+++ b/frontend/src/components/BudgetCard.tsx
@@ -20,7 +20,7 @@ function BudgetCard({ summary, compact }: BudgetCardProps) {
         <h2 className="text-caption text-text-secondary mb-sm">
           預算剩餘
         </h2>
-        <p className="text-display font-bold text-text-primary">
+        <p className="text-headline font-bold text-text-primary truncate">
           --
         </p>
         <p className="text-caption text-text-secondary mt-sm">
@@ -57,7 +57,7 @@ function BudgetCard({ summary, compact }: BudgetCardProps) {
           預算剩餘
         </p>
         <p
-          className={`text-display font-bold ${getPercentColor()}`}
+          className={`text-headline font-bold truncate ${getPercentColor()}`}
           aria-live="polite"
         >
           {isOverBudget ? '超支' : `${remainingPercent}%`}
@@ -68,11 +68,11 @@ function BudgetCard({ summary, compact }: BudgetCardProps) {
           <BudgetBar usedRatio={usedRatio} />
         </div>
 
-        <div className="flex justify-between">
-          <span className="text-small text-text-secondary">
+        <div className="flex justify-between gap-sm">
+          <span className="text-small text-text-secondary truncate min-w-0">
             支出 {formatMoney(totalSpent)}
           </span>
-          <span className="text-small text-text-secondary">
+          <span className="text-small text-text-secondary truncate min-w-0 text-right">
             目標 {formatMoney(monthlyBudget)}
           </span>
         </div>
@@ -91,7 +91,7 @@ function BudgetCard({ summary, compact }: BudgetCardProps) {
             預算剩餘
           </p>
           <p
-            className={`text-display font-bold ${getPercentColor()}`}
+            className={`text-headline font-bold truncate ${getPercentColor()}`}
             aria-live="polite"
           >
             {isOverBudget ? '超支' : `${remainingPercent}%`}
@@ -102,7 +102,7 @@ function BudgetCard({ summary, compact }: BudgetCardProps) {
             本月支出
           </p>
           <p
-            className="text-headline font-bold text-danger"
+            className="text-headline font-bold text-danger truncate"
             aria-live="polite"
           >
             {formatMoney(totalSpent)}
@@ -115,11 +115,11 @@ function BudgetCard({ summary, compact }: BudgetCardProps) {
         <BudgetBar usedRatio={usedRatio} />
       </div>
 
-      <div className="flex justify-between">
+      <div className="flex justify-between gap-sm">
         <span className="text-small text-text-secondary">
           $0
         </span>
-        <span className="text-small text-text-secondary">
+        <span className="text-small text-text-secondary truncate min-w-0 text-right">
           目標：{formatMoney(monthlyBudget)}
         </span>
       </div>


### PR DESCRIPTION
## Summary
- 將 AssetCard 和 BudgetCard 的金額字型從 `text-display` (36px) 縮小為 `text-headline` (24px)，避免六位數以上金額超出卡片邊界
- 為所有金額文字加上 `truncate` class 確保文字不會溢出容器
- 底部收支/預算資訊行加上 `truncate`、`min-w-0`、`gap-sm` 防止文字擠壓溢出

## Test plan
- [x] TypeScript 型別檢查通過
- [x] ESLint 無錯誤
- [x] 136 個單元測試全數通過
- [x] Production build 成功

Closes #86