### PR TITLE
feat: 設定頁面新增 AI 指示自訂系統提示詞 (#112)

### DIFF
--- a/backend/prisma/migrations/20260320115905_add_ai_instructions_to_users/migration.sql
+++ b/backend/prisma/migrations/20260320115905_add_ai_instructions_to_users/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN "ai_instructions" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
   aiEngine       String   @default("gemini") @map("ai_engine") // gemini, openai
   monthlyBudget  Decimal  @default(30000.00) @map("monthly_budget")
   currency       String   @default("TWD")
+  aiInstructions String?  @map("ai_instructions")
   createdAt      DateTime @default(now()) @map("created_at")
   updatedAt      DateTime @updatedAt @map("updated_at")
 

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -42,6 +42,7 @@ export function formatUserResponse(user: {
   aiEngine: string;
   monthlyBudget: unknown;
   currency: string;
+  aiInstructions?: string | null;
   createdAt: Date;
 }) {
   return {
@@ -52,6 +53,7 @@ export function formatUserResponse(user: {
     ai_engine: user.aiEngine,
     monthly_budget: Number(user.monthlyBudget),
     currency: user.currency,
+    ai_instructions: user.aiInstructions ?? null,
     created_at: user.createdAt.toISOString(),
   };
 }

--- a/backend/src/services/llmService.ts
+++ b/backend/src/services/llmService.ts
@@ -57,7 +57,7 @@ export async function parseTransaction(
   // 1. If chat intent → generate chat reply and return
   if (intent === 'chat') {
     const financialContext = await getFinancialContext(userId, user.monthlyBudget);
-    const chatReply = await generateChatReply(persona, rawText, financialContext, apiKey, provider);
+    const chatReply = await generateChatReply(persona, rawText, financialContext, apiKey, provider, user.aiInstructions);
     return {
       intent: 'chat',
       reply: chatReply,
@@ -74,12 +74,17 @@ export async function parseTransaction(
   const currentDate = new Date().toISOString().split('T')[0];
 
   // 2a. Data extraction
-  const extractorPrompt = buildDataExtractorPrompt({
+  let extractorPrompt = buildDataExtractorPrompt({
     rawText,
     categories,
     categoriesWithType,
     currentDate,
   });
+
+  // Inject user custom AI instructions if present
+  if (user.aiInstructions) {
+    extractorPrompt = `${extractorPrompt}\n\n## 使用者自訂 AI 指示\n${user.aiInstructions}`;
+  }
 
   const parsed = await provider.extractData(extractorPrompt, apiKey);
 
@@ -134,7 +139,8 @@ export async function parseTransaction(
 
   const personaSystemPrompt = getPersonaSystemPrompt(persona);
   const feedbackUserPrompt = buildPersonaFeedbackPrompt(feedbackInput);
-  const combinedPrompt = `${personaSystemPrompt}\n---SYSTEM---\n${feedbackUserPrompt}`;
+  const aiInstructionsBlock = user.aiInstructions ? `\n\n## 使用者自訂 AI 指示\n${user.aiInstructions}` : '';
+  const combinedPrompt = `${personaSystemPrompt}${aiInstructionsBlock}\n---SYSTEM---\n${feedbackUserPrompt}`;
 
   const feedback = await provider.generateFeedback(combinedPrompt, apiKey);
 
@@ -234,11 +240,13 @@ async function generateChatReply(
   rawText: string,
   financialContext: FinancialContext,
   apiKey: string,
-  provider: ReturnType<typeof getProvider>
+  provider: ReturnType<typeof getProvider>,
+  aiInstructions?: string | null
 ): Promise<AIFeedbackContent> {
   const systemPrompt = getChatPersonaSystemPrompt(persona);
   const userPrompt = buildChatReplyPrompt({ persona, rawText, financialContext });
-  const combinedPrompt = `${systemPrompt}\n---SYSTEM---\n${userPrompt}`;
+  const aiInstructionsBlock = aiInstructions ? `\n\n## 使用者自訂 AI 指示\n${aiInstructions}` : '';
+  const combinedPrompt = `${systemPrompt}${aiInstructionsBlock}\n---SYSTEM---\n${userPrompt}`;
 
   return provider.generateFeedback(combinedPrompt, apiKey);
 }

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -22,6 +22,7 @@ export async function updateProfile(userId: string, input: UpdateProfileInput) {
   if (input.persona !== undefined) updateData.persona = input.persona;
   if (input.ai_engine !== undefined) updateData.aiEngine = input.ai_engine;
   if (input.monthly_budget !== undefined) updateData.monthlyBudget = input.monthly_budget;
+  if (input.ai_instructions !== undefined) updateData.aiInstructions = input.ai_instructions;
 
   const user = await prisma.user.update({
     where: { id: userId },

--- a/backend/src/validators/userValidators.ts
+++ b/backend/src/validators/userValidators.ts
@@ -21,6 +21,11 @@ export const updateProfileSchema = z.object({
     .min(0, '月預算不可為負數')
     .max(10000000, '月預算不可超過 10,000,000')
     .optional(),
+  ai_instructions: z
+    .string()
+    .max(1000, 'AI 指示最多 1000 個字元')
+    .nullable()
+    .optional(),
 }).refine(
   (data) => Object.keys(data).length > 0,
   { message: '至少需提供一個欄位進行更新' }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -30,6 +30,7 @@ function SettingsPage() {
     monthlyBudget,
     userName,
     userEmail,
+    aiInstructions,
     loading,
     saving,
     error,
@@ -38,9 +39,14 @@ function SettingsPage() {
     updatePersona,
     updateBudget,
     updateAIEngine,
+    updateAIInstructions,
     validateApiKey,
     clearError,
   } = useSettingsStore()
+
+  // Local state for AI instructions
+  const [aiInstructionsInput, setAiInstructionsInput] = useState(aiInstructions)
+  const [aiInstructionsEditing, setAiInstructionsEditing] = useState(false)
 
   // Local state for budget input (so user can type freely)
   const [budgetInput, setBudgetInput] = useState(() =>
@@ -67,12 +73,13 @@ function SettingsPage() {
   const [showApiKey, setShowApiKey] = useState(false)
   const currentApiKey = apiKeys[aiEngine] ?? ''
 
-  // Load profile on mount and sync budget input
+  // Load profile on mount and sync budget input / AI instructions
   useEffect(() => {
     const load = async () => {
       await fetchProfile()
-      const budget = useSettingsStore.getState().monthlyBudget
-      if (budget > 0) setBudgetInput(String(budget))
+      const state = useSettingsStore.getState()
+      if (state.monthlyBudget > 0) setBudgetInput(String(state.monthlyBudget))
+      setAiInstructionsInput(state.aiInstructions)
     }
     load()
   }, [fetchProfile])
@@ -87,6 +94,13 @@ function SettingsPage() {
     }
     setBudgetEditing(false)
   }, [budgetInput, updateBudget, monthlyBudget])
+
+  const handleAiInstructionsSave = useCallback(() => {
+    if (aiInstructionsInput !== aiInstructions) {
+      updateAIInstructions(aiInstructionsInput)
+    }
+    setAiInstructionsEditing(false)
+  }, [aiInstructionsInput, aiInstructions, updateAIInstructions])
 
   const saveApiKeys = useCallback((keys: Record<string, string>) => {
     localStorage.setItem('llm_api_keys', JSON.stringify(keys))
@@ -238,6 +252,41 @@ function SettingsPage() {
               </button>
             )
           })}
+        </div>
+      </section>
+
+      {/* AI 指示 */}
+      <section className="bg-surface rounded-lg shadow-card p-lg mb-xl" aria-label="AI 指示">
+        <h2 className="text-caption text-text-secondary mb-md">
+          AI 指示
+        </h2>
+        <textarea
+          value={aiInstructionsInput}
+          onChange={(e) => {
+            setAiInstructionsInput(e.target.value)
+            setAiInstructionsEditing(true)
+          }}
+          onBlur={handleAiInstructionsSave}
+          placeholder="例如：若無適當分類，請建議新的類別名稱"
+          maxLength={1000}
+          rows={5}
+          className="w-full rounded-md border border-border bg-bg px-lg py-md text-body text-text-primary resize-none focus:outline-none focus:border-primary"
+          aria-label="自訂 AI 指示"
+        />
+        <div className="flex justify-between items-center mt-sm">
+          <p className="text-small text-text-secondary">
+            {aiInstructionsInput.length}/1000
+          </p>
+          {aiInstructionsEditing && (
+            <button
+              onClick={handleAiInstructionsSave}
+              disabled={saving}
+              className="h-9 px-lg rounded-md bg-primary text-white text-caption font-semibold disabled:opacity-50 transition-all hover:bg-primary-dark"
+              aria-label="儲存 AI 指示"
+            >
+              儲存
+            </button>
+          )}
         </div>
       </section>
 

--- a/frontend/src/stores/settingsStore.ts
+++ b/frontend/src/stores/settingsStore.ts
@@ -13,6 +13,7 @@ interface SettingsState {
   monthlyBudget: number
   userName: string
   userEmail: string
+  aiInstructions: string
 
   /** 載入/更新狀態 */
   loading: boolean
@@ -30,6 +31,8 @@ interface SettingsState {
   updateBudget: (monthlyBudget: number) => Promise<void>
   /** 更新 AI 引擎 */
   updateAIEngine: (aiEngine: AIEngine) => Promise<void>
+  /** 更新 AI 指示 */
+  updateAIInstructions: (aiInstructions: string) => Promise<void>
   /** 驗證 API Key */
   validateApiKey: (apiKey: string) => Promise<boolean>
   /** 清除錯誤 */
@@ -42,6 +45,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   monthlyBudget: 0,
   userName: '',
   userEmail: '',
+  aiInstructions: '',
   loading: false,
   saving: false,
   error: null,
@@ -58,6 +62,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
         monthlyBudget: Number(d.monthly_budget ?? d.monthlyBudget ?? 0),
         userName: d.name ?? '',
         userEmail: d.email ?? '',
+        aiInstructions: d.ai_instructions ?? '',
         loading: false,
       })
     } catch (err: unknown) {
@@ -99,6 +104,18 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     } catch (err: unknown) {
       const message = extractErrorMessage(err, '更新 AI 引擎失敗')
       set({ aiEngine: prev, saving: false, error: message })
+    }
+  },
+
+  updateAIInstructions: async (aiInstructions: string) => {
+    const prev = get().aiInstructions
+    set({ aiInstructions, saving: true, error: null })
+    try {
+      await api.put('/users/profile', { ai_instructions: aiInstructions || null })
+      set({ saving: false })
+    } catch (err: unknown) {
+      const message = extractErrorMessage(err, '更新 AI 指示失敗')
+      set({ aiInstructions: prev, saving: false, error: message })
     }
   },
 


### PR DESCRIPTION
## Summary
- Users model 新增 `ai_instructions` 欄位（可選，最大 1000 字元），含 Prisma migration
- `GET/PUT /users/profile` API 支援 `ai_instructions` 讀寫與驗證
- LLM 呼叫時將使用者自訂 AI 指示注入至 data extractor、persona feedback、chat reply 三個 prompt 的系統指示末尾
- 前端設定頁面新增「AI 指示」區塊：textarea（5 行）、即時字數計數、儲存按鈕

## Test plan
- [x] 後端 TypeScript 編譯通過（`npx tsc --noEmit`）
- [x] 後端 lint 通過
- [x] 後端 99 個測試全部通過
- [x] 前端 TypeScript 編譯通過
- [x] 前端 lint 通過
- [x] 前端 136 個測試全部通過
- [x] 前後端 build 成功

Closes #112