### PR TITLE
fix(frontend): 帳目編輯增加備註欄位與查詢條件排版調整 (#88)

### DIFF
--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -265,14 +265,14 @@ function TransactionItem({
                     data-testid="edit-date"
                   />
                 </div>
-                <div className="flex items-center gap-md">
-                  <span className="text-caption text-text-secondary w-[50px] shrink-0">備註</span>
-                  <input
-                    type="text"
+                <div className="flex items-start gap-md">
+                  <span className="text-caption text-text-secondary w-[50px] shrink-0 mt-xs">備註</span>
+                  <textarea
                     value={editForm.note}
                     onChange={(e) => setEditForm((f) => ({ ...f, note: e.target.value }))}
-                    className="flex-1 px-lg py-xs bg-bg rounded-sm text-body border border-border outline-none"
+                    className="flex-1 px-lg py-xs bg-bg rounded-sm text-body border border-border outline-none resize-none"
                     placeholder="備註"
+                    rows={2}
                     data-testid="edit-note"
                   />
                 </div>

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -139,20 +139,6 @@ function HistoryPage() {
       {/* Filter section */}
       <div className="space-y-sm mb-xl" data-testid="filter-section">
         <div className="flex gap-sm items-center flex-wrap">
-          <select
-            value={filters.category}
-            onChange={handleCategoryChange}
-            className="px-lg py-sm bg-bg rounded-xl text-caption text-text-secondary border-0 outline-none cursor-pointer"
-            aria-label="類別篩選"
-            data-testid="category-filter"
-          >
-            {categoryOptions.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-
           <input
             type="date"
             value={filters.startDate}
@@ -170,6 +156,20 @@ function HistoryPage() {
             aria-label="結束日期"
             data-testid="end-date-filter"
           />
+
+          <select
+            value={filters.category}
+            onChange={handleCategoryChange}
+            className="px-lg py-sm bg-bg rounded-xl text-caption text-text-secondary border-0 outline-none cursor-pointer"
+            aria-label="類別篩選"
+            data-testid="category-filter"
+          >
+            {categoryOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
 
           {hasActiveFilters && (
             <button


### PR DESCRIPTION
## Summary
- 將帳目編輯模式的備註欄位從 `<input>` 改為 `<textarea>`，支援多行備註輸入
- 將記錄頁面（HistoryPage）篩選區的類別下拉框移至日期範圍之後，排版順序改為：日期範圍 → 類別篩選

## Changes
- `frontend/src/components/TransactionItem.tsx` — 備註編輯欄位改用 textarea（2 行、不可調整大小）
- `frontend/src/pages/HistoryPage.tsx` — 調整篩選條件 DOM 順序

## Test plan
- [x] TypeScript 類型檢查通過
- [x] ESLint 通過
- [x] 136 個測試全數通過
- [x] Production build 成功

Closes #88