### PR TITLE
fix(frontend): 帳目修改類別下拉改用最新 categoryInfoList (#114)

### DIFF
--- a/frontend/src/components/RecentTransactions.tsx
+++ b/frontend/src/components/RecentTransactions.tsx
@@ -1,7 +1,7 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useMemo } from 'react'
 import type { Transaction } from '../stores/index'
 import { useDashboardStore } from '../stores/dashboardStore'
-import { getCategoryName, getCategoryTypeColorClass, CATEGORY_NAMES, INCOME_CATEGORIES } from '../lib/categoryUtils'
+import { getCategoryName, getCategoryTypeColorClass } from '../lib/categoryUtils'
 
 interface RecentTransactionsProps {
   transactions: Transaction[]
@@ -38,10 +38,6 @@ function formatDate(dateStr: string): string {
   return dateStr.split('T')[0]
 }
 
-const EXPENSE_CATEGORIES = Object.keys(CATEGORY_NAMES).filter((c) => !INCOME_CATEGORIES.has(c))
-const INCOME_CATEGORY_LIST = Object.keys(CATEGORY_NAMES).filter((c) => INCOME_CATEGORIES.has(c))
-
-
 function RecentTransactions({ transactions }: RecentTransactionsProps) {
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const [editingId, setEditingId] = useState<string | null>(null)
@@ -51,6 +47,16 @@ function RecentTransactions({ transactions }: RecentTransactionsProps) {
   const updateTransaction = useDashboardStore((s) => s.updateTransaction)
   const deleteTransaction = useDashboardStore((s) => s.deleteTransaction)
   const fetchBudgetSummary = useDashboardStore((s) => s.fetchBudgetSummary)
+  const categoryInfoList = useDashboardStore((s) => s.categoryInfoList)
+
+  const expenseCategoryList = useMemo(
+    () => categoryInfoList.filter((c) => c.type === 'expense').map((c) => c.category),
+    [categoryInfoList]
+  )
+  const incomeCategoryList = useMemo(
+    () => categoryInfoList.filter((c) => c.type === 'income').map((c) => c.category),
+    [categoryInfoList]
+  )
 
   const handleToggle = useCallback((id: string) => {
     setExpandedId((prev) => (prev === id ? null : id))
@@ -72,7 +78,7 @@ function RecentTransactions({ transactions }: RecentTransactionsProps) {
 
   const handleEditTypeChange = useCallback((newType: 'income' | 'expense') => {
     setEditForm((prev) => {
-      const categoryList = newType === 'income' ? INCOME_CATEGORY_LIST : EXPENSE_CATEGORIES
+      const categoryList = newType === 'income' ? incomeCategoryList : expenseCategoryList
       const categoryStillValid = categoryList.includes(prev.category)
       return {
         ...prev,
@@ -80,7 +86,7 @@ function RecentTransactions({ transactions }: RecentTransactionsProps) {
         category: categoryStillValid ? prev.category : categoryList[0],
       }
     })
-  }, [])
+  }, [incomeCategoryList, expenseCategoryList])
 
   const handleSaveEdit = useCallback(async (id: string) => {
     const parsedAmount = parseFloat(editForm.amount)
@@ -230,7 +236,7 @@ function RecentTransactions({ transactions }: RecentTransactionsProps) {
                             onChange={(e) => setEditForm((f) => ({ ...f, category: e.target.value }))}
                             className={`flex-1 h-9 rounded-md border border-border px-sm text-body ${getCategoryTypeColorClass(editForm.type)}`}
                           >
-                            {(editForm.type === 'income' ? INCOME_CATEGORY_LIST : EXPENSE_CATEGORIES).map((cat) => (
+                            {(editForm.type === 'income' ? incomeCategoryList : expenseCategoryList).map((cat) => (
                               <option key={cat} value={cat}>
                                 {categoryIcons[cat] ?? '📦'} {getCategoryName(cat)}
                               </option>

--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -1,7 +1,8 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useMemo } from 'react'
 import type { Transaction } from '../stores/index'
-import { getCategoryName, getCategoryTypeColorClass, CATEGORY_NAMES, INCOME_CATEGORIES } from '../lib/categoryUtils'
+import { getCategoryName, getCategoryTypeColorClass } from '../lib/categoryUtils'
 import type { UpdateTransactionInput } from '../stores/historyStore'
+import type { CategoryInfo } from '../stores/dashboardStore'
 
 interface TransactionItemProps {
   transaction: Transaction
@@ -11,6 +12,7 @@ interface TransactionItemProps {
   onUpdate: (id: string, input: UpdateTransactionInput) => Promise<void>
   isDeleting: boolean
   isUpdating: boolean
+  categoryInfoList?: CategoryInfo[]
 }
 
 const categoryIcons: Record<string, string> = {
@@ -29,9 +31,6 @@ const categoryIcons: Record<string, string> = {
   adjustment_expense: '🔧',
   adjustment_income: '🔧',
 }
-
-const EXPENSE_CATEGORIES = Object.keys(CATEGORY_NAMES).filter((c) => !INCOME_CATEGORIES.has(c))
-const INCOME_CATEGORY_LIST = Object.keys(CATEGORY_NAMES).filter((c) => INCOME_CATEGORIES.has(c))
 
 function formatTime(dateStr: string): string {
   const date = new Date(dateStr)
@@ -55,7 +54,17 @@ function TransactionItem({
   onUpdate,
   isDeleting,
   isUpdating,
+  categoryInfoList = [],
 }: TransactionItemProps) {
+  const expenseCategoryList = useMemo(
+    () => categoryInfoList.filter((c) => c.type === 'expense').map((c) => c.category),
+    [categoryInfoList]
+  )
+  const incomeCategoryList = useMemo(
+    () => categoryInfoList.filter((c) => c.type === 'income').map((c) => c.category),
+    [categoryInfoList]
+  )
+
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
   const [editForm, setEditForm] = useState({
@@ -119,7 +128,7 @@ function TransactionItem({
 
   const handleTypeChange = useCallback((newType: string) => {
     setEditForm((prev) => {
-      const categoryList = newType === 'income' ? INCOME_CATEGORY_LIST : EXPENSE_CATEGORIES
+      const categoryList = newType === 'income' ? incomeCategoryList : expenseCategoryList
       const categoryStillValid = categoryList.includes(prev.category)
       return {
         ...prev,
@@ -127,7 +136,7 @@ function TransactionItem({
         category: categoryStillValid ? prev.category : categoryList[0],
       }
     })
-  }, [])
+  }, [incomeCategoryList, expenseCategoryList])
 
   const txType = tx.type ?? 'expense'
 
@@ -239,7 +248,7 @@ function TransactionItem({
                     className="flex-1 px-lg py-xs bg-bg rounded-sm text-body border border-border outline-none"
                     data-testid="edit-category"
                   >
-                    {(editForm.type === 'income' ? INCOME_CATEGORY_LIST : EXPENSE_CATEGORIES).map((cat) => (
+                    {(editForm.type === 'income' ? incomeCategoryList : expenseCategoryList).map((cat) => (
                       <option key={cat} value={cat}>
                         {categoryIcons[cat] ?? '📦'} {getCategoryName(cat)}
                       </option>

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -230,6 +230,7 @@ function HistoryPage() {
                     onUpdate={handleUpdate}
                     isDeleting={isDeleting === tx.id}
                     isUpdating={isUpdating === tx.id}
+                    categoryInfoList={categoryInfoList}
                   />
                 ))}
               </div>


### PR DESCRIPTION
## Summary

- **RecentTransactions**（首頁）：編輯模式的類別下拉從靜態 `CATEGORY_NAMES` 改為從 `dashboardStore.categoryInfoList` 動態讀取
- **TransactionItem**（記錄頁）：新增 `categoryInfoList` prop，由 `HistoryPage` 傳入，取代靜態類別列表
- 兩處皆根據選中的 type（收入/支出）動態篩選類別，確保含自訂類別

## Root Cause

編輯帳目時，類別下拉選單使用的是從 `CATEGORY_NAMES`（hardcoded）衍生的靜態陣列，不會反映使用者新增/刪除的自訂類別。新增帳目的 `ParsedResultCard` 已正確使用 `categoryInfoList`，但修改流程未跟進。

## Test Plan

- [x] TypeScript 編譯通過 (`tsc --noEmit`)
- [x] ESLint 通過
- [x] 136 個單元測試全部通過
- [x] Build 成功

Closes #114