### PR TITLE
fix: 統計頁面「自訂」時段新增日期選擇器

### DIFF
--- a/backend/src/routes/statsRoutes.ts
+++ b/backend/src/routes/statsRoutes.ts
@@ -10,27 +10,43 @@ router.get('/distribution', authMiddleware, async (req: AuthRequest, res: Respon
   try {
     const userId = req.userId!;
 
-    // Support optional month query param (format: YYYY-MM)
+    // Support period (week | month | custom) and date range params
+    const periodParam = req.query.period as string | undefined;
+    const startDateParam = req.query.start_date as string | undefined;
+    const endDateParam = req.query.end_date as string | undefined;
     const monthParam = req.query.month as string | undefined;
-    let year: number, month: number;
-
-    if (monthParam && /^\d{4}-\d{2}$/.test(monthParam)) {
-      const parts = monthParam.split('-');
-      year = parseInt(parts[0], 10);
-      month = parseInt(parts[1], 10) - 1;
-    } else {
-      const now = new Date();
-      year = now.getFullYear();
-      month = now.getMonth();
-    }
 
     // Support optional type query param (income | expense)
     const typeParam = req.query.type as string | undefined;
     const validTypes = ['income', 'expense'];
     const typeFilter = typeParam && validTypes.includes(typeParam) ? typeParam : undefined;
 
-    const monthStart = new Date(year, month, 1);
-    const monthEnd = new Date(year, month + 1, 0, 23, 59, 59, 999);
+    let monthStart: Date;
+    let monthEnd: Date;
+
+    if (periodParam === 'custom' && startDateParam && endDateParam) {
+      // Custom date range
+      monthStart = new Date(startDateParam + 'T00:00:00');
+      monthEnd = new Date(endDateParam + 'T23:59:59.999');
+    } else if (periodParam === 'week') {
+      // Current week (Monday to Sunday)
+      const now = new Date();
+      const dayOfWeek = now.getDay();
+      const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+      monthStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() + mondayOffset);
+      monthEnd = new Date(monthStart.getFullYear(), monthStart.getMonth(), monthStart.getDate() + 6, 23, 59, 59, 999);
+    } else if (monthParam && /^\d{4}-\d{2}$/.test(monthParam)) {
+      const parts = monthParam.split('-');
+      const year = parseInt(parts[0], 10);
+      const month = parseInt(parts[1], 10) - 1;
+      monthStart = new Date(year, month, 1);
+      monthEnd = new Date(year, month + 1, 0, 23, 59, 59, 999);
+    } else {
+      // Default: current month
+      const now = new Date();
+      monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+      monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999);
+    }
 
     const whereClause: Record<string, unknown> = {
       userId,
@@ -60,7 +76,9 @@ router.get('/distribution', authMiddleware, async (req: AuthRequest, res: Respon
       }))
       .sort((a, b) => b.amount - a.amount);
 
-    const monthStr = `${year}-${String(month + 1).padStart(2, '0')}`;
+    const monthStr = periodParam === 'custom'
+      ? `${startDateParam} ~ ${endDateParam}`
+      : `${monthStart.getFullYear()}-${String(monthStart.getMonth() + 1).padStart(2, '0')}`;
 
     const response: ApiResponse<Record<string, unknown>> = {
       code: 200,

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -24,11 +24,22 @@ function StatsPage() {
   const [totalAmount, setTotalAmount] = useState(0)
   const [loading, setLoading] = useState(true)
 
+  // Custom date range
+  const today = new Date().toISOString().slice(0, 10)
+  const firstOfMonth = new Date(new Date().getFullYear(), new Date().getMonth(), 1).toISOString().slice(0, 10)
+  const [customStart, setCustomStart] = useState(firstOfMonth)
+  const [customEnd, setCustomEnd] = useState(today)
+
   const fetchData = useCallback(async () => {
     setLoading(true)
     try {
+      const params: Record<string, string> = { period: timeFilter, type: typeTab }
+      if (timeFilter === 'custom') {
+        params.start_date = customStart
+        params.end_date = customEnd
+      }
       const requests: Promise<unknown>[] = [
-        api.get('/stats/distribution', { params: { period: timeFilter, type: typeTab } }),
+        api.get('/stats/distribution', { params }),
       ]
 
       // Only fetch budget summary for expense tab
@@ -74,7 +85,7 @@ function StatsPage() {
     } finally {
       setLoading(false)
     }
-  }, [timeFilter, typeTab])
+  }, [timeFilter, typeTab, customStart, customEnd])
 
   useEffect(() => {
     void fetchData()
@@ -146,6 +157,30 @@ function StatsPage() {
         ))}
       </div>
 
+      {/* Custom date range picker */}
+      {timeFilter === 'custom' && (
+        <div className="flex gap-sm mb-xl items-center">
+          <input
+            type="date"
+            value={customStart}
+            onChange={(e) => setCustomStart(e.target.value)}
+            max={customEnd}
+            className="flex-1 h-10 rounded-md border border-border bg-surface px-md text-caption text-text-primary focus:outline-none focus:border-primary"
+            aria-label="開始日期"
+          />
+          <span className="text-caption text-text-secondary">～</span>
+          <input
+            type="date"
+            value={customEnd}
+            onChange={(e) => setCustomEnd(e.target.value)}
+            min={customStart}
+            max={today}
+            className="flex-1 h-10 rounded-md border border-border bg-surface px-md text-caption text-text-primary focus:outline-none focus:border-primary"
+            aria-label="結束日期"
+          />
+        </div>
+      )}
+
       {loading ? (
         <div className="space-y-xl">
           <div className="bg-surface rounded-lg shadow-card p-lg animate-pulse">
@@ -158,11 +193,15 @@ function StatsPage() {
           {/* Total amount card */}
           <section
             className="bg-surface rounded-lg shadow-card p-lg mb-xl"
-            aria-label={isExpense ? '本月總支出' : '本月總收入'}
+            aria-label={isExpense ? '總支出' : '總收入'}
           >
             <div className="flex justify-between items-baseline mb-sm">
               <p className="text-caption text-text-secondary">
-                {isExpense ? '本月總支出' : '本月總收入'}
+                {timeFilter === 'week'
+                  ? (isExpense ? '本週總支出' : '本週總收入')
+                  : timeFilter === 'custom'
+                    ? (isExpense ? '區間總支出' : '區間總收入')
+                    : (isExpense ? '本月總支出' : '本月總收入')}
               </p>
               {isExpense && budgetSummary && budgetSummary.monthlyBudget > 0 && (
                 <p className="text-small text-text-secondary">

--- a/frontend/src/test/StatsPage.test.tsx
+++ b/frontend/src/test/StatsPage.test.tsx
@@ -227,7 +227,7 @@ describe('StatsPage', () => {
     await user.click(screen.getByTestId('tab-income'))
 
     await waitFor(() => {
-      const section = screen.getByLabelText('本月總收入')
+      const section = screen.getByLabelText('總收入')
       const headline = section.querySelector('.text-headline')
       expect(headline).not.toBeNull()
       expect(headline!.className).toContain('text-success')

--- a/frontend/src/test/StatsPage.test.tsx
+++ b/frontend/src/test/StatsPage.test.tsx
@@ -216,7 +216,7 @@ describe('StatsPage', () => {
 
     // Expense tab - red headline
     await waitFor(() => {
-      const section = screen.getByLabelText('本月總支出')
+      const section = screen.getByLabelText('總支出')
       const headline = section.querySelector('.text-headline')
       expect(headline).not.toBeNull()
       expect(headline!.className).toContain('text-danger')


### PR DESCRIPTION
## Summary
- 後端 `/stats/distribution` 新增 `period`、`start_date`、`end_date` 查詢參數，支援本週與自訂日期範圍查詢
- 前端選擇「自訂」時段時顯示起迄日期選擇器，日期變更即時重新載入數據
- 總金額卡片標籤依時段動態切換（本週總支出/本月總支出/區間總支出）

Closes #137

## Test plan
- [ ] 選擇「自訂」後出現起迄日期選擇器
- [ ] 修改日期後統計數據即時更新
- [ ] 開始日期不可晚於結束日期
- [ ] 「本週」「本月」模式不顯示日期選擇器
- [ ] 切換「收入/支出」tab 搭配自訂日期範圍正常運作