### PR TITLE
feat(frontend): 記錄頁語義查詢 UI + 篩選互斥邏輯 (T-502)

### DIFF
--- a/frontend/src/components/VoiceInput.tsx
+++ b/frontend/src/components/VoiceInput.tsx
@@ -7,9 +7,10 @@ import {
 interface VoiceInputProps {
   onSubmit: (text: string) => void
   disabled?: boolean
+  placeholder?: string
 }
 
-function VoiceInput({ onSubmit, disabled = false }: VoiceInputProps) {
+function VoiceInput({ onSubmit, disabled = false, placeholder: customPlaceholder }: VoiceInputProps) {
   const [inputText, setInputText] = useState('')
   const [showError, setShowError] = useState(false)
   const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -103,7 +104,7 @@ function VoiceInput({ onSubmit, disabled = false }: VoiceInputProps) {
   const getPlaceholder = () => {
     if (isRecording) return '正在聆聽...'
     if (isRecognizing) return '辨識中...'
-    return '例如：中午吃拉麵 280 元'
+    return customPlaceholder ?? '例如：中午吃拉麵 280 元'
   }
 
   return (

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useState, useCallback, useMemo } from 'react'
 import { useHistoryStore } from '../stores/historyStore'
 import { useDashboardStore } from '../stores/dashboardStore'
+import { useSettingsStore } from '../stores/settingsStore'
 import TransactionItem from '../components/TransactionItem'
+import AIFeedbackCard from '../components/AIFeedbackCard'
+import VoiceInput from '../components/VoiceInput'
 import type { Transaction } from '../stores/index'
 import { getCategoryName } from '../lib/categoryUtils'
 
@@ -48,16 +51,22 @@ function HistoryPage() {
     isDeleting,
     isUpdating,
     errorMessage,
+    aiQueryResult,
+    isQuerying,
     fetchTransactions,
     loadMore,
     setFilters,
-    resetFilters,
     deleteTransaction,
     updateTransaction,
+    queryTransactions,
+    clearAIQuery,
+    clearAllFilters,
   } = useHistoryStore()
 
   const categoryInfoList = useDashboardStore((s) => s.categoryInfoList)
   const fetchCategories = useDashboardStore((s) => s.fetchCategories)
+  const persona = useSettingsStore((s) => s.persona)
+  const aiEngine = useSettingsStore((s) => s.aiEngine)
 
   const expenseCategories = useMemo(
     () => categoryInfoList.filter((c) => c.type === 'expense'),
@@ -75,35 +84,46 @@ function HistoryPage() {
     fetchTransactions(true)
   }, [fetchCategories, fetchTransactions])
 
+  // 手動篩選器變更 → 清除 AI 查詢（互斥）
   const handleCategoryChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
+      clearAIQuery()
       setFilters({ category: e.target.value })
-      // Trigger re-fetch after state update
       setTimeout(() => useHistoryStore.getState().fetchTransactions(true), 0)
     },
-    [setFilters]
+    [setFilters, clearAIQuery]
   )
 
   const handleStartDateChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
+      clearAIQuery()
       setFilters({ startDate: e.target.value })
       setTimeout(() => useHistoryStore.getState().fetchTransactions(true), 0)
     },
-    [setFilters]
+    [setFilters, clearAIQuery]
   )
 
   const handleEndDateChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
+      clearAIQuery()
       setFilters({ endDate: e.target.value })
       setTimeout(() => useHistoryStore.getState().fetchTransactions(true), 0)
     },
-    [setFilters]
+    [setFilters, clearAIQuery]
   )
 
+  // 清除所有篩選（手動 + AI 查詢）
   const handleResetFilters = useCallback(() => {
-    resetFilters()
-    setTimeout(() => useHistoryStore.getState().fetchTransactions(true), 0)
-  }, [resetFilters])
+    clearAllFilters()
+  }, [clearAllFilters])
+
+  // AI 語義查詢
+  const handleAIQuery = useCallback(
+    (text: string) => {
+      queryTransactions(text)
+    },
+    [queryTransactions]
+  )
 
   const handleToggle = useCallback((id: string) => {
     setExpandedId((prev) => (prev === id ? null : id))
@@ -126,7 +146,7 @@ function HistoryPage() {
 
   const grouped = useMemo(() => groupByDate(transactions), [transactions])
 
-  const hasActiveFilters = filters.category || filters.startDate || filters.endDate
+  const hasActiveFilters = filters.category || filters.startDate || filters.endDate || aiQueryResult
 
   return (
     <div className="p-2xl pb-32">
@@ -208,6 +228,20 @@ function HistoryPage() {
         </div>
       </div>
 
+      {/* AI Query Feedback Card — only shown when there's a query result */}
+      {aiQueryResult && (
+        <div data-testid="ai-query-feedback">
+          <AIFeedbackCard
+            feedbackText={aiQueryResult.summary.text}
+            persona={persona}
+            aiEngine={aiEngine}
+          />
+          <div className="mx-2xl mb-lg text-small text-text-tertiary">
+            共 {aiQueryResult.summary.match_count} 筆匹配，合計 ${aiQueryResult.summary.total_amount.toLocaleString()}
+          </div>
+        </div>
+      )}
+
       {/* Error message */}
       {errorMessage && (
         <div className="mb-lg p-md bg-danger-light rounded-md text-danger text-body text-center" data-testid="error-message">
@@ -215,14 +249,21 @@ function HistoryPage() {
         </div>
       )}
 
+      {/* Querying indicator */}
+      {isQuerying && (
+        <div className="text-center py-3xl" data-testid="querying-state">
+          <p className="text-body text-text-secondary">AI 正在分析您的查詢...</p>
+        </div>
+      )}
+
       {/* Transaction list */}
-      {transactions.length === 0 && !isLoading ? (
+      {!isQuerying && transactions.length === 0 && !isLoading ? (
         <div className="text-center py-3xl" data-testid="empty-state">
           <p className="text-body text-text-tertiary">
-            還沒有記帳紀錄，開始記帳吧！
+            {aiQueryResult ? '找不到符合條件的記錄' : '還沒有記帳紀錄，開始記帳吧！'}
           </p>
         </div>
-      ) : (
+      ) : !isQuerying ? (
         <div data-testid="transaction-list">
           {Array.from(grouped.entries()).map(([dateKey, txList]) => (
             <div key={dateKey} className="mb-lg">
@@ -247,8 +288,8 @@ function HistoryPage() {
             </div>
           ))}
 
-          {/* Load more */}
-          {hasMore && (
+          {/* Load more — hidden during AI query mode */}
+          {hasMore && !aiQueryResult && (
             <div className="text-center py-lg">
               <button
                 type="button"
@@ -262,14 +303,21 @@ function HistoryPage() {
             </div>
           )}
         </div>
-      )}
+      ) : null}
 
       {/* Loading indicator for initial load */}
-      {isLoading && transactions.length === 0 && (
+      {isLoading && transactions.length === 0 && !isQuerying && (
         <div className="text-center py-3xl" data-testid="loading-state">
           <p className="text-body text-text-secondary">載入中...</p>
         </div>
       )}
+
+      {/* AI Query Voice Input — fixed at bottom */}
+      <VoiceInput
+        onSubmit={handleAIQuery}
+        disabled={isQuerying}
+        placeholder="問問 AI 教練..."
+      />
     </div>
   )
 }

--- a/frontend/src/stores/historyStore.ts
+++ b/frontend/src/stores/historyStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import api from '../lib/api'
 import type { Transaction } from '../stores/index'
+import { useSettingsStore } from './settingsStore'
 
 export interface HistoryFilters {
   category: string
@@ -17,6 +18,21 @@ export interface UpdateTransactionInput {
   note?: string
 }
 
+/** AI 語義查詢結果 */
+export interface AIQueryResult {
+  summary: {
+    text: string
+    emotion_tag: string
+    total_amount: number
+    match_count: number
+  }
+  matched_transaction_ids: string[]
+  time_range: {
+    start_date: string
+    end_date: string
+  }
+}
+
 interface HistoryState {
   transactions: Transaction[]
   filters: HistoryFilters
@@ -27,6 +43,11 @@ interface HistoryState {
   isUpdating: string | null
   errorMessage: string
 
+  // AI Query state
+  aiQueryResult: AIQueryResult | null
+  aiQueryText: string
+  isQuerying: boolean
+
   // Actions
   fetchTransactions: (reset?: boolean) => Promise<void>
   loadMore: () => Promise<void>
@@ -34,6 +55,9 @@ interface HistoryState {
   resetFilters: () => void
   deleteTransaction: (id: string) => Promise<void>
   updateTransaction: (id: string, input: UpdateTransactionInput) => Promise<void>
+  queryTransactions: (queryText: string) => Promise<void>
+  clearAIQuery: () => void
+  clearAllFilters: () => void
 }
 
 const PAGE_SIZE = 20
@@ -42,6 +66,19 @@ const defaultFilters: HistoryFilters = {
   category: '',
   startDate: '',
   endDate: '',
+}
+
+/** 讀取當前引擎對應的 API Key */
+function getActiveApiKey(): string {
+  const engine = useSettingsStore.getState().aiEngine
+  try {
+    const stored = localStorage.getItem('llm_api_keys')
+    if (stored) {
+      const keys = JSON.parse(stored)
+      return keys[engine] ?? ''
+    }
+  } catch { /* ignore */ }
+  return localStorage.getItem('llm_api_key') ?? ''
 }
 
 export const useHistoryStore = create<HistoryState>((set, get) => ({
@@ -53,6 +90,11 @@ export const useHistoryStore = create<HistoryState>((set, get) => ({
   isDeleting: null,
   isUpdating: null,
   errorMessage: '',
+
+  // AI Query state
+  aiQueryResult: null,
+  aiQueryText: '',
+  isQuerying: false,
 
   fetchTransactions: async (reset = true) => {
     const state = get()
@@ -164,5 +206,87 @@ export const useHistoryStore = create<HistoryState>((set, get) => ({
       set({ isUpdating: null, errorMessage: message })
       throw err
     }
+  },
+
+  queryTransactions: async (queryText: string) => {
+    const state = get()
+    if (state.isQuerying) return
+
+    // 互斥：清除手動篩選器
+    set({
+      isQuerying: true,
+      errorMessage: '',
+      aiQueryText: queryText,
+      filters: { ...defaultFilters },
+    })
+
+    try {
+      const llmApiKey = getActiveApiKey()
+      if (!llmApiKey) {
+        set({ isQuerying: false, errorMessage: '請先在設定頁面輸入 AI API Key' })
+        return
+      }
+
+      const res = await api.post(
+        '/ai/query',
+        { query_text: queryText },
+        { headers: { 'X-LLM-API-Key': llmApiKey } }
+      )
+
+      const result = res.data.data as AIQueryResult
+
+      // 載入匹配時間範圍內的交易記錄
+      const params: Record<string, string | number> = {
+        page: 1,
+        limit: 200,
+        sort: 'desc',
+        start_date: result.time_range.start_date,
+        end_date: result.time_range.end_date,
+      }
+      const txRes = await api.get('/transactions', { params })
+      const allItems: Transaction[] = txRes.data.data.items.map(
+        (t: Record<string, unknown>) => ({
+          id: t.id as string,
+          type: (t.type as 'income' | 'expense') ?? 'expense',
+          amount: t.amount as number,
+          category: t.category as string,
+          merchant: t.merchant as string,
+          rawText: (t.raw_text as string) ?? '',
+          note: (t.note as string) ?? undefined,
+          transactionDate: t.transaction_date as string,
+          createdAt: t.created_at as string,
+        })
+      )
+
+      // 篩選出匹配的交易
+      const matchedIds = new Set(result.matched_transaction_ids)
+      const matched = allItems.filter((tx) => matchedIds.has(tx.id))
+
+      set({
+        aiQueryResult: result,
+        transactions: matched,
+        hasMore: false,
+        page: 1,
+        isQuerying: false,
+      })
+    } catch (err: unknown) {
+      const message =
+        (err as { response?: { data?: { message?: string } } })?.response?.data
+          ?.message ?? 'AI 查詢失敗，請稍後重試'
+      set({ isQuerying: false, errorMessage: message })
+    }
+  },
+
+  clearAIQuery: () => {
+    set({ aiQueryResult: null, aiQueryText: '' })
+  },
+
+  clearAllFilters: () => {
+    set({
+      filters: { ...defaultFilters },
+      aiQueryResult: null,
+      aiQueryText: '',
+    })
+    setTimeout(() => useHistoryStore.getState().fetchTransactions(true), 0)
   },
 }))


### PR DESCRIPTION
## 變更摘要
在記錄頁面實作語音/自然語義篩選查詢 UI（PRD-F-014）：底部新增 VoiceInput 查詢輸入框，查詢後上方顯示 AI 教練回饋卡片，下方僅顯示匹配帳目。手動篩選器與 AI 查詢互斥。

## 關聯 Issue
Closes #126

## 變更清單
- `HistoryPage.tsx`：新增 VoiceInput（自訂 placeholder）、AIFeedbackCard（僅有查詢結果時顯示）、篩選互斥邏輯、AI 查詢載入狀態
- `historyStore.ts`：新增 `aiQueryResult`/`aiQueryText`/`isQuerying` 狀態、`queryTransactions()`/`clearAIQuery()`/`clearAllFilters()` actions
- `VoiceInput.tsx`：新增 `placeholder` prop 支援

## 測試結果
- 單元測試：✅ 全部通過（136/136）
- TypeScript：✅ 零錯誤
- ESLint：✅ 零問題
- Build：✅ 成功
- 本地驗證：✅ Vibe Check 通過