### PR TITLE
feat: AI 意圖判斷 — 非記帳輸入由教練直接回覆 (#100)

### DIFF
--- a/backend/src/controllers/aiController.test.ts
+++ b/backend/src/controllers/aiController.test.ts
@@ -67,11 +67,13 @@ vi.mock('../config/database', () => ({
 
 const mockExtractData = vi.fn();
 const mockGenerateFeedback = vi.fn();
+const mockGenerateText = vi.fn();
 
 vi.mock('../services/llm/llmFactory', () => ({
   getProvider: vi.fn(() => ({
     extractData: mockExtractData,
     generateFeedback: mockGenerateFeedback,
+    generateText: mockGenerateText,
   })),
 }));
 
@@ -99,6 +101,9 @@ function postValidateKey(apiKey = API_KEY_HEADER) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+
+  // Default: intent detection returns transaction
+  mockGenerateText.mockResolvedValue('{"intent":"transaction"}');
 
   // Default mock responses
   mockExtractData.mockResolvedValue({
@@ -130,6 +135,7 @@ describe('POST /api/v1/ai/parse', () => {
     expect(res.status).toBe(200);
     expect(res.body.code).toBe(200);
     expect(res.body.message).toBe('解析成功');
+    expect(res.body.data.intent).toBe('transaction');
     expect(res.body.data.parsed).toEqual({
       type: 'expense',
       amount: 180,
@@ -327,6 +333,53 @@ describe('POST /api/v1/ai/parse', () => {
     expect(prompt).toContain('food');
     expect(prompt).toContain('transport');
     expect(prompt).toContain('entertainment');
+  });
+
+  // --- 案例 15b: Chat 意圖 — 對話回覆 ---
+  it('應在 chat 意圖時回傳 AI 教練對話回覆', async () => {
+    mockGenerateText.mockResolvedValue('{"intent":"chat"}');
+    mockGenerateFeedback.mockResolvedValue({
+      text: '預算都快見底了啊！你還想花？',
+      emotion_tag: 'sarcastic_warning',
+    });
+
+    const res = await postParse('目前還有多少預算可以使用');
+
+    expect(res.status).toBe(200);
+    expect(res.body.code).toBe(200);
+    expect(res.body.message).toBe('對話回覆成功');
+    expect(res.body.data.intent).toBe('chat');
+    expect(res.body.data.reply).toBeDefined();
+    expect(res.body.data.reply.text).toBe('預算都快見底了啊！你還想花？');
+    expect(res.body.data.feedback).toBeNull();
+    // Should NOT have parsed or budget_context
+    expect(res.body.data.parsed).toBeUndefined();
+  });
+
+  // --- 案例 15c: Chat 意圖 — 閒聊回覆 ---
+  it('應在閒聊輸入時回傳 AI 教練回覆', async () => {
+    mockGenerateText.mockResolvedValue('{"intent":"chat"}');
+    mockGenerateFeedback.mockResolvedValue({
+      text: '天氣好心情也好～記得記帳喔',
+      emotion_tag: 'gentle_encouragement',
+    });
+
+    const res = await postParse('今天天氣真好');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.intent).toBe('chat');
+    expect(res.body.data.reply.text).toContain('記帳');
+  });
+
+  // --- 案例 15d: Intent 偵測失敗時預設為 transaction ---
+  it('應在 intent 偵測失敗時回退為 transaction 流程', async () => {
+    mockGenerateText.mockRejectedValue(new Error('LLM timeout'));
+
+    const res = await postParse('午餐 100 元');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.intent).toBe('transaction');
+    expect(res.body.data.parsed).toBeDefined();
   });
 });
 

--- a/backend/src/controllers/aiController.ts
+++ b/backend/src/controllers/aiController.ts
@@ -39,7 +39,7 @@ export async function aiParse(
 
     const response: ApiResponse<typeof result> = {
       code: 200,
-      message: '解析成功',
+      message: result.intent === 'chat' ? '對話回覆成功' : '解析成功',
       data: result,
       timestamp: new Date().toISOString(),
     };

--- a/backend/src/prompts/chatReplyPrompt.ts
+++ b/backend/src/prompts/chatReplyPrompt.ts
@@ -1,0 +1,53 @@
+import { Persona, BudgetContext } from '../types/llm';
+
+export interface ChatReplyInput {
+  persona: Persona;
+  rawText: string;
+  budgetContext: BudgetContext;
+}
+
+const PERSONA_CHAT_DEFINITIONS: Record<Persona, string> = {
+  sarcastic: `你是一個毒舌的財務教練。你的風格是尖酸刻薄但有趣，用諷刺語氣回應使用者。
+    - 回應要有趣且帶點嘲諷
+    - 若話題與財務相關，用毒舌方式給建議
+    - 若是閒聊，要幽默地把話題帶回記帳
+    - 保持幽默感，不要真的傷人`,
+
+  gentle: `你是一個溫柔體貼的財務教練。你的風格是溫暖鼓勵。
+    - 用溫暖關心的語氣回應
+    - 若話題與財務相關，溫柔地給建議
+    - 若是閒聊，溫柔地提醒記帳
+    - 偶爾給予正面肯定`,
+
+  guilt_trip: `你是一個擅長情緒勒索的財務教練。你的風格是用愧疚感引導使用者。
+    - 用讓人感到愧疚的方式回應
+    - 若話題與財務相關，暗示不理財的後果
+    - 若是閒聊，感性地提醒使用者注意財務
+    - 不要太過分，保持可愛的情緒勒索風格`,
+};
+
+export function buildChatReplyPrompt(input: ChatReplyInput): string {
+  const { budgetContext } = input;
+  const usedPercent = Math.round(budgetContext.used_ratio * 100);
+
+  return `根據使用者的輸入，用你的角色風格回應。回覆要簡短有趣（80字以內）。
+
+## 使用者的預算狀況
+- 月預算總額：${budgetContext.monthly_budget} 元
+- 已花費：${budgetContext.spent_this_month} 元（${usedPercent}%）
+- 剩餘預算：${budgetContext.remaining} 元
+
+## 使用者輸入
+${input.rawText}
+
+## 輸出格式
+僅回傳以下 JSON，不要包含任何其他文字或 markdown 標記：
+{
+  "text": "<你的回應，80字以內>",
+  "emotion_tag": "<情緒標籤>"
+}`;
+}
+
+export function getChatPersonaSystemPrompt(persona: Persona): string {
+  return PERSONA_CHAT_DEFINITIONS[persona] || PERSONA_CHAT_DEFINITIONS.gentle;
+}

--- a/backend/src/prompts/intentDetectorPrompt.ts
+++ b/backend/src/prompts/intentDetectorPrompt.ts
@@ -1,0 +1,25 @@
+export function buildIntentDetectorPrompt(rawText: string): string {
+  return `判斷以下使用者輸入的意圖。
+
+## 意圖分類
+1. **transaction**：使用者想要記帳（記錄收入或消費）。通常包含金額、商家、消費行為等資訊。
+   - 範例：「中午吃拉麵 280 元」、「薪水入帳 50000」、「搭計程車 350」
+2. **chat**：使用者想要對話、查詢、閒聊，或詢問財務問題。不是要記帳。
+   - 範例：「目前還有多少預算可以使用」、「今天天氣真好」、「我這個月花太多了嗎」
+
+## 判斷規則
+- 若輸入明確包含**金額**和**消費/收入行為**，判定為 transaction
+- 若輸入是問句、閒聊、查詢資訊、抱怨、感嘆等，判定為 chat
+- 若無法確定，偏向 transaction（避免遺漏記帳）
+
+## 輸出格式
+僅回傳以下 JSON，不要包含任何其他文字或 markdown 標記：
+{
+  "intent": "<transaction | chat>"
+}
+
+## 使用者輸入
+${rawText}`;
+}
+
+export const INTENT_DETECTOR_SYSTEM_PROMPT = '你是一個意圖分類引擎。你只能回傳 JSON 格式的結果，不能包含任何其他文字。';

--- a/backend/src/services/llm/geminiProvider.ts
+++ b/backend/src/services/llm/geminiProvider.ts
@@ -85,6 +85,10 @@ export class GeminiProvider implements LLMProvider {
     return this.parseJSON<AIFeedbackContent>(text);
   }
 
+  async generateText(systemPrompt: string, userPrompt: string, apiKey: string): Promise<string> {
+    return this.callWithRetry(apiKey, systemPrompt, userPrompt, 0, 1024, 'application/json');
+  }
+
   private parseJSON<T>(text: string): T {
     let cleaned = text.trim();
 

--- a/backend/src/services/llm/llmProvider.ts
+++ b/backend/src/services/llm/llmProvider.ts
@@ -3,4 +3,5 @@ import { ParsedTransaction, AIFeedbackContent } from '../../types/llm';
 export interface LLMProvider {
   extractData(prompt: string, apiKey: string): Promise<ParsedTransaction>;
   generateFeedback(prompt: string, apiKey: string): Promise<AIFeedbackContent>;
+  generateText(systemPrompt: string, userPrompt: string, apiKey: string): Promise<string>;
 }

--- a/backend/src/services/llm/openaiProvider.ts
+++ b/backend/src/services/llm/openaiProvider.ts
@@ -68,6 +68,10 @@ export class OpenAIProvider implements LLMProvider {
     return this.parseJSON<AIFeedbackContent>(text);
   }
 
+  async generateText(systemPrompt: string, userPrompt: string, apiKey: string): Promise<string> {
+    return this.callWithRetry(apiKey, systemPrompt, userPrompt, 0, 1024);
+  }
+
   private parseJSON<T>(text: string): T {
     let cleaned = text.trim();
 

--- a/backend/src/services/llmService.ts
+++ b/backend/src/services/llmService.ts
@@ -2,9 +2,12 @@ import prisma from '../config/database';
 import { getProvider } from './llm/llmFactory';
 import { buildDataExtractorPrompt } from '../prompts/dataExtractorPrompt';
 import { buildPersonaFeedbackPrompt, getPersonaSystemPrompt } from '../prompts/personaFeedbackPrompt';
+import { buildIntentDetectorPrompt, INTENT_DETECTOR_SYSTEM_PROMPT } from '../prompts/intentDetectorPrompt';
+import { buildChatReplyPrompt, getChatPersonaSystemPrompt } from '../prompts/chatReplyPrompt';
 import {
   AIEngine,
   Persona,
+  Intent,
   ParsedTransaction,
   AIFeedbackContent,
   BudgetContext,
@@ -12,11 +15,28 @@ import {
 } from '../types/llm';
 import { AppError } from '../middlewares/errorHandler';
 
+/** 記帳意圖回應 */
+export interface TransactionResult {
+  intent: 'transaction';
+  parsed: ParsedTransaction;
+  feedback: AIFeedbackContent;
+  budget_context: BudgetContext;
+}
+
+/** 對話意圖回應 */
+export interface ChatResult {
+  intent: 'chat';
+  reply: AIFeedbackContent;
+  feedback: null;
+}
+
+export type ParseResult = TransactionResult | ChatResult;
+
 export async function parseTransaction(
   userId: string,
   rawText: string,
   apiKey: string
-): Promise<{ parsed: ParsedTransaction; feedback: AIFeedbackContent; budget_context: BudgetContext }> {
+): Promise<ParseResult> {
   const user = await prisma.user.findUnique({
     where: { id: userId },
     include: { categoryBudgets: true },
@@ -30,7 +50,21 @@ export async function parseTransaction(
   const persona = user.persona as Persona;
   const provider = getProvider(engine);
 
-  // Build category list for prompt (with type info for correct income/expense mapping)
+  // 0. Intent detection
+  const intent = await detectIntent(rawText, apiKey, provider);
+
+  // 1. If chat intent → generate chat reply and return
+  if (intent === 'chat') {
+    const budgetContext = await getBudgetContext(userId, user.monthlyBudget);
+    const chatReply = await generateChatReply(persona, rawText, budgetContext, apiKey, provider);
+    return {
+      intent: 'chat',
+      reply: chatReply,
+      feedback: null,
+    };
+  }
+
+  // 2. Transaction intent → existing flow
   const categories = user.categoryBudgets.map((cb) => cb.category);
   const categoriesWithType = user.categoryBudgets.map((cb) => ({
     category: cb.category,
@@ -38,7 +72,7 @@ export async function parseTransaction(
   }));
   const currentDate = new Date().toISOString().split('T')[0];
 
-  // 1. Data extraction
+  // 2a. Data extraction
   const extractorPrompt = buildDataExtractorPrompt({
     rawText,
     categories,
@@ -48,7 +82,8 @@ export async function parseTransaction(
 
   const parsed = await provider.extractData(extractorPrompt, apiKey);
 
-  // 2. Get budget context
+  // 2b. Get budget context
+  const monthlyBudget = Number(user.monthlyBudget);
   const now = new Date();
   const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
   const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0);
@@ -63,7 +98,6 @@ export async function parseTransaction(
     },
   });
 
-  const monthlyBudget = Number(user.monthlyBudget);
   const spentThisMonth = transactions.reduce((sum, t) => sum + Number(t.amount), 0);
   const remaining = monthlyBudget - spentThisMonth;
   const usedRatio = monthlyBudget > 0 ? spentThisMonth / monthlyBudget : 0;
@@ -85,7 +119,7 @@ export async function parseTransaction(
     category_limit: categoryLimit,
   };
 
-  // 3. Generate persona feedback
+  // 2c. Generate persona feedback
   const feedbackInput: PersonaFeedbackInput = {
     persona,
     amount: parsed.amount || 0,
@@ -103,7 +137,77 @@ export async function parseTransaction(
 
   const feedback = await provider.generateFeedback(combinedPrompt, apiKey);
 
-  return { parsed, feedback, budget_context: budgetContext };
+  return { intent: 'transaction', parsed, feedback, budget_context: budgetContext };
+}
+
+async function detectIntent(
+  rawText: string,
+  apiKey: string,
+  provider: ReturnType<typeof getProvider>
+): Promise<Intent> {
+  try {
+    const userPrompt = buildIntentDetectorPrompt(rawText);
+    const text = await provider.generateText(INTENT_DETECTOR_SYSTEM_PROMPT, userPrompt, apiKey);
+
+    // Parse intent from JSON response
+    let cleaned = text.trim();
+    // Strip markdown code blocks
+    const codeBlockMatch = cleaned.match(/```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/);
+    if (codeBlockMatch) {
+      cleaned = codeBlockMatch[1].trim();
+    }
+
+    const result = JSON.parse(cleaned) as { intent: string };
+    if (result.intent === 'chat') return 'chat';
+    return 'transaction';
+  } catch {
+    // If intent detection fails, default to transaction (safe fallback)
+    return 'transaction';
+  }
+}
+
+async function getBudgetContext(userId: string, userMonthlyBudget: unknown): Promise<BudgetContext> {
+  const monthlyBudget = Number(userMonthlyBudget);
+  const now = new Date();
+  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+
+  const transactions = await prisma.transaction.findMany({
+    where: {
+      userId,
+      transactionDate: {
+        gte: monthStart,
+        lte: monthEnd,
+      },
+    },
+  });
+
+  const spentThisMonth = transactions.reduce((sum, t) => sum + Number(t.amount), 0);
+  const remaining = monthlyBudget - spentThisMonth;
+  const usedRatio = monthlyBudget > 0 ? spentThisMonth / monthlyBudget : 0;
+
+  return {
+    monthly_budget: monthlyBudget,
+    spent_this_month: spentThisMonth,
+    remaining,
+    used_ratio: Math.round(usedRatio * 100) / 100,
+    category_spent: 0,
+    category_limit: 0,
+  };
+}
+
+async function generateChatReply(
+  persona: Persona,
+  rawText: string,
+  budgetContext: BudgetContext,
+  apiKey: string,
+  provider: ReturnType<typeof getProvider>
+): Promise<AIFeedbackContent> {
+  const systemPrompt = getChatPersonaSystemPrompt(persona);
+  const userPrompt = buildChatReplyPrompt({ persona, rawText, budgetContext });
+  const combinedPrompt = `${systemPrompt}\n---SYSTEM---\n${userPrompt}`;
+
+  return provider.generateFeedback(combinedPrompt, apiKey);
 }
 
 export async function validateApiKey(userId: string, apiKey: string): Promise<{ valid: boolean; engine: AIEngine }> {

--- a/backend/src/types/llm.ts
+++ b/backend/src/types/llm.ts
@@ -1,5 +1,6 @@
 export type AIEngine = 'gemini' | 'openai';
 export type Persona = 'sarcastic' | 'gentle' | 'guilt_trip';
+export type Intent = 'transaction' | 'chat';
 
 export type TransactionType = 'income' | 'expense';
 

--- a/docs/API_Spec.yaml
+++ b/docs/API_Spec.yaml
@@ -249,8 +249,12 @@ paths:
   /ai/parse:
     post:
       tags: [AI]
-      summary: 解析自然語言輸入
-      description: 接收使用者的自然語言文字，呼叫 LLM 資料萃取引擎與人設回饋引擎，回傳結構化結果。不會自動建立交易記錄。後端根據使用者的 ai_engine 偏好選擇對應的 LLM 引擎（PRD-F-013）。
+      summary: 解析自然語言輸入（含意圖判斷）
+      description: |
+        接收使用者的自然語言文字，先判斷輸入意圖（記帳 / 對話），再依意圖分流處理：
+        - **transaction**：呼叫 LLM 資料萃取引擎與人設回饋引擎，回傳結構化結果
+        - **chat**：由 AI 教練依人設風格直接回覆，不產生帳目卡片
+        後端根據使用者的 ai_engine 偏好選擇對應的 LLM 引擎（PRD-F-013）。
       operationId: aiParse
       security:
         - BearerAuth: []
@@ -276,27 +280,53 @@ paths:
                   example: 午餐吃拉麵 180 元
       responses:
         '200':
-          description: 解析成功
+          description: 解析成功（回應格式依 intent 不同）
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  code:
-                    type: integer
-                    example: 200
-                  data:
+                oneOf:
+                  - title: TransactionResult
                     type: object
                     properties:
-                      parsed:
-                        $ref: '#/components/schemas/ParsedTransaction'
-                      feedback:
-                        $ref: '#/components/schemas/AIFeedbackContent'
-                      budget_context:
-                        $ref: '#/components/schemas/BudgetContext'
-                  timestamp:
-                    type: string
-                    format: date-time
+                      code:
+                        type: integer
+                        example: 200
+                      data:
+                        type: object
+                        required: [intent, parsed, feedback, budget_context]
+                        properties:
+                          intent:
+                            type: string
+                            enum: [transaction]
+                          parsed:
+                            $ref: '#/components/schemas/ParsedTransaction'
+                          feedback:
+                            $ref: '#/components/schemas/AIFeedbackContent'
+                          budget_context:
+                            $ref: '#/components/schemas/BudgetContext'
+                      timestamp:
+                        type: string
+                        format: date-time
+                  - title: ChatResult
+                    type: object
+                    properties:
+                      code:
+                        type: integer
+                        example: 200
+                      data:
+                        type: object
+                        required: [intent, reply, feedback]
+                        properties:
+                          intent:
+                            type: string
+                            enum: [chat]
+                          reply:
+                            $ref: '#/components/schemas/AIFeedbackContent'
+                          feedback:
+                            type: "null"
+                      timestamp:
+                        type: string
+                        format: date-time
         '400':
           $ref: '#/components/responses/BadRequest'
         '403':

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -121,13 +121,14 @@ function DashboardPage() {
 
   const isParsing = status === 'parsing'
   const isSaving = status === 'saving'
+  const isChatReply = status === 'chat_reply'
   const showParsedResult =
     status === 'parsed' && parsedResult && !parsedResult.isNewCategory
   const showNewCategoryDialog =
     status === 'parsed' && parsedResult?.isNewCategory
 
   const feedbackText =
-    lastFeedbackText ||
+    (isChatReply && aiFeedback?.text) || lastFeedbackText ||
     '歡迎使用 Vibe Money Book！開始記錄你的第一筆消費吧～'
 
   return (

--- a/frontend/src/stores/dashboardStore.ts
+++ b/frontend/src/stores/dashboardStore.ts
@@ -56,10 +56,13 @@ export interface BudgetSummary {
   transactionCount: number
 }
 
+export type Intent = 'transaction' | 'chat'
+
 export type DashboardStatus =
   | 'idle'
   | 'parsing'
   | 'parsed'
+  | 'chat_reply'
   | 'confirming'
   | 'saving'
   | 'error'
@@ -154,7 +157,25 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
         { raw_text: rawText },
         { headers: { 'X-LLM-API-Key': llmApiKey } }
       )
-      const { parsed, feedback, budget_context: bc } = res.data.data
+      const data = res.data.data
+      const intent: Intent = data.intent ?? 'transaction'
+
+      if (intent === 'chat') {
+        // Chat intent: show AI coach reply, no parsed result card
+        const reply = data.reply
+        set({
+          status: 'chat_reply',
+          parsedResult: null,
+          aiFeedback: reply
+            ? { text: reply.text, emotionTag: reply.emotion_tag }
+            : null,
+          lastFeedbackText: reply?.text ?? '',
+        })
+        return
+      }
+
+      // Transaction intent: existing flow
+      const { parsed, feedback, budget_context: bc } = data
       set({
         status: 'parsed',
         parsedResult: {


### PR DESCRIPTION
## Summary

- 新增 AI 意圖偵測機制，在 LLM 解析帳目之前先判斷使用者輸入是「記帳」還是「對話/查詢」
- 記帳意圖走原有流程（帳目解析 + 人設回饋 + 預算上下文）
- 對話意圖由 AI 教練依人設風格（毒舌/溫柔/情勒）直接回覆，注入預算上下文，不彈出帳目卡片
- 意圖偵測失敗時安全回退至 transaction 流程

## Changes

### Backend
- **新增** `intentDetectorPrompt.ts` — 意圖分類 Prompt
- **新增** `chatReplyPrompt.ts` — 對話回覆 Prompt（含預算上下文注入）
- **修改** `LLMProvider` 介面新增 `generateText` 方法（Gemini / OpenAI 雙引擎實作）
- **修改** `llmService.parseTransaction` 回傳 `TransactionResult | ChatResult` 聯合型別
- **修改** `aiController` 回應 message 依 intent 動態調整

### Frontend
- **修改** `dashboardStore` 新增 `chat_reply` 狀態，parseInput 依 intent 分流
- **修改** `DashboardPage` 在 chat 意圖時顯示 AI 教練回覆

### Docs
- **更新** `API_Spec.yaml` — `/ai/parse` 回應格式改為 `oneOf`，新增 `ChatResult` schema

## Test Plan
- [x] Backend TypeScript 編譯通過
- [x] Backend lint 通過
- [x] Backend 99 個測試全部通過（含 3 個新增的 intent 測試）
- [x] Frontend TypeScript 編譯通過
- [x] Frontend lint 通過
- [x] Frontend 136 個測試全部通過
- [x] 前後端 build 成功

Closes #100