### PR TITLE
feat(frontend): 語音輸入自動停止條件優化 (#94)

### DIFF
--- a/frontend/src/components/VoiceInput.tsx
+++ b/frontend/src/components/VoiceInput.tsx
@@ -13,10 +13,32 @@ function VoiceInput({ onSubmit, disabled = false }: VoiceInputProps) {
   const [inputText, setInputText] = useState('')
   const [showError, setShowError] = useState(false)
   const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // #94: Ref to flag that the next onResult should trigger auto-submit
+  const autoSubmitRef = useRef(false)
+  const onSubmitRef = useRef(onSubmit)
+  const disabledRef = useRef(disabled)
   const isSupported = isSpeechRecognitionSupported()
 
+  useEffect(() => {
+    onSubmitRef.current = onSubmit
+    disabledRef.current = disabled
+  }, [onSubmit, disabled])
+
   const handleVoiceResult = useCallback((transcript: string) => {
-    setInputText(transcript)
+    // #94: If auto-submit was requested (send button pressed during recording),
+    // submit the transcript immediately instead of just setting inputText.
+    if (autoSubmitRef.current) {
+      autoSubmitRef.current = false
+      const text = transcript.trim()
+      if (text) {
+        setInputText('')
+        onSubmitRef.current(text)
+      } else {
+        setInputText(transcript)
+      }
+    } else {
+      setInputText(transcript)
+    }
   }, [])
 
   const handleVoiceInterim = useCallback((interim: string) => {
@@ -29,13 +51,17 @@ function VoiceInput({ onSubmit, disabled = false }: VoiceInputProps) {
     errorTimerRef.current = setTimeout(() => setShowError(false), 3000)
   }, [])
 
-  const { status, errorMessage, toggleRecording } =
+  const { status, errorMessage, toggleRecording, stopRecording } =
     useVoiceRecognition({
       lang: 'zh-TW',
       onResult: handleVoiceResult,
       onInterimResult: handleVoiceInterim,
       onError: handleVoiceError,
     })
+
+  const isRecording = status === 'recording'
+  const isRecognizing = status === 'recognizing'
+  const isActive = isRecording || isRecognizing
 
   // Cleanup error timer on unmount
   useEffect(() => {
@@ -44,16 +70,20 @@ function VoiceInput({ onSubmit, disabled = false }: VoiceInputProps) {
     }
   }, [])
 
-  const isRecording = status === 'recording'
-  const isRecognizing = status === 'recognizing'
-  const isActive = isRecording || isRecognizing
-
   const handleSubmit = useCallback(() => {
+    // #94: If recording is active, stop recording and auto-submit the result.
+    // stopRecording() synchronously delivers the transcript via onResult callback,
+    // where autoSubmitRef triggers immediate submission.
+    if (isActive) {
+      autoSubmitRef.current = true
+      stopRecording()
+      return
+    }
     const text = inputText.trim()
     if (!text || disabled) return
     onSubmit(text)
     setInputText('')
-  }, [inputText, onSubmit, disabled])
+  }, [inputText, onSubmit, disabled, isActive, stopRecording])
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -166,11 +196,11 @@ function VoiceInput({ onSubmit, disabled = false }: VoiceInputProps) {
           </button>
         )}
 
-        {/* Send button */}
+        {/* Send button — enabled during recording so user can stop+send (#94) */}
         <button
           type="button"
           onClick={handleSubmit}
-          disabled={disabled || !inputText.trim()}
+          disabled={disabled || (!inputText.trim() && !isActive)}
           className="w-10 h-10 rounded-full bg-primary flex items-center justify-center shadow-fab transition-opacity duration-[var(--transition-fast)] disabled:opacity-40"
           aria-label="送出"
         >

--- a/frontend/src/hooks/useVoiceRecognition.ts
+++ b/frontend/src/hooks/useVoiceRecognition.ts
@@ -4,6 +4,8 @@ export type VoiceStatus = 'idle' | 'recording' | 'recognizing' | 'error'
 
 interface UseVoiceRecognitionOptions {
   lang?: string
+  /** 靜默超時時間（毫秒），預設 5000ms */
+  silenceTimeout?: number
   onResult?: (transcript: string) => void
   onInterimResult?: (transcript: string) => void
   onError?: (error: string) => void
@@ -33,7 +35,7 @@ export function isSpeechRecognitionSupported(): boolean {
 export function useVoiceRecognition(
   options: UseVoiceRecognitionOptions = {}
 ): UseVoiceRecognitionReturn {
-  const { lang = 'zh-TW', onResult, onInterimResult, onError } = options
+  const { lang = 'zh-TW', silenceTimeout = 5000, onResult, onInterimResult, onError } = options
 
   const [isSupported] = useState(() => isSpeechRecognitionSupported())
   const [status, setStatus] = useState<VoiceStatus>('idle')
@@ -48,6 +50,8 @@ export function useVoiceRecognition(
   // accumulation — it is overwritten (not appended) on every onresult event.
   const latestFinalRef = useRef('')
   const latestInterimRef = useRef('')
+  const silenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const stopRecordingRef = useRef<() => void>(() => {})
 
   // Keep callbacks ref updated
   useEffect(() => {
@@ -79,6 +83,13 @@ export function useVoiceRecognition(
       setErrorMessage('')
       setTranscript('')
       setInterimTranscript('')
+      // #94: Start silence timer — if no speech detected within timeout, auto-stop
+      if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current)
+      if (silenceTimeout > 0) {
+        silenceTimerRef.current = setTimeout(() => {
+          stopRecordingRef.current()
+        }, silenceTimeout)
+      }
     }
 
     recognition.onresult = (event: SpeechRecognitionEvent) => {
@@ -111,6 +122,14 @@ export function useVoiceRecognition(
         setStatus('recognizing')
         callbacksRef.current.onInterimResult?.(displayText)
       }
+
+      // #94: Reset silence timer — auto-stop after silenceTimeout ms of no new results
+      if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current)
+      if (silenceTimeout > 0) {
+        silenceTimerRef.current = setTimeout(() => {
+          stopRecordingRef.current()
+        }, silenceTimeout)
+      }
     }
 
     recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
@@ -129,9 +148,14 @@ export function useVoiceRecognition(
 
     recognitionRef.current = recognition
     recognition.start()
-  }, [lang])
+  }, [lang, silenceTimeout])
 
   const stopRecording = useCallback(() => {
+    // #94: Clear silence timer
+    if (silenceTimerRef.current) {
+      clearTimeout(silenceTimerRef.current)
+      silenceTimerRef.current = null
+    }
     if (recognitionRef.current) {
       recognitionRef.current.stop()
       // Deliver the latest computed transcript (final + interim).
@@ -148,6 +172,11 @@ export function useVoiceRecognition(
     }
   }, [])
 
+  // Keep stopRecordingRef in sync so silence timer always calls the latest version
+  useEffect(() => {
+    stopRecordingRef.current = stopRecording
+  }, [stopRecording])
+
   // Toggle recording: start if idle, stop if active (#70)
   const toggleRecording = useCallback(() => {
     if (recognitionRef.current) {
@@ -160,6 +189,7 @@ export function useVoiceRecognition(
   // Cleanup on unmount
   useEffect(() => {
     return () => {
+      if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current)
       if (recognitionRef.current) {
         recognitionRef.current.abort()
         recognitionRef.current = null


### PR DESCRIPTION
## Summary
- 新增 **5 秒靜默超時**自動停止錄音：錄音開始時啟動計時器，每次 `onresult` 事件重置；超時自動呼叫 `stopRecording()`
- 新增**傳送按鈕停止錄音**：錄音中按傳送 → 停止錄音 → 取得辨識結果 → 立即送出
- 傳送按鈕在錄音中保持可點擊狀態，提供更直覺的操作體驗

## Changes
- `useVoiceRecognition.ts`：新增 `silenceTimeout` 選項（預設 5000ms）、silence timer ref、`stopRecordingRef` 以避免 stale closure
- `VoiceInput.tsx`：使用 `autoSubmitRef` + `onSubmitRef` 實現錄音中送出的同步交付，避免 React 批次更新問題

## Test plan
- [ ] 開始錄音後不說話，確認 5 秒後自動停止
- [ ] 開始錄音並說話，確認最後一次語音辨識結果後 5 秒自動停止
- [ ] 錄音中按傳送按鈕，確認停止錄音後文字自動送出
- [ ] 錄音中按麥克風按鈕（toggle），確認停止錄音並顯示結果
- [ ] 正常文字輸入送出功能不受影響

Closes #94