### PR TITLE
fix(frontend): 記錄頁面日期篩選加 placeholder 提示 (#121)

### DIFF
--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -143,6 +143,7 @@ function HistoryPage() {
             type="date"
             value={filters.startDate}
             onChange={handleStartDateChange}
+            placeholder="開始日期"
             className="px-lg py-sm bg-bg rounded-xl text-caption text-text-secondary border-0 outline-none"
             aria-label="開始日期"
             data-testid="start-date-filter"
@@ -152,6 +153,7 @@ function HistoryPage() {
             type="date"
             value={filters.endDate}
             onChange={handleEndDateChange}
+            placeholder="結束日期"
             className="px-lg py-sm bg-bg rounded-xl text-caption text-text-secondary border-0 outline-none"
             aria-label="結束日期"
             data-testid="end-date-filter"


### PR DESCRIPTION
## Summary
- 為記錄頁面（HistoryPage）的開始日期與結束日期 `<input type="date">` 加上 `placeholder` 屬性
- 開始日期顯示「開始日期」、結束日期顯示「結束日期」

Closes #121

## Test plan
- [x] TypeScript 編譯通過
- [x] ESLint 通過
- [x] 136 個測試全部通過
- [x] Production build 成功