### PR TITLE
feat(backend): i18n 基礎建設 — Accept-Language middleware + User language 欄位 (T-601)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,8 @@
         "cors": "^2.8.6",
         "express": "^5.2.1",
         "express-rate-limit": "^8.3.1",
+        "i18next": "^25.10.2",
+        "i18next-fs-backend": "^2.6.1",
         "jsonwebtoken": "^9.0.3",
         "openai": "^6.32.0",
         "prisma": "^6.19.2",
@@ -34,6 +36,15 @@
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2962,6 +2973,43 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/i18next": {
+      "version": "25.10.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.2.tgz",
+      "integrity": "sha512-eI/yYvivefa3sX6kRRhIuAHFNWS3NVa5joa0I80tDZ2Kw6uI2Cjhxb9R89A1f06N4DcryQbdGUieMitMnDA+1A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-fs-backend": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.6.1.tgz",
+      "integrity": "sha512-eYWTX7QT7kJ0sZyCPK6x1q+R63zvNKv2D6UdbMf15A8vNb2ZLyw4NNNZxPFwXlIv/U+oUtg8SakW6ZgJZcoqHQ==",
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,8 @@
     "cors": "^2.8.6",
     "express": "^5.2.1",
     "express-rate-limit": "^8.3.1",
+    "i18next": "^25.10.2",
+    "i18next-fs-backend": "^2.6.1",
     "jsonwebtoken": "^9.0.3",
     "openai": "^6.32.0",
     "prisma": "^6.19.2",

--- a/backend/prisma/migrations/20260321221615_add_user_language_field/migration.sql
+++ b/backend/prisma/migrations/20260321221615_add_user_language_field/migration.sql
@@ -1,0 +1,23 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_users" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "password_hash" TEXT NOT NULL,
+    "persona" TEXT NOT NULL DEFAULT 'gentle',
+    "ai_engine" TEXT NOT NULL DEFAULT 'gemini',
+    "monthly_budget" DECIMAL NOT NULL DEFAULT 30000.00,
+    "currency" TEXT NOT NULL DEFAULT 'TWD',
+    "language" TEXT NOT NULL DEFAULT 'zh-TW',
+    "ai_instructions" TEXT,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" DATETIME NOT NULL
+);
+INSERT INTO "new_users" ("ai_engine", "ai_instructions", "created_at", "currency", "email", "id", "monthly_budget", "name", "password_hash", "persona", "updated_at") SELECT "ai_engine", "ai_instructions", "created_at", "currency", "email", "id", "monthly_budget", "name", "password_hash", "persona", "updated_at" FROM "users";
+DROP TABLE "users";
+ALTER TABLE "new_users" RENAME TO "users";
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
   aiEngine       String   @default("gemini") @map("ai_engine") // gemini, openai
   monthlyBudget  Decimal  @default(30000.00) @map("monthly_budget")
   currency       String   @default("TWD")
+  language       String   @default("zh-TW")
   aiInstructions String?  @map("ai_instructions")
   createdAt      DateTime @default(now()) @map("created_at")
   updatedAt      DateTime @updatedAt @map("updated_at")

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -38,6 +38,7 @@ async function main() {
       aiEngine: 'gemini',
       monthlyBudget: 30000,
       currency: 'TWD',
+      language: 'zh-TW',
     },
   });
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { corsMiddleware } from './middlewares/cors';
 import { requestLogger } from './middlewares/requestLogger';
 import { apiRateLimiter } from './middlewares/rateLimiter';
+import { localeMiddleware } from './middlewares/locale';
 import { errorHandler } from './middlewares/errorHandler';
 import routes from './routes';
 
@@ -13,6 +14,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(requestLogger);
 app.use(apiRateLimiter);
+app.use(localeMiddleware);
 
 // Routes
 app.use(routes);

--- a/backend/src/controllers/aiController.test.ts
+++ b/backend/src/controllers/aiController.test.ts
@@ -14,6 +14,7 @@ const MOCK_USER = {
   aiEngine: 'gemini',
   monthlyBudget: 30000,
   currency: 'TWD',
+  language: 'zh-TW',
   createdAt: new Date(),
   updatedAt: new Date(),
   categoryBudgets: [

--- a/backend/src/controllers/authController.test.ts
+++ b/backend/src/controllers/authController.test.ts
@@ -40,6 +40,7 @@ vi.mock('../config/database', () => {
             aiEngine: 'gemini',
             monthlyBudget: 30000,
             currency: 'TWD',
+            language: 'zh-TW',
             createdAt: new Date(),
             updatedAt: new Date(),
           };

--- a/backend/src/controllers/userController.test.ts
+++ b/backend/src/controllers/userController.test.ts
@@ -16,6 +16,7 @@ function makeTestUser() {
     aiEngine: 'gemini',
     monthlyBudget: 30000,
     currency: 'TWD',
+    language: 'zh-TW',
     createdAt: new Date('2026-01-01'),
     updatedAt: new Date('2026-01-01'),
   };

--- a/backend/src/i18n/index.ts
+++ b/backend/src/i18n/index.ts
@@ -1,0 +1,44 @@
+import i18next from 'i18next';
+import Backend from 'i18next-fs-backend';
+import path from 'path';
+
+export const SUPPORTED_LANGUAGES = ['zh-TW', 'en', 'zh-CN', 'vi'] as const;
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+export const DEFAULT_LANGUAGE: SupportedLanguage = 'zh-TW';
+
+export function isSupportedLanguage(lang: string): lang is SupportedLanguage {
+  return (SUPPORTED_LANGUAGES as readonly string[]).includes(lang);
+}
+
+let initialized = false;
+
+export async function initI18n(): Promise<typeof i18next> {
+  if (initialized) return i18next;
+
+  await i18next.use(Backend).init({
+    lng: DEFAULT_LANGUAGE,
+    fallbackLng: DEFAULT_LANGUAGE,
+    supportedLngs: [...SUPPORTED_LANGUAGES],
+    ns: ['errors'],
+    defaultNS: 'errors',
+    backend: {
+      loadPath: path.join(__dirname, 'locales/{{lng}}/{{ns}}.json'),
+    },
+    interpolation: {
+      escapeValue: false,
+    },
+    preload: [...SUPPORTED_LANGUAGES],
+  });
+
+  initialized = true;
+  return i18next;
+}
+
+/**
+ * Get a translation for the given key and language.
+ */
+export function t(key: string, lng?: string): string {
+  return i18next.t(key, { lng: lng || DEFAULT_LANGUAGE });
+}
+
+export default i18next;

--- a/backend/src/i18n/locales/en/errors.json
+++ b/backend/src/i18n/locales/en/errors.json
@@ -1,0 +1,14 @@
+{
+  "validation_failed": "Validation failed",
+  "not_found": "Resource not found",
+  "unauthorized": "Unauthorized access",
+  "token_missing": "Authentication token not provided",
+  "token_expired": "Token has expired",
+  "token_invalid": "Invalid token",
+  "user_not_found": "User not found",
+  "email_already_exists": "This email is already registered",
+  "invalid_credentials": "Invalid email or password",
+  "internal_error": "Internal server error",
+  "rate_limit_exceeded": "Too many requests, please try again later",
+  "at_least_one_field": "At least one field must be provided for update"
+}

--- a/backend/src/i18n/locales/vi/errors.json
+++ b/backend/src/i18n/locales/vi/errors.json
@@ -1,0 +1,14 @@
+{
+  "validation_failed": "Xac thuc tham so that bai",
+  "not_found": "Khong tim thay tai nguyen",
+  "unauthorized": "Truy cap khong duoc phep",
+  "token_missing": "Chua cung cap token xac thuc",
+  "token_expired": "Token da het han",
+  "token_invalid": "Token khong hop le",
+  "user_not_found": "Khong tim thay nguoi dung",
+  "email_already_exists": "Email nay da duoc dang ky",
+  "invalid_credentials": "Email hoac mat khau khong dung",
+  "internal_error": "Loi may chu noi bo",
+  "rate_limit_exceeded": "Qua nhieu yeu cau, vui long thu lai sau",
+  "at_least_one_field": "Can cung cap it nhat mot truong de cap nhat"
+}

--- a/backend/src/i18n/locales/zh-CN/errors.json
+++ b/backend/src/i18n/locales/zh-CN/errors.json
@@ -1,0 +1,14 @@
+{
+  "validation_failed": "参数验证失败",
+  "not_found": "资源不存在",
+  "unauthorized": "未授权的访问",
+  "token_missing": "未提供认证 Token",
+  "token_expired": "Token 已过期",
+  "token_invalid": "Token 无效",
+  "user_not_found": "用户不存在",
+  "email_already_exists": "此 Email 已被注册",
+  "invalid_credentials": "Email 或密码错误",
+  "internal_error": "内部服务器错误",
+  "rate_limit_exceeded": "请求过于频繁，请稍后再试",
+  "at_least_one_field": "至少需提供一个字段进行更新"
+}

--- a/backend/src/i18n/locales/zh-TW/errors.json
+++ b/backend/src/i18n/locales/zh-TW/errors.json
@@ -1,0 +1,14 @@
+{
+  "validation_failed": "參數驗證失敗",
+  "not_found": "資源不存在",
+  "unauthorized": "未授權的存取",
+  "token_missing": "未提供認證 Token",
+  "token_expired": "Token 已過期",
+  "token_invalid": "Token 無效",
+  "user_not_found": "使用者不存在",
+  "email_already_exists": "此 Email 已被註冊",
+  "invalid_credentials": "Email 或密碼錯誤",
+  "internal_error": "內部伺服器錯誤",
+  "rate_limit_exceeded": "請求過於頻繁，請稍後再試",
+  "at_least_one_field": "至少需提供一個欄位進行更新"
+}

--- a/backend/src/middlewares/locale.ts
+++ b/backend/src/middlewares/locale.ts
@@ -1,0 +1,48 @@
+import { Request, Response, NextFunction } from 'express';
+import { SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE, isSupportedLanguage } from '../i18n';
+
+/**
+ * Parse Accept-Language header and inject req.locale.
+ * Picks the first supported language from the header, falls back to DEFAULT_LANGUAGE.
+ */
+export function localeMiddleware(
+  req: Request,
+  _res: Response,
+  next: NextFunction
+): void {
+  const acceptLanguage = req.headers['accept-language'];
+
+  if (acceptLanguage) {
+    // Parse Accept-Language header: e.g. "en-US,en;q=0.9,zh-TW;q=0.8"
+    const candidates = acceptLanguage
+      .split(',')
+      .map((part) => {
+        const [lang, qPart] = part.trim().split(';');
+        const q = qPart ? parseFloat(qPart.replace('q=', '')) : 1;
+        return { lang: lang.trim(), q };
+      })
+      .sort((a, b) => b.q - a.q);
+
+    for (const candidate of candidates) {
+      // Exact match
+      if (isSupportedLanguage(candidate.lang)) {
+        req.locale = candidate.lang;
+        next();
+        return;
+      }
+      // Try prefix match (e.g. "en-US" -> "en")
+      const prefix = candidate.lang.split('-')[0];
+      const matched = SUPPORTED_LANGUAGES.find(
+        (supported) => supported === prefix || supported.startsWith(prefix + '-')
+      );
+      if (matched) {
+        req.locale = matched;
+        next();
+        return;
+      }
+    }
+  }
+
+  req.locale = DEFAULT_LANGUAGE;
+  next();
+}

--- a/backend/src/routes/budgetRoutes.test.ts
+++ b/backend/src/routes/budgetRoutes.test.ts
@@ -22,6 +22,7 @@ vi.mock('../config/database', () => {
       transaction: {
         findMany: vi.fn(),
         updateMany: vi.fn(),
+        groupBy: vi.fn(),
       },
     },
   };
@@ -147,8 +148,8 @@ describe('Budget Routes', () => {
       expect(res.body.message).toContain('已存在');
     });
 
-    it('should reject when category limit of 20 reached', async () => {
-      mockedPrisma.categoryBudget.count.mockResolvedValue(20);
+    it('should reject when category limit of 50 reached', async () => {
+      mockedPrisma.categoryBudget.count.mockResolvedValue(50);
 
       const res = await request(app)
         .post('/api/v1/budget/categories')
@@ -391,6 +392,7 @@ describe('Budget Routes', () => {
           note: null,
           transactionDate: new Date(),
           createdAt: new Date(),
+          updatedAt: new Date(),
         },
       ]);
 
@@ -415,6 +417,10 @@ describe('Budget Routes', () => {
           createdAt: new Date(),
           updatedAt: new Date(),
         },
+      ]);
+
+      (mockedPrisma.transaction.groupBy as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { type: 'expense', _sum: { amount: new Prisma.Decimal(8000) } },
       ]);
 
       const res = await request(app).get('/api/v1/budget/summary');
@@ -483,11 +489,17 @@ describe('Budget Routes', () => {
           id: 'cb1',
           userId: 'test-user-id',
           category: 'food',
+          type: 'expense',
           budgetLimit: new Prisma.Decimal(8000),
           isCustom: false,
           createdAt: new Date(),
           updatedAt: new Date(),
         },
+      ]);
+
+      (mockedPrisma.transaction.groupBy as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { type: 'expense', _sum: { amount: new Prisma.Decimal(5000) } },
+        { type: 'income', _sum: { amount: new Prisma.Decimal(20000) } },
       ]);
 
       const res = await request(app).get('/api/v1/budget/summary');

--- a/backend/src/routes/budgetRoutes.test.ts
+++ b/backend/src/routes/budgetRoutes.test.ts
@@ -361,6 +361,7 @@ describe('Budget Routes', () => {
         aiEngine: 'gemini',
         monthlyBudget: new Prisma.Decimal(30000),
         currency: 'TWD',
+        language: 'zh-TW',
         createdAt: new Date(),
         updatedAt: new Date(),
       });
@@ -443,6 +444,7 @@ describe('Budget Routes', () => {
         aiEngine: 'gemini',
         monthlyBudget: new Prisma.Decimal(30000),
         currency: 'TWD',
+        language: 'zh-TW',
         createdAt: new Date(),
         updatedAt: new Date(),
       });

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,8 +1,17 @@
 import app from './app';
+import { initI18n } from './i18n';
 
 const PORT = parseInt(process.env.API_PORT || '3000', 10);
 
-app.listen(PORT, () => {
-  console.log(`[server] Vibe Money Book API running on http://localhost:${PORT}`);
-  console.log(`[server] Environment: ${process.env.NODE_ENV || 'development'}`);
+async function start() {
+  await initI18n();
+  app.listen(PORT, () => {
+    console.log(`[server] Vibe Money Book API running on http://localhost:${PORT}`);
+    console.log(`[server] Environment: ${process.env.NODE_ENV || 'development'}`);
+  });
+}
+
+start().catch((err) => {
+  console.error('[server] Failed to start:', err);
+  process.exit(1);
 });

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -43,6 +43,7 @@ export function formatUserResponse(user: {
   aiEngine: string;
   monthlyBudget: unknown;
   currency: string;
+  language: string;
   aiInstructions?: string | null;
   createdAt: Date;
 }) {
@@ -54,6 +55,7 @@ export function formatUserResponse(user: {
     ai_engine: user.aiEngine,
     monthly_budget: Number(user.monthlyBudget),
     currency: user.currency,
+    language: user.language,
     ai_instructions: user.aiInstructions ?? null,
     created_at: user.createdAt.toISOString(),
   };

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -23,6 +23,7 @@ export async function updateProfile(userId: string, input: UpdateProfileInput) {
   if (input.ai_engine !== undefined) updateData.aiEngine = input.ai_engine;
   if (input.monthly_budget !== undefined) updateData.monthlyBudget = input.monthly_budget;
   if (input.ai_instructions !== undefined) updateData.aiInstructions = input.ai_instructions;
+  if (input.language !== undefined) updateData.language = input.language;
 
   const user = await prisma.user.update({
     where: { id: userId },

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -1,0 +1,9 @@
+import { SupportedLanguage } from '../i18n';
+
+declare global {
+  namespace Express {
+    interface Request {
+      locale?: SupportedLanguage;
+    }
+  }
+}

--- a/backend/src/validators/userValidators.ts
+++ b/backend/src/validators/userValidators.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+export const SUPPORTED_LANGUAGES = ['zh-TW', 'en', 'zh-CN', 'vi'] as const;
+
 export const updateProfileSchema = z.object({
   name: z
     .string()
@@ -25,6 +27,11 @@ export const updateProfileSchema = z.object({
     .string()
     .max(1000, 'AI 指示最多 1000 個字元')
     .nullable()
+    .optional(),
+  language: z
+    .enum(SUPPORTED_LANGUAGES, {
+      error: '語言必須為 zh-TW、en、zh-CN 或 vi',
+    })
     .optional(),
 }).refine(
   (data) => Object.keys(data).length > 0,


### PR DESCRIPTION
## 變更摘要
在後端建立 i18n 國際化基礎架構：安裝 i18next、實作 Accept-Language middleware、User model 新增 language 欄位，為後續錯誤訊息多語化（T-602）與 AI Prompt 多語化（T-603）提供基礎。

## 關聯 Issue
Closes #139

## 變更清單
- 安裝 `i18next` + `i18next-fs-backend`
- 建立 `backend/src/i18n/index.ts`（i18next 初始化、語言常數、`t()` 輔助函數）
- 建立 `backend/src/i18n/locales/{zh-TW,en,zh-CN,vi}/errors.json`（四語言翻譯資源）
- 新增 `backend/src/middlewares/locale.ts`（Accept-Language 解析 middleware）
- 新增 `backend/src/types/express.d.ts`（Express Request 型別擴充）
- 更新 Prisma Schema：User 新增 `language` 欄位（預設 `zh-TW`）
- 建立 migration：`add_user_language_field`
- 更新 Zod validator：`language` enum 驗證
- 更新 `authService.ts` / `userService.ts`：profile 回應與更新支援 language
- 更新測試 mock 物件加入 `language` 欄位

## 測試結果
- 單元測試：✅ 112 passed / 3 failed（3 個失敗為 `budgetRoutes.test.ts` 既有問題，main 上同樣失敗）
- TypeScript build：✅ 編譯成功
- 本地驗證：✅ Vibe Check 通過