### PR TITLE
feat: 新增帳務調整類別與統一帳目編輯 UI 頁籤設計 (#105)

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -11,12 +11,14 @@ const DEFAULT_CATEGORIES = [
   { category: 'medical', type: 'expense', budgetLimit: 2000 },
   { category: 'transport', type: 'expense', budgetLimit: 3000 },
   { category: 'other', type: 'expense', budgetLimit: 0 },
+  { category: 'adjustment_expense', type: 'expense', budgetLimit: 0 },
   // 收入類別
   { category: 'salary', type: 'income', budgetLimit: 0 },
   { category: 'investment', type: 'income', budgetLimit: 0 },
   { category: 'pension', type: 'income', budgetLimit: 0 },
   { category: 'insurance', type: 'income', budgetLimit: 0 },
   { category: 'other_income', type: 'income', budgetLimit: 0 },
+  { category: 'adjustment_income', type: 'income', budgetLimit: 0 },
 ];
 
 async function main() {

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -17,12 +17,14 @@ const DEFAULT_CATEGORY_BUDGETS = [
   { category: 'medical', type: 'expense', budgetLimit: 2000, isCustom: false },
   { category: 'transport', type: 'expense', budgetLimit: 3000, isCustom: false },
   { category: 'other', type: 'expense', budgetLimit: 0, isCustom: false },
+  { category: 'adjustment_expense', type: 'expense', budgetLimit: 0, isCustom: false },
   // 收入類別
   { category: 'salary', type: 'income', budgetLimit: 0, isCustom: false },
   { category: 'investment', type: 'income', budgetLimit: 0, isCustom: false },
   { category: 'pension', type: 'income', budgetLimit: 0, isCustom: false },
   { category: 'insurance', type: 'income', budgetLimit: 0, isCustom: false },
   { category: 'other_income', type: 'income', budgetLimit: 0, isCustom: false },
+  { category: 'adjustment_income', type: 'income', budgetLimit: 0, isCustom: false },
 ];
 
 function generateToken(userId: string): string {

--- a/frontend/src/components/ParsedResultCard.tsx
+++ b/frontend/src/components/ParsedResultCard.tsx
@@ -16,11 +16,6 @@ interface ParsedResultCardProps {
   categoryInfoList?: CategoryInfo[]
 }
 
-const typeLabels: Record<TransactionType, string> = {
-  income: '收入',
-  expense: '消費',
-}
-
 function ParsedResultCard({
   result,
   onConfirm,
@@ -73,44 +68,39 @@ function ParsedResultCard({
         AI 幫你整理好了
       </h3>
 
-      <div className="space-y-sm mb-lg">
-        {/* Issue #58: Transaction type selector */}
-        <div className="flex items-center gap-md">
-          <span className="text-caption text-text-secondary w-[60px] shrink-0">
-            類型
-          </span>
-          <div className="flex gap-sm" role="radiogroup" aria-label="交易類型">
-            <button
-              type="button"
-              onClick={() => handleTypeChange('expense')}
-              className={`px-md py-xs rounded-md text-caption font-semibold transition-colors ${
-                type === 'expense'
-                  ? 'bg-danger text-surface'
-                  : 'bg-bg text-text-secondary border border-border'
-              }`}
-              role="radio"
-              aria-checked={type === 'expense'}
-              aria-label="消費"
-            >
-              {typeLabels.expense}
-            </button>
-            <button
-              type="button"
-              onClick={() => handleTypeChange('income')}
-              className={`px-md py-xs rounded-md text-caption font-semibold transition-colors ${
-                type === 'income'
-                  ? 'bg-success text-surface'
-                  : 'bg-bg text-text-secondary border border-border'
-              }`}
-              role="radio"
-              aria-checked={type === 'income'}
-              aria-label="收入"
-            >
-              {typeLabels.income}
-            </button>
-          </div>
-        </div>
+      {/* Issue #105: 收入/支出 頁籤 */}
+      <div className="flex border-b border-border mb-lg" role="tablist" aria-label="交易類型">
+        <button
+          type="button"
+          onClick={() => handleTypeChange('expense')}
+          className={`flex-1 py-2 text-body font-semibold transition-colors ${
+            type === 'expense'
+              ? 'border-b-2 border-danger text-danger'
+              : 'text-text-secondary'
+          }`}
+          role="tab"
+          aria-selected={type === 'expense'}
+          aria-label="支出"
+        >
+          支出
+        </button>
+        <button
+          type="button"
+          onClick={() => handleTypeChange('income')}
+          className={`flex-1 py-2 text-body font-semibold transition-colors ${
+            type === 'income'
+              ? 'border-b-2 border-success text-success'
+              : 'text-text-secondary'
+          }`}
+          role="tab"
+          aria-selected={type === 'income'}
+          aria-label="收入"
+        >
+          收入
+        </button>
+      </div>
 
+      <div className="space-y-sm mb-lg">
         {/* Issue #59: always editable (default edit mode) */}
         <div className="flex items-center gap-md">
           <span className="text-caption text-text-secondary w-[60px] shrink-0">

--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -26,6 +26,8 @@ const categoryIcons: Record<string, string> = {
   pension: '🏦',
   insurance: '🛡️',
   other_income: '💵',
+  adjustment_expense: '🔧',
+  adjustment_income: '🔧',
 }
 
 const EXPENSE_CATEGORIES = Object.keys(CATEGORY_NAMES).filter((c) => !INCOME_CATEGORIES.has(c))

--- a/frontend/src/lib/categoryUtils.ts
+++ b/frontend/src/lib/categoryUtils.ts
@@ -7,12 +7,14 @@ export const CATEGORY_COLORS: Record<string, string> = {
   medical: '#FD79A8',
   transport: '#4ECDC4',
   other: '#B2BEC3',
+  adjustment_expense: '#95A5A6',
   // 收入類別
   salary: '#22C55E',
   investment: '#10B981',
   pension: '#059669',
   insurance: '#047857',
   other_income: '#6EE7B7',
+  adjustment_income: '#86EFAC',
 }
 
 /** Fallback colors for custom categories */
@@ -27,16 +29,18 @@ export const CATEGORY_NAMES: Record<string, string> = {
   medical: '醫療',
   transport: '交通',
   other: '其它',
+  adjustment_expense: '帳務調整',
   // 收入類別
   salary: '薪資收入',
   investment: '投資收益',
   pension: '退休金',
   insurance: '保險理賠',
   other_income: '其它',
+  adjustment_income: '帳務調整',
 }
 
 /** 收入類別集合 */
-export const INCOME_CATEGORIES = new Set(['salary', 'investment', 'pension', 'insurance', 'other_income'])
+export const INCOME_CATEGORIES = new Set(['salary', 'investment', 'pension', 'insurance', 'other_income', 'adjustment_income'])
 
 /** 根據類別判斷是否為收入類別 */
 export function isIncomeCategory(category: string): boolean {

--- a/frontend/src/test/dashboardComponents.test.tsx
+++ b/frontend/src/test/dashboardComponents.test.tsx
@@ -153,8 +153,8 @@ describe('ParsedResultCard', () => {
     expect(screen.getByLabelText('類別')).toBeInTheDocument()
     expect(screen.getByLabelText('商家')).toBeInTheDocument()
     expect(screen.getByLabelText('日期')).toBeInTheDocument()
-    // Should have type selector (Issue #58)
-    expect(screen.getByLabelText('消費')).toBeInTheDocument()
+    // Should have type tab selector (Issue #105)
+    expect(screen.getByLabelText('支出')).toBeInTheDocument()
     expect(screen.getByLabelText('收入')).toBeInTheDocument()
   })
 
@@ -209,9 +209,9 @@ describe('ParsedResultCard', () => {
         categories={categories}
       />
     )
-    // Income button should be selected
-    const incomeBtn = screen.getByLabelText('收入')
-    expect(incomeBtn.getAttribute('aria-checked')).toBe('true')
+    // Income tab should be selected (Issue #105)
+    const incomeTab = screen.getByLabelText('收入')
+    expect(incomeTab.getAttribute('aria-selected')).toBe('true')
   })
 
   it('allows switching between income and expense types', async () => {
@@ -225,11 +225,11 @@ describe('ParsedResultCard', () => {
         categories={categories}
       />
     )
-    // Default is expense
-    expect(screen.getByLabelText('消費').getAttribute('aria-checked')).toBe('true')
+    // Default is expense (Issue #105: tabs use aria-selected)
+    expect(screen.getByLabelText('支出').getAttribute('aria-selected')).toBe('true')
     // Switch to income
     await user.click(screen.getByLabelText('收入'))
-    expect(screen.getByLabelText('收入').getAttribute('aria-checked')).toBe('true')
+    expect(screen.getByLabelText('收入').getAttribute('aria-selected')).toBe('true')
     // Confirm with income type
     await user.click(screen.getByText('確認新增'))
     expect(onConfirm).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

- 新增「帳務調整」預設類別：`adjustment_expense`（支出）與 `adjustment_income`（收入），同步更新 seed、新使用者預設類別、前端中文對照與顏色
- 首頁 `ParsedResultCard` 從 radio button 改為與記錄頁一致的收入/支出頁籤設計，頁籤切換時自動篩選對應類型的類別
- 更新前端測試以匹配新的頁籤 UI（`aria-selected` / 「支出」標籤）

## Test plan

- [x] Backend: `tsc --noEmit` 通過
- [x] Backend: `npm run lint` 通過
- [x] Backend: `npm test -- --run` 全部 99 tests 通過
- [x] Frontend: `tsc --noEmit` 通過
- [x] Frontend: `npm run lint` 通過
- [x] Frontend: `npm test -- --run` 全部 136 tests 通過
- [x] Backend & Frontend build 成功

Closes #105