### PR TITLE
fix(frontend): API 401 回應時自動清除 token 並跳轉登入頁 (#98)

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -17,15 +17,29 @@ api.interceptors.request.use((config) => {
   return config
 })
 
+// 不應觸發自動登出的 API 路徑（登入/註冊本身回傳 401 屬正常業務錯誤）
+const AUTH_WHITELIST = ['/auth/login', '/auth/register']
+
 // Response interceptor — 統一錯誤處理
 api.interceptors.response.use(
   (response) => response,
   (error) => {
-    // 401 時可導向登入頁
     if (error.response?.status === 401) {
-      localStorage.removeItem('auth_token')
-      localStorage.removeItem('auth_user')
-      window.location.href = '/login'
+      const requestUrl = error.config?.url ?? ''
+      const isAuthRequest = AUTH_WHITELIST.some((path) => requestUrl.includes(path))
+
+      if (!isAuthRequest) {
+        // Token 失效：清除本地狀態並導向登入頁
+        localStorage.removeItem('auth_token')
+        localStorage.removeItem('auth_user')
+
+        // 重置 Zustand auth store（延遲 import 避免循環依賴）
+        import('../stores/authStore.ts').then(({ useAuthStore }) => {
+          useAuthStore.getState().logout()
+        })
+
+        window.location.href = '/login'
+      }
     }
     return Promise.reject(error)
   },


### PR DESCRIPTION
## Summary
- 修復 JWT Token 失效時前端未自動登出的問題
- 在 Axios response interceptor 中攔截 401，清除 localStorage 與 Zustand auth store 狀態後導向 `/login`
- 以 `AUTH_WHITELIST` 排除登入/註冊 API 本身的 401，避免死循環

## Changes
- `frontend/src/lib/api.ts`：新增 AUTH_WHITELIST、在 401 interceptor 中判斷是否為 auth 請求，非 auth 請求才觸發自動登出

## Vibe Check
- [x] `tsc --noEmit` — 通過
- [x] `npm run lint` — 通過
- [x] `npm test -- --run` — 136 tests passed
- [x] `npm run build` — 成功

Closes #98