### PR TITLE
fix(frontend): 記錄頁面類別篩選以 optgroup 區分收入/支出 (#110)

### DIFF
--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -56,17 +56,17 @@ function HistoryPage() {
     updateTransaction,
   } = useHistoryStore()
 
-  const storeCategories = useDashboardStore((s) => s.categories)
+  const categoryInfoList = useDashboardStore((s) => s.categoryInfoList)
   const fetchCategories = useDashboardStore((s) => s.fetchCategories)
 
-  const categoryOptions = useMemo(() => {
-    const opts = [{ value: '', label: '全部類別' }]
-    for (const cat of storeCategories) {
-      const icon = CATEGORY_ICONS[cat] ?? '📦'
-      opts.push({ value: cat, label: `${icon} ${getCategoryName(cat)}` })
-    }
-    return opts
-  }, [storeCategories])
+  const expenseCategories = useMemo(
+    () => categoryInfoList.filter((c) => c.type === 'expense'),
+    [categoryInfoList]
+  )
+  const incomeCategories = useMemo(
+    () => categoryInfoList.filter((c) => c.type === 'income'),
+    [categoryInfoList]
+  )
 
   const [expandedId, setExpandedId] = useState<string | null>(null)
 
@@ -164,11 +164,25 @@ function HistoryPage() {
             aria-label="類別篩選"
             data-testid="category-filter"
           >
-            {categoryOptions.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
+            <option value="">全部類別</option>
+            {expenseCategories.length > 0 && (
+              <optgroup label="支出">
+                {expenseCategories.map((c) => (
+                  <option key={c.category} value={c.category}>
+                    {(CATEGORY_ICONS[c.category] ?? '📦') + ' ' + getCategoryName(c.category)}
+                  </option>
+                ))}
+              </optgroup>
+            )}
+            {incomeCategories.length > 0 && (
+              <optgroup label="收入">
+                {incomeCategories.map((c) => (
+                  <option key={c.category} value={c.category}>
+                    {(CATEGORY_ICONS[c.category] ?? '📦') + ' ' + getCategoryName(c.category)}
+                  </option>
+                ))}
+              </optgroup>
+            )}
           </select>
 
           {hasActiveFilters && (


### PR DESCRIPTION
## Summary
- 將記錄頁面（HistoryPage）的類別篩選下拉選單從扁平列表改為使用 `<optgroup>` 分組
- 支出類別歸入「支出」群組，收入類別歸入「收入」群組，解決同名類別（如「其它」、「帳務調整」）無法區分的問題
- 改用 `categoryInfoList`（含 type 資訊）取代原本的 `categories`（純 string[]）

Closes #110

## Test plan
- [x] TypeScript 編譯通過 (`tsc --noEmit`)
- [x] ESLint 通過
- [x] 全部 136 個測試通過
- [x] Build 成功