### PR TITLE
feat(backend): AI 教練對話回覆注入使用者真實財務上下文 (#104)

### DIFF
--- a/backend/src/prompts/chatReplyPrompt.ts
+++ b/backend/src/prompts/chatReplyPrompt.ts
@@ -1,9 +1,9 @@
-import { Persona, BudgetContext } from '../types/llm';
+import { Persona, FinancialContext } from '../types/llm';
 
 export interface ChatReplyInput {
   persona: Persona;
   rawText: string;
-  budgetContext: BudgetContext;
+  financialContext: FinancialContext;
 }
 
 const PERSONA_CHAT_DEFINITIONS: Record<Persona, string> = {
@@ -26,16 +26,41 @@ const PERSONA_CHAT_DEFINITIONS: Record<Persona, string> = {
     - 不要太過分，保持可愛的情緒勒索風格`,
 };
 
+function formatAmount(amount: number, type?: 'income' | 'expense'): string {
+  const prefix = type === 'income' ? '+' : type === 'expense' ? '-' : '';
+  return `${prefix}${amount.toLocaleString('zh-TW')}`;
+}
+
+function buildFinancialContextBlock(ctx: FinancialContext): string {
+  const usedPercent = Math.round(ctx.used_ratio * 100);
+
+  let block = `## 使用者財務現況
+- 總資產：${formatAmount(ctx.net_assets)} 元
+- 本月收入：${formatAmount(ctx.total_income, 'income')} 元
+- 本月支出：${formatAmount(ctx.total_expense, 'expense')} 元
+- 月預算：${ctx.monthly_budget.toLocaleString('zh-TW')} 元
+- 已消費：${ctx.spent_this_month.toLocaleString('zh-TW')} 元（${usedPercent}%）
+- 預算剩餘：${ctx.remaining.toLocaleString('zh-TW')} 元`;
+
+  if (ctx.recent_transactions.length > 0) {
+    block += '\n\n## 近期帳目';
+    ctx.recent_transactions.forEach((t, i) => {
+      const sign = t.type === 'income' ? '+' : '-';
+      const merchant = t.merchant || '';
+      block += `\n${i + 1}. ${t.date} ${t.category} ${sign}${t.amount.toLocaleString('zh-TW')} ${merchant}`;
+    });
+  }
+
+  return block;
+}
+
 export function buildChatReplyPrompt(input: ChatReplyInput): string {
-  const { budgetContext } = input;
-  const usedPercent = Math.round(budgetContext.used_ratio * 100);
+  const financialBlock = buildFinancialContextBlock(input.financialContext);
 
   return `根據使用者的輸入，用你的角色風格回應。回覆要簡短有趣（80字以內）。
+請根據使用者的真實財務狀況來回應，讓回覆更貼近使用者的實際情況。
 
-## 使用者的預算狀況
-- 月預算總額：${budgetContext.monthly_budget} 元
-- 已花費：${budgetContext.spent_this_month} 元（${usedPercent}%）
-- 剩餘預算：${budgetContext.remaining} 元
+${financialBlock}
 
 ## 使用者輸入
 ${input.rawText}

--- a/backend/src/services/llmService.ts
+++ b/backend/src/services/llmService.ts
@@ -11,6 +11,7 @@ import {
   ParsedTransaction,
   AIFeedbackContent,
   BudgetContext,
+  FinancialContext,
   PersonaFeedbackInput,
 } from '../types/llm';
 import { AppError } from '../middlewares/errorHandler';
@@ -55,8 +56,8 @@ export async function parseTransaction(
 
   // 1. If chat intent → generate chat reply and return
   if (intent === 'chat') {
-    const budgetContext = await getBudgetContext(userId, user.monthlyBudget);
-    const chatReply = await generateChatReply(persona, rawText, budgetContext, apiKey, provider);
+    const financialContext = await getFinancialContext(userId, user.monthlyBudget);
+    const chatReply = await generateChatReply(persona, rawText, financialContext, apiKey, provider);
     return {
       intent: 'chat',
       reply: chatReply,
@@ -166,45 +167,77 @@ async function detectIntent(
   }
 }
 
-async function getBudgetContext(userId: string, userMonthlyBudget: unknown): Promise<BudgetContext> {
+async function getFinancialContext(userId: string, userMonthlyBudget: unknown): Promise<FinancialContext> {
   const monthlyBudget = Number(userMonthlyBudget);
   const now = new Date();
   const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
   const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0);
 
-  const transactions = await prisma.transaction.findMany({
-    where: {
-      userId,
-      transactionDate: {
-        gte: monthStart,
-        lte: monthEnd,
+  // Query current month transactions and recent 10 transactions in parallel
+  const [monthTransactions, recentTransactions] = await Promise.all([
+    prisma.transaction.findMany({
+      where: {
+        userId,
+        transactionDate: {
+          gte: monthStart,
+          lte: monthEnd,
+        },
       },
-    },
-  });
+    }),
+    prisma.transaction.findMany({
+      where: { userId },
+      orderBy: { transactionDate: 'desc' },
+      take: 10,
+      select: {
+        transactionDate: true,
+        category: true,
+        type: true,
+        amount: true,
+        merchant: true,
+      },
+    }),
+  ]);
 
-  const spentThisMonth = transactions.reduce((sum, t) => sum + Number(t.amount), 0);
+  const totalIncome = monthTransactions
+    .filter((t) => t.type === 'income')
+    .reduce((sum, t) => sum + Number(t.amount), 0);
+
+  const totalExpense = monthTransactions
+    .filter((t) => t.type === 'expense')
+    .reduce((sum, t) => sum + Number(t.amount), 0);
+
+  const spentThisMonth = totalExpense;
   const remaining = monthlyBudget - spentThisMonth;
   const usedRatio = monthlyBudget > 0 ? spentThisMonth / monthlyBudget : 0;
+  const netAssets = totalIncome - totalExpense;
 
   return {
     monthly_budget: monthlyBudget,
     spent_this_month: spentThisMonth,
     remaining,
     used_ratio: Math.round(usedRatio * 100) / 100,
-    category_spent: 0,
-    category_limit: 0,
+    total_income: totalIncome,
+    total_expense: totalExpense,
+    net_assets: netAssets,
+    recent_transactions: recentTransactions.map((t) => ({
+      date: t.transactionDate.toISOString().split('T')[0],
+      category: t.category,
+      type: t.type as 'income' | 'expense',
+      amount: Number(t.amount),
+      merchant: t.merchant,
+    })),
   };
 }
 
 async function generateChatReply(
   persona: Persona,
   rawText: string,
-  budgetContext: BudgetContext,
+  financialContext: FinancialContext,
   apiKey: string,
   provider: ReturnType<typeof getProvider>
 ): Promise<AIFeedbackContent> {
   const systemPrompt = getChatPersonaSystemPrompt(persona);
-  const userPrompt = buildChatReplyPrompt({ persona, rawText, budgetContext });
+  const userPrompt = buildChatReplyPrompt({ persona, rawText, financialContext });
   const combinedPrompt = `${systemPrompt}\n---SYSTEM---\n${userPrompt}`;
 
   return provider.generateFeedback(combinedPrompt, apiKey);

--- a/backend/src/types/llm.ts
+++ b/backend/src/types/llm.ts
@@ -42,6 +42,25 @@ export interface DataExtractorInput {
   currentDate: string;
 }
 
+export interface RecentTransaction {
+  date: string;
+  category: string;
+  type: 'income' | 'expense';
+  amount: number;
+  merchant: string | null;
+}
+
+export interface FinancialContext {
+  monthly_budget: number;
+  spent_this_month: number;
+  remaining: number;
+  used_ratio: number;
+  total_income: number;
+  total_expense: number;
+  net_assets: number;
+  recent_transactions: RecentTransaction[];
+}
+
 export interface PersonaFeedbackInput {
   persona: Persona;
   amount: number;


### PR DESCRIPTION
## Summary
- 新增 `FinancialContext` 及 `RecentTransaction` 型別，包含總資產、月收入/支出、預算狀況及近期交易
- `chatReplyPrompt` 改用 `FinancialContext`，將使用者真實財務數據（總資產、收支、預算、近期 10 筆帳目）注入 AI 教練 Prompt
- `llmService` 新增 `getFinancialContext()`，以 `Promise.all` 並行查詢當月交易與最近 10 筆交易，兼顧效能
- 移除已無用的 `getBudgetContext()`（僅 chat 意圖使用，已被取代）

Closes #104

## Test plan
- [x] TypeScript 型別檢查通過 (`tsc --noEmit`)
- [x] ESLint 檢查通過
- [x] 99 個既有測試全數通過
- [x] Build 成功