### PR TITLE
feat(frontend): 總資產與預算卡片排版優化 (#95)

### DIFF
--- a/frontend/src/components/AssetCard.tsx
+++ b/frontend/src/components/AssetCard.tsx
@@ -44,13 +44,15 @@ function AssetCard({ summary }: AssetCardProps) {
       >
         {isPositive ? '+' : '-'}{formatMoney(totalAsset)}
       </p>
-      <div className="flex justify-between mt-sm gap-sm">
-        <span className="text-small text-text-secondary truncate min-w-0">
-          收入 {formatMoney(totalIncome)}
-        </span>
-        <span className="text-small text-text-secondary truncate min-w-0 text-right">
-          支出 {formatMoney(totalSpent)}
-        </span>
+      <div className="space-y-xs mt-sm text-caption">
+        <div className="flex justify-between">
+          <span className="text-text-secondary">收入</span>
+          <span className="text-success">+{formatMoney(totalIncome)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-text-secondary">支出</span>
+          <span className="text-danger">-{formatMoney(totalSpent)}</span>
+        </div>
       </div>
     </section>
   )

--- a/frontend/src/components/BudgetCard.tsx
+++ b/frontend/src/components/BudgetCard.tsx
@@ -68,13 +68,15 @@ function BudgetCard({ summary, compact }: BudgetCardProps) {
           <BudgetBar usedRatio={usedRatio} />
         </div>
 
-        <div className="flex justify-between gap-sm">
-          <span className="text-small text-text-secondary truncate min-w-0">
-            支出 {formatMoney(totalSpent)}
-          </span>
-          <span className="text-small text-text-secondary truncate min-w-0 text-right">
-            目標 {formatMoney(monthlyBudget)}
-          </span>
+        <div className="space-y-xs text-caption">
+          <div className="flex justify-between">
+            <span className="text-text-secondary">支出</span>
+            <span className="text-danger">-{formatMoney(totalSpent)}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-text-secondary">目標</span>
+            <span className="text-text-primary">{formatMoney(monthlyBudget)}</span>
+          </div>
         </div>
       </section>
     )


### PR DESCRIPTION
## Summary
- 將首頁「總資產」卡片底部的收入/支出從單行改為雙行顯示，並加上顏色區分（綠色收入、紅色支出）
- 將首頁「預算剩餘」卡片底部的支出/目標從單行改為雙行顯示，支出顯示紅色、目標顯示主色

Closes #95

## Test plan
- [x] TypeScript 型別檢查通過
- [x] ESLint 通過
- [x] 136 個測試全部通過
- [x] Production build 成功