### PR TITLE
fix: 修正 AI 指示未正確注入 LLM Prompt (#115)

### DIFF
--- a/backend/src/prompts/chatReplyPrompt.ts
+++ b/backend/src/prompts/chatReplyPrompt.ts
@@ -54,11 +54,15 @@ function buildFinancialContextBlock(ctx: FinancialContext): string {
   return block;
 }
 
-export function buildChatReplyPrompt(input: ChatReplyInput): string {
+export function buildChatReplyPrompt(input: ChatReplyInput & { aiInstructions?: string | null }): string {
   const financialBlock = buildFinancialContextBlock(input.financialContext);
 
+  const aiInstructionsReminder = input.aiInstructions
+    ? `\n\n## 注意：請務必遵從系統指示中的使用者自訂指示來調整你的回覆風格與內容。`
+    : '';
+
   return `根據使用者的輸入，用你的角色風格回應。回覆要簡短有趣（80字以內）。
-請根據使用者的真實財務狀況來回應，讓回覆更貼近使用者的實際情況。
+請根據使用者的真實財務狀況來回應，讓回覆更貼近使用者的實際情況。${aiInstructionsReminder}
 
 ${financialBlock}
 

--- a/backend/src/prompts/personaFeedbackPrompt.ts
+++ b/backend/src/prompts/personaFeedbackPrompt.ts
@@ -17,11 +17,15 @@ const PERSONA_DEFINITIONS: Record<string, string> = {
     - 若超預算，加重情緒勒索`,
 };
 
-export function buildPersonaFeedbackPrompt(input: PersonaFeedbackInput): string {
+export function buildPersonaFeedbackPrompt(input: PersonaFeedbackInput, aiInstructions?: string | null): string {
   const budgetUsedPercent = Math.round(input.budgetUsedRatio * 100);
   const categoryUsedPercent = Math.round(input.categoryBudgetUsedRatio * 100);
 
-  return `根據以下消費資訊，用你的角色風格給出簡短的財務評論（50字以內）。
+  const aiInstructionsReminder = aiInstructions
+    ? `\n\n## 注意：請務必遵從系統指示中的使用者自訂指示來調整你的回覆風格與內容。`
+    : '';
+
+  return `根據以下消費資訊，用你的角色風格給出簡短的財務評論（50字以內）。${aiInstructionsReminder}
 
 ## 消費資訊
 - 金額：${input.amount} 元

--- a/backend/src/services/llmService.ts
+++ b/backend/src/services/llmService.ts
@@ -73,18 +73,13 @@ export async function parseTransaction(
   }));
   const currentDate = new Date().toISOString().split('T')[0];
 
-  // 2a. Data extraction
-  let extractorPrompt = buildDataExtractorPrompt({
+  // 2a. Data extraction (不注入 AI 指示，data extractor 只做結構化提取)
+  const extractorPrompt = buildDataExtractorPrompt({
     rawText,
     categories,
     categoriesWithType,
     currentDate,
   });
-
-  // Inject user custom AI instructions if present
-  if (user.aiInstructions) {
-    extractorPrompt = `${extractorPrompt}\n\n## 使用者自訂 AI 指示\n${user.aiInstructions}`;
-  }
 
   const parsed = await provider.extractData(extractorPrompt, apiKey);
 
@@ -138,8 +133,10 @@ export async function parseTransaction(
   };
 
   const personaSystemPrompt = getPersonaSystemPrompt(persona);
-  const feedbackUserPrompt = buildPersonaFeedbackPrompt(feedbackInput);
-  const aiInstructionsBlock = user.aiInstructions ? `\n\n## 使用者自訂 AI 指示\n${user.aiInstructions}` : '';
+  const feedbackUserPrompt = buildPersonaFeedbackPrompt(feedbackInput, user.aiInstructions);
+  const aiInstructionsBlock = user.aiInstructions
+    ? `\n\n【重要】使用者自訂指示（你必須優先遵從以下指示來調整回覆風格與內容）：\n${user.aiInstructions}`
+    : '';
   const combinedPrompt = `${personaSystemPrompt}${aiInstructionsBlock}\n---SYSTEM---\n${feedbackUserPrompt}`;
 
   const feedback = await provider.generateFeedback(combinedPrompt, apiKey);
@@ -244,8 +241,10 @@ async function generateChatReply(
   aiInstructions?: string | null
 ): Promise<AIFeedbackContent> {
   const systemPrompt = getChatPersonaSystemPrompt(persona);
-  const userPrompt = buildChatReplyPrompt({ persona, rawText, financialContext });
-  const aiInstructionsBlock = aiInstructions ? `\n\n## 使用者自訂 AI 指示\n${aiInstructions}` : '';
+  const userPrompt = buildChatReplyPrompt({ persona, rawText, financialContext, aiInstructions });
+  const aiInstructionsBlock = aiInstructions
+    ? `\n\n【重要】使用者自訂指示（你必須優先遵從以下指示來調整回覆風格與內容）：\n${aiInstructions}`
+    : '';
   const combinedPrompt = `${systemPrompt}${aiInstructionsBlock}\n---SYSTEM---\n${userPrompt}`;
 
   return provider.generateFeedback(combinedPrompt, apiKey);


### PR DESCRIPTION
## Summary

- 移除 data extractor 中不必要的 AI 指示注入，避免干擾結構化數據提取
- 加強 system prompt 中 AI 指示的措辭，使用【重要】標記讓 LLM 優先遵從
- 在 persona feedback 和 chat reply 的 user prompt 中加入提醒，確保 LLM 不會忽略自訂指示

## Root Cause

AI 指示在 system prompt 中使用較弱的 Markdown 標題格式（`## 使用者自訂 AI 指示`），容易被 user prompt 中更嚴格的格式指令（如「50字以內」、「僅回傳 JSON」）覆蓋。同時 user prompt 中完全沒有提及自訂指示的存在，LLM 傾向優先遵從 user prompt 中的明確指令。

## Changes

| 檔案 | 變更 |
|------|------|
| `backend/src/services/llmService.ts` | 移除 data extractor AI 指示注入；加強 feedback/chat system prompt 措辭 |
| `backend/src/prompts/personaFeedbackPrompt.ts` | 新增 `aiInstructions` 參數，在 user prompt 中加入遵從提醒 |
| `backend/src/prompts/chatReplyPrompt.ts` | 新增 `aiInstructions` 參數，在 user prompt 中加入遵從提醒 |

## Test plan

- [x] Backend TypeScript 編譯通過
- [x] Backend lint 通過
- [x] Backend 99 個測試全部通過
- [x] Backend build 成功
- [x] Frontend TypeScript 編譯通過
- [x] Frontend lint 通過
- [x] Frontend build 成功

Closes #115