### PR TITLE
feat(backend): AI 語義查詢 API — POST /ai/query (T-501)

### DIFF
--- a/backend/src/__tests__/aiQuery.test.ts
+++ b/backend/src/__tests__/aiQuery.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  TIME_RANGE_SYSTEM_PROMPT,
+  buildTimeRangePrompt,
+  buildTransactionMatchSystemPrompt,
+  buildTransactionMatchUserPrompt,
+} from '../prompts/queryPrompt';
+import { TransactionSummaryForQuery } from '../types/llm';
+import { aiQuerySchema } from '../validators/aiValidators';
+
+// ─── Prompt 構建測試 ───
+
+describe('queryPrompt', () => {
+  describe('buildTimeRangePrompt', () => {
+    it('should include query text and current time', () => {
+      const prompt = buildTimeRangePrompt('最近一個月的開銷', '2026年3月21日 星期六 15:00:00 (GMT+8)');
+      expect(prompt).toContain('最近一個月的開銷');
+      expect(prompt).toContain('2026年3月21日');
+    });
+  });
+
+  describe('TIME_RANGE_SYSTEM_PROMPT', () => {
+    it('should instruct JSON output format', () => {
+      expect(TIME_RANGE_SYSTEM_PROMPT).toContain('start_date');
+      expect(TIME_RANGE_SYSTEM_PROMPT).toContain('end_date');
+      expect(TIME_RANGE_SYSTEM_PROMPT).toContain('JSON');
+    });
+  });
+
+  describe('buildTransactionMatchSystemPrompt', () => {
+    it('should include persona instruction for sarcastic', () => {
+      const prompt = buildTransactionMatchSystemPrompt('sarcastic');
+      expect(prompt).toContain('毒舌');
+      expect(prompt).toContain('matched_ids');
+    });
+
+    it('should include persona instruction for gentle', () => {
+      const prompt = buildTransactionMatchSystemPrompt('gentle');
+      expect(prompt).toContain('溫柔');
+    });
+
+    it('should include persona instruction for guilt_trip', () => {
+      const prompt = buildTransactionMatchSystemPrompt('guilt_trip');
+      expect(prompt).toContain('心疼');
+    });
+  });
+
+  describe('buildTransactionMatchUserPrompt', () => {
+    const mockTransactions: TransactionSummaryForQuery[] = [
+      {
+        id: 'uuid-1',
+        amount: 600,
+        type: 'expense',
+        category: '寵物用品',
+        merchant: '阿貓阿狗',
+        note: '貓砂',
+        transaction_date: '2026-03-19',
+      },
+      {
+        id: 'uuid-2',
+        amount: 1200,
+        type: 'expense',
+        category: '寵物用品',
+        merchant: '阿貓阿狗',
+        note: null,
+        transaction_date: '2026-03-18',
+      },
+    ];
+
+    it('should include query text and transaction details', () => {
+      const prompt = buildTransactionMatchUserPrompt('阿貓阿狗花了多少', mockTransactions);
+      expect(prompt).toContain('阿貓阿狗花了多少');
+      expect(prompt).toContain('uuid-1');
+      expect(prompt).toContain('uuid-2');
+      expect(prompt).toContain('$600');
+      expect(prompt).toContain('$1200');
+      expect(prompt).toContain('共 2 筆');
+    });
+
+    it('should handle empty transactions', () => {
+      const prompt = buildTransactionMatchUserPrompt('查詢', []);
+      expect(prompt).toContain('共 0 筆');
+      expect(prompt).toContain('（無交易記錄）');
+    });
+  });
+});
+
+// ─── Validator 測試 ───
+
+describe('aiQuerySchema', () => {
+  it('should accept valid query_text', () => {
+    const result = aiQuerySchema.safeParse({ query_text: '最近一個月毛小孩的開銷' });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject empty query_text', () => {
+    const result = aiQuerySchema.safeParse({ query_text: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject missing query_text', () => {
+    const result = aiQuerySchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject query_text exceeding 500 chars', () => {
+    const result = aiQuerySchema.safeParse({ query_text: 'a'.repeat(501) });
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept query_text at exactly 500 chars', () => {
+    const result = aiQuerySchema.safeParse({ query_text: 'a'.repeat(500) });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ─── Service 層 Mock 測試 ───
+
+// Mock prisma
+vi.mock('../config/database', () => ({
+  default: {
+    user: {
+      findUnique: vi.fn(),
+    },
+    transaction: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+// Mock llmFactory
+vi.mock('../services/llm/llmFactory', () => ({
+  getProvider: vi.fn(),
+}));
+
+describe('queryTransactions service', () => {
+  let queryTransactions: typeof import('../services/llmService').queryTransactions;
+  let mockPrisma: any;
+  let mockGetProvider: any;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const prismaModule = await import('../config/database');
+    mockPrisma = prismaModule.default;
+
+    const factoryModule = await import('../services/llm/llmFactory');
+    mockGetProvider = factoryModule.getProvider;
+
+    const serviceModule = await import('../services/llmService');
+    queryTransactions = serviceModule.queryTransactions;
+  });
+
+  it('should return query result with matched IDs', async () => {
+    // Mock user
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: 'user-1',
+      aiEngine: 'gemini',
+      persona: 'sarcastic',
+      aiInstructions: null,
+    });
+
+    // Mock transactions
+    mockPrisma.transaction.findMany.mockResolvedValue([
+      {
+        id: 'txn-1',
+        amount: 600,
+        type: 'expense',
+        category: '寵物用品',
+        merchant: '阿貓阿狗',
+        note: '貓砂',
+        transactionDate: new Date('2026-03-19'),
+      },
+      {
+        id: 'txn-2',
+        amount: 1200,
+        type: 'expense',
+        category: '寵物用品',
+        merchant: '阿貓阿狗',
+        note: null,
+        transactionDate: new Date('2026-03-18'),
+      },
+      {
+        id: 'txn-3',
+        amount: 180,
+        type: 'expense',
+        category: '飲食',
+        merchant: '拉麵店',
+        note: null,
+        transactionDate: new Date('2026-03-17'),
+      },
+    ]);
+
+    // Mock LLM provider
+    const mockProvider = {
+      generateText: vi.fn()
+        // 1st call: time range parsing
+        .mockResolvedValueOnce(JSON.stringify({
+          start_date: '2026-03-01',
+          end_date: '2026-03-31',
+        }))
+        // 2nd call: transaction matching
+        .mockResolvedValueOnce(JSON.stringify({
+          matched_ids: ['txn-1', 'txn-2'],
+          total_amount: 1800,
+          summary_text: '你在阿貓阿狗花了 1800 元！',
+          emotion_tag: 'sarcastic_warning',
+        })),
+      extractData: vi.fn(),
+      generateFeedback: vi.fn(),
+    };
+    mockGetProvider.mockReturnValue(mockProvider);
+
+    const result = await queryTransactions('user-1', '阿貓阿狗花了多少', 'test-key');
+
+    expect(result.matched_transaction_ids).toEqual(['txn-1', 'txn-2']);
+    expect(result.summary.text).toContain('1800');
+    expect(result.summary.match_count).toBe(2);
+    expect(result.summary.total_amount).toBe(1800);
+    expect(result.time_range.start_date).toBe('2026-03-01');
+    expect(result.time_range.end_date).toBe('2026-03-31');
+
+    // Verify two LLM calls were made
+    expect(mockProvider.generateText).toHaveBeenCalledTimes(2);
+  });
+
+  it('should fallback to current month when time parsing fails', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: 'user-1',
+      aiEngine: 'gemini',
+      persona: 'gentle',
+      aiInstructions: null,
+    });
+
+    mockPrisma.transaction.findMany.mockResolvedValue([]);
+
+    const mockProvider = {
+      generateText: vi.fn()
+        .mockResolvedValueOnce('invalid json')  // time range parse fails
+        .mockResolvedValueOnce(JSON.stringify({
+          matched_ids: [],
+          total_amount: 0,
+          summary_text: '找不到相關記錄呢。',
+          emotion_tag: 'neutral',
+        })),
+      extractData: vi.fn(),
+      generateFeedback: vi.fn(),
+    };
+    mockGetProvider.mockReturnValue(mockProvider);
+
+    const result = await queryTransactions('user-1', '潛水花了多少', 'test-key');
+
+    // Should fallback to current month
+    const now = new Date();
+    const expectedMonth = String(now.getMonth() + 1).padStart(2, '0');
+    expect(result.time_range.start_date).toContain(`-${expectedMonth}-01`);
+    expect(result.matched_transaction_ids).toEqual([]);
+  });
+
+  it('should filter out invalid matched IDs', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: 'user-1',
+      aiEngine: 'openai',
+      persona: 'gentle',
+      aiInstructions: null,
+    });
+
+    mockPrisma.transaction.findMany.mockResolvedValue([
+      {
+        id: 'txn-1',
+        amount: 100,
+        type: 'expense',
+        category: '飲食',
+        merchant: '便當店',
+        note: null,
+        transactionDate: new Date('2026-03-15'),
+      },
+    ]);
+
+    const mockProvider = {
+      generateText: vi.fn()
+        .mockResolvedValueOnce(JSON.stringify({
+          start_date: '2026-03-01',
+          end_date: '2026-03-31',
+        }))
+        .mockResolvedValueOnce(JSON.stringify({
+          matched_ids: ['txn-1', 'txn-FAKE'],  // txn-FAKE doesn't exist
+          total_amount: 100,
+          summary_text: '找到了！',
+          emotion_tag: 'neutral',
+        })),
+      extractData: vi.fn(),
+      generateFeedback: vi.fn(),
+    };
+    mockGetProvider.mockReturnValue(mockProvider);
+
+    const result = await queryTransactions('user-1', '便當', 'test-key');
+
+    // Should filter out invalid ID
+    expect(result.matched_transaction_ids).toEqual(['txn-1']);
+    expect(result.summary.match_count).toBe(1);
+  });
+
+  it('should throw 404 for non-existent user', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(null);
+
+    await expect(
+      queryTransactions('non-existent', '查詢', 'test-key')
+    ).rejects.toThrow('使用者不存在');
+  });
+});

--- a/backend/src/controllers/aiController.ts
+++ b/backend/src/controllers/aiController.ts
@@ -1,6 +1,6 @@
 import { Response, NextFunction } from 'express';
 import { AuthRequest } from '../middlewares/auth';
-import { aiParseSchema } from '../validators/aiValidators';
+import { aiParseSchema, aiQuerySchema } from '../validators/aiValidators';
 import * as llmService from '../services/llmService';
 import { AppError } from '../middlewares/errorHandler';
 import { ApiResponse } from '../types';
@@ -64,6 +64,35 @@ export async function validateKey(
     const response: ApiResponse<typeof result> = {
       code: 200,
       message: '驗證成功',
+      data: result,
+      timestamp: new Date().toISOString(),
+    };
+
+    res.status(200).json(response);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function aiQuery(
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const parsed = aiQuerySchema.safeParse(req.body);
+    if (!parsed.success) {
+      throw new AppError('參數驗證失敗', 400, formatZodErrors(parsed.error));
+    }
+
+    const apiKey = extractApiKey(req);
+    const userId = req.userId!;
+
+    const result = await llmService.queryTransactions(userId, parsed.data.query_text, apiKey);
+
+    const response: ApiResponse<typeof result> = {
+      code: 200,
+      message: '查詢成功',
       data: result,
       timestamp: new Date().toISOString(),
     };

--- a/backend/src/prompts/queryPrompt.ts
+++ b/backend/src/prompts/queryPrompt.ts
@@ -1,0 +1,83 @@
+import { TransactionSummaryForQuery, Persona } from '../types/llm';
+
+// ─── 階段 1：時間範圍解析 ───
+
+export const TIME_RANGE_SYSTEM_PROMPT = `你是一個時間範圍解析器。你的任務是從使用者的查詢文字中提取時間範圍。
+
+規則：
+1. 輸出格式必須為 JSON：{ "start_date": "YYYY-MM-DD", "end_date": "YYYY-MM-DD" }
+2. 僅輸出 JSON，不要加任何解釋文字
+3. 支援相對日期：「最近一個月」、「上週」、「今年」、「這個月」等
+4. 若使用者未提及時間，預設為當月（當月 1 日至當月最後一天）
+5. 「最近 N 天/週/月」從今天往回推算
+6. 注意閏年與月份天數差異`;
+
+export function buildTimeRangePrompt(queryText: string, currentDateTime: string): string {
+  return `當前時間：${currentDateTime}
+
+使用者查詢：「${queryText}」
+
+請從上述查詢中提取時間範圍，輸出 JSON。若無法確定時間範圍，使用當月作為預設。`;
+}
+
+// ─── 階段 2：交易匹配分析 ───
+
+function getQueryPersonaInstruction(persona: Persona): string {
+  switch (persona) {
+    case 'sarcastic':
+      return '你是一個毒舌教練 🔥，用尖銳犀利但幽默的語氣總結使用者的消費情況。';
+    case 'gentle':
+      return '你是一個溫柔管家 💖，用溫暖關懷的語氣總結使用者的消費情況。';
+    case 'guilt_trip':
+      return '你是一個心疼天使 🥺，用帶有愧疚感但善意的語氣總結使用者的消費情況。';
+  }
+}
+
+export function buildTransactionMatchSystemPrompt(persona: Persona): string {
+  return `你是一個消費分析助手。你的任務是根據使用者的查詢，從交易記錄中找出匹配的項目，並生成一句總結。
+
+${getQueryPersonaInstruction(persona)}
+
+規則：
+1. 仔細分析使用者查詢的語義，找出所有相關的交易記錄
+2. 匹配可基於：商家名稱（模糊匹配）、類別、備註內容、消費描述
+3. 輸出格式必須為 JSON，不要加任何解釋文字
+4. summary_text 必須是一句自然語言的總結（50 字以內），使用指定的人設風格
+5. 計算匹配交易的金額總和（僅計算 expense 的金額，income 不計入支出總和）
+6. emotion_tag 可選值：sarcastic_warning, gentle_reminder, guilt_concern, encouraging, neutral
+
+輸出格式：
+{
+  "matched_ids": ["uuid-1", "uuid-2"],
+  "total_amount": 2800,
+  "summary_text": "你這個月在這上面花了 2800 元...",
+  "emotion_tag": "sarcastic_warning"
+}
+
+若無匹配交易，回傳：
+{
+  "matched_ids": [],
+  "total_amount": 0,
+  "summary_text": "找不到相關的消費記錄呢。",
+  "emotion_tag": "neutral"
+}`;
+}
+
+export function buildTransactionMatchUserPrompt(
+  queryText: string,
+  transactions: TransactionSummaryForQuery[]
+): string {
+  const txnList = transactions
+    .map(
+      (t) =>
+        `- ID: ${t.id} | ${t.transaction_date} | ${t.type} | $${t.amount} | 類別: ${t.category} | 商家: ${t.merchant || '(無)'} | 備註: ${t.note || '(無)'}`
+    )
+    .join('\n');
+
+  return `使用者查詢：「${queryText}」
+
+以下是時間範圍內的交易記錄（共 ${transactions.length} 筆）：
+${txnList || '（無交易記錄）'}
+
+請找出與使用者查詢相關的交易記錄，輸出 JSON。`;
+}

--- a/backend/src/routes/aiRoutes.ts
+++ b/backend/src/routes/aiRoutes.ts
@@ -1,11 +1,12 @@
 import { Router } from 'express';
 import { authMiddleware } from '../middlewares/auth';
 import { llmRateLimiter } from '../middlewares/rateLimiter';
-import { aiParse, validateKey } from '../controllers/aiController';
+import { aiParse, validateKey, aiQuery } from '../controllers/aiController';
 
 const router = Router();
 
 router.post('/parse', authMiddleware, llmRateLimiter, aiParse);
 router.post('/validate-key', authMiddleware, llmRateLimiter, validateKey);
+router.post('/query', authMiddleware, llmRateLimiter, aiQuery);
 
 export default router;

--- a/backend/src/services/llmService.ts
+++ b/backend/src/services/llmService.ts
@@ -5,6 +5,12 @@ import { buildPersonaFeedbackPrompt, getPersonaSystemPrompt } from '../prompts/p
 import { buildIntentDetectorPrompt, INTENT_DETECTOR_SYSTEM_PROMPT } from '../prompts/intentDetectorPrompt';
 import { buildChatReplyPrompt, getChatPersonaSystemPrompt } from '../prompts/chatReplyPrompt';
 import {
+  TIME_RANGE_SYSTEM_PROMPT,
+  buildTimeRangePrompt,
+  buildTransactionMatchSystemPrompt,
+  buildTransactionMatchUserPrompt,
+} from '../prompts/queryPrompt';
+import {
   AIEngine,
   Persona,
   Intent,
@@ -13,6 +19,10 @@ import {
   BudgetContext,
   FinancialContext,
   PersonaFeedbackInput,
+  QueryTimeRange,
+  TransactionSummaryForQuery,
+  QueryMatchResult,
+  AIQueryResult,
 } from '../types/llm';
 import { AppError } from '../middlewares/errorHandler';
 
@@ -280,6 +290,161 @@ async function generateChatReply(
 
 
   return provider.generateFeedback(combinedPrompt, apiKey);
+}
+
+// ─── AI 語義查詢 (PRD-F-014) ───
+
+export async function queryTransactions(
+  userId: string,
+  queryText: string,
+  apiKey: string
+): Promise<AIQueryResult> {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user) {
+    throw new AppError('使用者不存在', 404);
+  }
+
+  const engine = user.aiEngine as AIEngine;
+  const persona = user.persona as Persona;
+  const provider = getProvider(engine);
+
+  // 當前時間（台北時區）
+  const now = new Date();
+  const taipeiDate = new Date(now.toLocaleString('en-US', { timeZone: 'Asia/Taipei' }));
+  const year = taipeiDate.getFullYear();
+  const month = taipeiDate.getMonth() + 1;
+  const day = taipeiDate.getDate();
+  const dayNames = ['星期日', '星期一', '星期二', '星期三', '星期四', '星期五', '星期六'];
+  const weekday = dayNames[taipeiDate.getDay()];
+  const hh = String(taipeiDate.getHours()).padStart(2, '0');
+  const mm = String(taipeiDate.getMinutes()).padStart(2, '0');
+  const ss = String(taipeiDate.getSeconds()).padStart(2, '0');
+  const currentDateTime = `${year}年${month}月${day}日 ${weekday} ${hh}:${mm}:${ss} (GMT+8)`;
+
+  // 階段 1：時間範圍解析
+  const timeRange = await parseTimeRange(queryText, currentDateTime, apiKey, provider, taipeiDate);
+
+  // 階段 2a：查詢 DB 取得交易記錄
+  const startDate = new Date(timeRange.start_date);
+  const endDate = new Date(timeRange.end_date);
+  const transactions = await prisma.transaction.findMany({
+    where: {
+      userId,
+      transactionDate: {
+        gte: startDate,
+        lte: endDate,
+      },
+    },
+    orderBy: { transactionDate: 'desc' },
+    take: 200, // SRD §4.1.3: 最多 200 筆
+    select: {
+      id: true,
+      amount: true,
+      type: true,
+      category: true,
+      merchant: true,
+      note: true,
+      transactionDate: true,
+    },
+  });
+
+  const txnSummaries: TransactionSummaryForQuery[] = transactions.map((t) => ({
+    id: t.id,
+    amount: Number(t.amount),
+    type: t.type,
+    category: t.category,
+    merchant: t.merchant,
+    note: t.note,
+    transaction_date: t.transactionDate.toISOString().split('T')[0],
+  }));
+
+  // 階段 2b：LLM 匹配分析
+  const matchResult = await matchTransactions(queryText, txnSummaries, persona, apiKey, provider);
+
+  return {
+    summary: {
+      text: matchResult.summary_text,
+      emotion_tag: matchResult.emotion_tag,
+      total_amount: matchResult.total_amount,
+      match_count: matchResult.matched_ids.length,
+    },
+    matched_transaction_ids: matchResult.matched_ids,
+    time_range: timeRange,
+  };
+}
+
+async function parseTimeRange(
+  queryText: string,
+  currentDateTime: string,
+  apiKey: string,
+  provider: ReturnType<typeof getProvider>,
+  taipeiDate: Date
+): Promise<QueryTimeRange> {
+  // 預設當月
+  const defaultStart = `${taipeiDate.getFullYear()}-${String(taipeiDate.getMonth() + 1).padStart(2, '0')}-01`;
+  const lastDay = new Date(taipeiDate.getFullYear(), taipeiDate.getMonth() + 1, 0).getDate();
+  const defaultEnd = `${taipeiDate.getFullYear()}-${String(taipeiDate.getMonth() + 1).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`;
+
+  try {
+    const userPrompt = buildTimeRangePrompt(queryText, currentDateTime);
+    const text = await provider.generateText(TIME_RANGE_SYSTEM_PROMPT, userPrompt, apiKey);
+
+    let cleaned = text.trim();
+    const codeBlockMatch = cleaned.match(/```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/);
+    if (codeBlockMatch) {
+      cleaned = codeBlockMatch[1].trim();
+    }
+
+    const result = JSON.parse(cleaned) as QueryTimeRange;
+    if (result.start_date && result.end_date) {
+      return result;
+    }
+  } catch {
+    // fallback to current month
+  }
+
+  return { start_date: defaultStart, end_date: defaultEnd };
+}
+
+async function matchTransactions(
+  queryText: string,
+  transactions: TransactionSummaryForQuery[],
+  persona: Persona,
+  apiKey: string,
+  provider: ReturnType<typeof getProvider>
+): Promise<QueryMatchResult> {
+  const systemPrompt = buildTransactionMatchSystemPrompt(persona);
+  const userPrompt = buildTransactionMatchUserPrompt(queryText, transactions);
+
+  try {
+    const text = await provider.generateText(systemPrompt, userPrompt, apiKey);
+
+    let cleaned = text.trim();
+    const codeBlockMatch = cleaned.match(/```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/);
+    if (codeBlockMatch) {
+      cleaned = codeBlockMatch[1].trim();
+    }
+
+    const result = JSON.parse(cleaned) as QueryMatchResult;
+
+    // 驗證 matched_ids 皆為有效的交易 ID
+    const validIds = new Set(transactions.map((t) => t.id));
+    result.matched_ids = result.matched_ids.filter((id) => validIds.has(id));
+
+    return {
+      matched_ids: result.matched_ids,
+      total_amount: result.total_amount || 0,
+      summary_text: result.summary_text || '查詢完成。',
+      emotion_tag: result.emotion_tag || 'neutral',
+    };
+  } catch {
+    return {
+      matched_ids: [],
+      total_amount: 0,
+      summary_text: '查詢處理時發生問題，請稍後再試。',
+      emotion_tag: 'neutral',
+    };
+  }
 }
 
 export async function validateApiKey(userId: string, apiKey: string): Promise<{ valid: boolean; engine: AIEngine }> {

--- a/backend/src/types/llm.ts
+++ b/backend/src/types/llm.ts
@@ -74,3 +74,40 @@ export interface PersonaFeedbackInput {
   monthlyBudget: number;
   remainingBudget: number;
 }
+
+/** AI 語義查詢：時間範圍 */
+export interface QueryTimeRange {
+  start_date: string;
+  end_date: string;
+}
+
+/** AI 語義查詢：交易記錄摘要（送入 LLM 的精簡格式） */
+export interface TransactionSummaryForQuery {
+  id: string;
+  amount: number;
+  type: string;
+  category: string;
+  merchant: string | null;
+  note: string | null;
+  transaction_date: string;
+}
+
+/** AI 語義查詢：LLM 匹配分析結果 */
+export interface QueryMatchResult {
+  matched_ids: string[];
+  total_amount: number;
+  summary_text: string;
+  emotion_tag: string;
+}
+
+/** AI 語義查詢：最終回應 */
+export interface AIQueryResult {
+  summary: {
+    text: string;
+    emotion_tag: string;
+    total_amount: number;
+    match_count: number;
+  };
+  matched_transaction_ids: string[];
+  time_range: QueryTimeRange;
+}

--- a/backend/src/validators/aiValidators.ts
+++ b/backend/src/validators/aiValidators.ts
@@ -8,3 +8,12 @@ export const aiParseSchema = z.object({
 });
 
 export type AIParseInput = z.infer<typeof aiParseSchema>;
+
+export const aiQuerySchema = z.object({
+  query_text: z
+    .string({ error: '請提供查詢文字' })
+    .min(1, '查詢文字不可為空')
+    .max(500, '查詢文字不可超過 500 字元'),
+});
+
+export type AIQueryInput = z.infer<typeof aiQuerySchema>;


### PR DESCRIPTION
## 變更摘要
實作 `POST /ai/query` 端點（PRD-F-014），透過兩階段 LLM 呼叫處理自然語言篩選查詢：階段 1 解析時間範圍，階段 2 匹配交易記錄並生成人設風格總結評語。

## 關聯 Issue
Closes #125

## 變更清單
- 新增 `queryPrompt.ts`：時間範圍解析 + 交易匹配分析 Prompt 模板
- 新增 `llmService.queryTransactions()`：兩階段 LLM 呼叫主流程
- 新增 `llmService.parseTimeRange()`：時間範圍解析（含 fallback 當月）
- 新增 `llmService.matchTransactions()`：交易匹配分析（含無效 ID 過濾）
- 新增 `aiController.aiQuery()` handler + `aiQuerySchema` validator
- 新增 `POST /ai/query` 路由（含 auth + rate limit）
- 新增 `AIQueryResult`、`QueryTimeRange` 等類型定義
- 新增 16 個單元測試

## 測試結果
- 單元測試：✅ 全部通過（115/115，含新增 16 個）
- 本地驗證：✅ Vibe Check 通過
- TypeScript：✅ 無新增錯誤（既有 aiInstructions 問題不影響）