### PR TITLE
feat(frontend): i18n 基礎建設 — react-i18next 初始化 + useLocaleFormatter hook (T-604)

### DIFF
--- a/backend/src/routes/budgetRoutes.test.ts
+++ b/backend/src/routes/budgetRoutes.test.ts
@@ -22,6 +22,7 @@ vi.mock('../config/database', () => {
       transaction: {
         findMany: vi.fn(),
         updateMany: vi.fn(),
+        groupBy: vi.fn(),
       },
     },
   };
@@ -147,8 +148,8 @@ describe('Budget Routes', () => {
       expect(res.body.message).toContain('已存在');
     });
 
-    it('should reject when category limit of 20 reached', async () => {
-      mockedPrisma.categoryBudget.count.mockResolvedValue(20);
+    it('should reject when category limit of 50 reached', async () => {
+      mockedPrisma.categoryBudget.count.mockResolvedValue(50);
 
       const res = await request(app)
         .post('/api/v1/budget/categories')
@@ -390,6 +391,7 @@ describe('Budget Routes', () => {
           note: null,
           transactionDate: new Date(),
           createdAt: new Date(),
+          updatedAt: new Date(),
         },
       ]);
 
@@ -414,6 +416,10 @@ describe('Budget Routes', () => {
           createdAt: new Date(),
           updatedAt: new Date(),
         },
+      ]);
+
+      (mockedPrisma.transaction.groupBy as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { type: 'expense', _sum: { amount: new Prisma.Decimal(8000) } },
       ]);
 
       const res = await request(app).get('/api/v1/budget/summary');
@@ -481,11 +487,17 @@ describe('Budget Routes', () => {
           id: 'cb1',
           userId: 'test-user-id',
           category: 'food',
+          type: 'expense',
           budgetLimit: new Prisma.Decimal(8000),
           isCustom: false,
           createdAt: new Date(),
           updatedAt: new Date(),
         },
+      ]);
+
+      (mockedPrisma.transaction.groupBy as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { type: 'expense', _sum: { amount: new Prisma.Decimal(5000) } },
+        { type: 'income', _sum: { amount: new Prisma.Decimal(20000) } },
       ]);
 
       const res = await request(app).get('/api/v1/budget/summary');

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,8 +9,11 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.13.6",
+        "i18next": "^25.10.2",
+        "i18next-browser-languagedetector": "^8.2.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-i18next": "^16.6.0",
         "react-router-dom": "^7.13.1",
         "recharts": "^3.8.0",
         "vite-plugin-pwa": "^1.2.0",
@@ -5736,6 +5739,55 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.10.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.2.tgz",
+      "integrity": "sha512-eI/yYvivefa3sX6kRRhIuAHFNWS3NVa5joa0I80tDZ2Kw6uI2Cjhxb9R89A1f06N4DcryQbdGUieMitMnDA+1A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz",
+      "integrity": "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
     "node_modules/idb": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
@@ -7256,6 +7308,33 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-i18next": {
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.0.tgz",
+      "integrity": "sha512-bxVftl2q/pfupKVmBH80ui1rHl3ia2sdcR0Yhn6cr0PyoHfO8JLZ19fccwOIH+0dMBCIkdO5gAmEQFCTAggeQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.6.2",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {
@@ -8814,6 +8893,15 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,8 +13,11 @@
   },
   "dependencies": {
     "axios": "^1.13.6",
+    "i18next": "^25.10.2",
+    "i18next-browser-languagedetector": "^8.2.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-i18next": "^16.6.0",
     "react-router-dom": "^7.13.1",
     "recharts": "^3.8.0",
     "vite-plugin-pwa": "^1.2.0",

--- a/frontend/src/hooks/useLocaleFormatter.ts
+++ b/frontend/src/hooks/useLocaleFormatter.ts
@@ -1,0 +1,58 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+/** UI 語言 → Intl locale 對應（用於數字/日期格式化） */
+const intlLocaleMap: Record<string, string> = {
+  'zh-TW': 'zh-TW',
+  en: 'en-US',
+  'zh-CN': 'zh-CN',
+  vi: 'vi-VN',
+}
+
+function getIntlLocale(language: string): string {
+  return intlLocaleMap[language] ?? 'zh-TW'
+}
+
+/**
+ * 依當前 i18n 語言提供 Intl 格式化工具。
+ *
+ * - `formatNumber(value)` — 使用 Intl.NumberFormat 格式化數字
+ * - `formatCurrency(value, currency?)` — 使用 Intl.NumberFormat currency 模式
+ * - `formatDate(date, options?)` — 使用 Intl.DateTimeFormat 格式化日期
+ */
+export function useLocaleFormatter() {
+  const { i18n } = useTranslation()
+  const language = i18n.language
+
+  const intlLocale = useMemo(() => getIntlLocale(language), [language])
+
+  const formatNumber = useMemo(() => {
+    const formatter = new Intl.NumberFormat(intlLocale)
+    return (value: number): string => formatter.format(value)
+  }, [intlLocale])
+
+  const formatCurrency = useMemo(() => {
+    return (value: number, currency = 'TWD'): string => {
+      const formatter = new Intl.NumberFormat(intlLocale, {
+        style: 'currency',
+        currency,
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+      })
+      return formatter.format(value)
+    }
+  }, [intlLocale])
+
+  const formatDate = useMemo(() => {
+    return (
+      date: Date | string | number,
+      options?: Intl.DateTimeFormatOptions,
+    ): string => {
+      const d = date instanceof Date ? date : new Date(date)
+      const formatter = new Intl.DateTimeFormat(intlLocale, options)
+      return formatter.format(d)
+    }
+  }, [intlLocale])
+
+  return { formatNumber, formatCurrency, formatDate, intlLocale }
+}

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1,0 +1,136 @@
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import LanguageDetector from 'i18next-browser-languagedetector'
+
+// zh-TW translations
+import zhTWCommon from './locales/zh-TW/common.json'
+import zhTWDashboard from './locales/zh-TW/dashboard.json'
+import zhTWStats from './locales/zh-TW/stats.json'
+import zhTWHistory from './locales/zh-TW/history.json'
+import zhTWSettings from './locales/zh-TW/settings.json'
+import zhTWAuth from './locales/zh-TW/auth.json'
+import zhTWCategories from './locales/zh-TW/categories.json'
+import zhTWValidation from './locales/zh-TW/validation.json'
+
+// en translations
+import enCommon from './locales/en/common.json'
+import enDashboard from './locales/en/dashboard.json'
+import enStats from './locales/en/stats.json'
+import enHistory from './locales/en/history.json'
+import enSettings from './locales/en/settings.json'
+import enAuth from './locales/en/auth.json'
+import enCategories from './locales/en/categories.json'
+import enValidation from './locales/en/validation.json'
+
+// zh-CN translations
+import zhCNCommon from './locales/zh-CN/common.json'
+import zhCNDashboard from './locales/zh-CN/dashboard.json'
+import zhCNStats from './locales/zh-CN/stats.json'
+import zhCNHistory from './locales/zh-CN/history.json'
+import zhCNSettings from './locales/zh-CN/settings.json'
+import zhCNAuth from './locales/zh-CN/auth.json'
+import zhCNCategories from './locales/zh-CN/categories.json'
+import zhCNValidation from './locales/zh-CN/validation.json'
+
+// vi translations
+import viCommon from './locales/vi/common.json'
+import viDashboard from './locales/vi/dashboard.json'
+import viStats from './locales/vi/stats.json'
+import viHistory from './locales/vi/history.json'
+import viSettings from './locales/vi/settings.json'
+import viAuth from './locales/vi/auth.json'
+import viCategories from './locales/vi/categories.json'
+import viValidation from './locales/vi/validation.json'
+
+/** 支援的語言清單 */
+export const supportedLngs = ['zh-TW', 'en', 'zh-CN', 'vi'] as const
+export type SupportedLanguage = (typeof supportedLngs)[number]
+
+/** 翻譯 namespace 清單 */
+export const namespaces = [
+  'common',
+  'dashboard',
+  'stats',
+  'history',
+  'settings',
+  'auth',
+  'categories',
+  'validation',
+] as const
+
+/** 語言代碼 → 語音辨識語言代碼對應 */
+export const voiceLangMap: Record<SupportedLanguage, string> = {
+  'zh-TW': 'zh-TW',
+  en: 'en-US',
+  'zh-CN': 'zh-CN',
+  vi: 'vi-VN',
+}
+
+/** 根據 UI 語言取得語音辨識語言代碼 */
+export function getVoiceLang(locale: string): string {
+  return voiceLangMap[locale as SupportedLanguage] ?? 'zh-TW'
+}
+
+const resources = {
+  'zh-TW': {
+    common: zhTWCommon,
+    dashboard: zhTWDashboard,
+    stats: zhTWStats,
+    history: zhTWHistory,
+    settings: zhTWSettings,
+    auth: zhTWAuth,
+    categories: zhTWCategories,
+    validation: zhTWValidation,
+  },
+  en: {
+    common: enCommon,
+    dashboard: enDashboard,
+    stats: enStats,
+    history: enHistory,
+    settings: enSettings,
+    auth: enAuth,
+    categories: enCategories,
+    validation: enValidation,
+  },
+  'zh-CN': {
+    common: zhCNCommon,
+    dashboard: zhCNDashboard,
+    stats: zhCNStats,
+    history: zhCNHistory,
+    settings: zhCNSettings,
+    auth: zhCNAuth,
+    categories: zhCNCategories,
+    validation: zhCNValidation,
+  },
+  vi: {
+    common: viCommon,
+    dashboard: viDashboard,
+    stats: viStats,
+    history: viHistory,
+    settings: viSettings,
+    auth: viAuth,
+    categories: viCategories,
+    validation: viValidation,
+  },
+}
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources,
+    fallbackLng: 'zh-TW',
+    supportedLngs: [...supportedLngs],
+    ns: [...namespaces],
+    defaultNS: 'common',
+    detection: {
+      order: ['localStorage', 'navigator'],
+      lookupLocalStorage: 'i18nextLng',
+      caches: ['localStorage'],
+    },
+    interpolation: {
+      escapeValue: false, // React 已自動處理 XSS 防護
+    },
+  })
+
+export default i18n

--- a/frontend/src/i18n/locales/en/auth.json
+++ b/frontend/src/i18n/locales/en/auth.json
@@ -1,0 +1,15 @@
+{
+  "login": {
+    "title": "Login",
+    "submit": "Login",
+    "noAccount": "Don't have an account?"
+  },
+  "register": {
+    "title": "Register",
+    "submit": "Register",
+    "hasAccount": "Already have an account?"
+  },
+  "email": "Email",
+  "password": "Password",
+  "name": "Name"
+}

--- a/frontend/src/i18n/locales/en/categories.json
+++ b/frontend/src/i18n/locales/en/categories.json
@@ -1,0 +1,12 @@
+{
+  "food": "Food",
+  "transport": "Transport",
+  "entertainment": "Entertainment",
+  "shopping": "Shopping",
+  "housing": "Housing",
+  "medical": "Medical",
+  "education": "Education",
+  "other": "Other",
+  "salary": "Salary",
+  "investment": "Investment"
+}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1,0 +1,17 @@
+{
+  "save": "Save",
+  "cancel": "Cancel",
+  "confirm": "Confirm",
+  "delete": "Delete",
+  "edit": "Edit",
+  "loading": "Loading...",
+  "error": "An error occurred",
+  "retry": "Retry",
+  "back": "Back",
+  "next": "Next",
+  "done": "Done",
+  "close": "Close",
+  "search": "Search",
+  "noData": "No data",
+  "currency": "USD"
+}

--- a/frontend/src/i18n/locales/en/dashboard.json
+++ b/frontend/src/i18n/locales/en/dashboard.json
@@ -1,0 +1,10 @@
+{
+  "budgetCard": {
+    "title": "Monthly Budget"
+  },
+  "recentTransactions": "Recent Transactions",
+  "voiceInput": {
+    "placeholder": "Tell me what you spent...",
+    "recording": "Recording..."
+  }
+}

--- a/frontend/src/i18n/locales/en/history.json
+++ b/frontend/src/i18n/locales/en/history.json
@@ -1,0 +1,10 @@
+{
+  "filter": {
+    "category": "Category",
+    "dateRange": "Date Range",
+    "type": "Type"
+  },
+  "aiQuery": {
+    "placeholder": "Search transactions with natural language..."
+  }
+}

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -1,0 +1,14 @@
+{
+  "language": {
+    "title": "Language"
+  },
+  "persona": {
+    "title": "AI Persona",
+    "sarcastic": "Sarcastic",
+    "gentle": "Gentle",
+    "guilt_trip": "Guilt Trip"
+  },
+  "budget": {
+    "title": "Monthly Budget"
+  }
+}

--- a/frontend/src/i18n/locales/en/stats.json
+++ b/frontend/src/i18n/locales/en/stats.json
@@ -1,0 +1,12 @@
+{
+  "distribution": {
+    "title": "Expense Distribution"
+  },
+  "period": {
+    "thisMonth": "This Month",
+    "lastMonth": "Last Month",
+    "custom": "Custom"
+  },
+  "totalIncome": "Total Income",
+  "totalExpense": "Total Expense"
+}

--- a/frontend/src/i18n/locales/en/validation.json
+++ b/frontend/src/i18n/locales/en/validation.json
@@ -1,0 +1,7 @@
+{
+  "required": "This field is required",
+  "invalidEmail": "Please enter a valid email",
+  "passwordTooShort": "Password must be at least 8 characters",
+  "passwordMismatch": "Passwords do not match",
+  "invalidAmount": "Please enter a valid amount"
+}

--- a/frontend/src/i18n/locales/vi/auth.json
+++ b/frontend/src/i18n/locales/vi/auth.json
@@ -1,0 +1,15 @@
+{
+  "login": {
+    "title": "Đăng nhập",
+    "submit": "Đăng nhập",
+    "noAccount": "Chưa có tài khoản?"
+  },
+  "register": {
+    "title": "Đăng ký",
+    "submit": "Đăng ký",
+    "hasAccount": "Đã có tài khoản?"
+  },
+  "email": "Email",
+  "password": "Mật khẩu",
+  "name": "Tên"
+}

--- a/frontend/src/i18n/locales/vi/categories.json
+++ b/frontend/src/i18n/locales/vi/categories.json
@@ -1,0 +1,12 @@
+{
+  "food": "Ăn uống",
+  "transport": "Giao thông",
+  "entertainment": "Giải trí",
+  "shopping": "Mua sắm",
+  "housing": "Nhà ở",
+  "medical": "Y tế",
+  "education": "Giáo dục",
+  "other": "Khác",
+  "salary": "Lương",
+  "investment": "Đầu tư"
+}

--- a/frontend/src/i18n/locales/vi/common.json
+++ b/frontend/src/i18n/locales/vi/common.json
@@ -1,0 +1,17 @@
+{
+  "save": "Lưu",
+  "cancel": "Hủy",
+  "confirm": "Xác nhận",
+  "delete": "Xóa",
+  "edit": "Sửa",
+  "loading": "Đang tải...",
+  "error": "Đã xảy ra lỗi",
+  "retry": "Thử lại",
+  "back": "Quay lại",
+  "next": "Tiếp theo",
+  "done": "Hoàn tất",
+  "close": "Đóng",
+  "search": "Tìm kiếm",
+  "noData": "Không có dữ liệu",
+  "currency": "VND"
+}

--- a/frontend/src/i18n/locales/vi/dashboard.json
+++ b/frontend/src/i18n/locales/vi/dashboard.json
@@ -1,0 +1,10 @@
+{
+  "budgetCard": {
+    "title": "Ngân sách tháng"
+  },
+  "recentTransactions": "Giao dịch gần đây",
+  "voiceInput": {
+    "placeholder": "Nói cho tôi biết bạn đã chi gì...",
+    "recording": "Đang ghi âm..."
+  }
+}

--- a/frontend/src/i18n/locales/vi/history.json
+++ b/frontend/src/i18n/locales/vi/history.json
@@ -1,0 +1,10 @@
+{
+  "filter": {
+    "category": "Danh mục",
+    "dateRange": "Khoảng thời gian",
+    "type": "Loại"
+  },
+  "aiQuery": {
+    "placeholder": "Tìm kiếm giao dịch bằng ngôn ngữ tự nhiên..."
+  }
+}

--- a/frontend/src/i18n/locales/vi/settings.json
+++ b/frontend/src/i18n/locales/vi/settings.json
@@ -1,0 +1,14 @@
+{
+  "language": {
+    "title": "Ngôn ngữ"
+  },
+  "persona": {
+    "title": "Nhân cách AI",
+    "sarcastic": "Châm biếm",
+    "gentle": "Nhẹ nhàng",
+    "guilt_trip": "Cảm giác tội lỗi"
+  },
+  "budget": {
+    "title": "Ngân sách tháng"
+  }
+}

--- a/frontend/src/i18n/locales/vi/stats.json
+++ b/frontend/src/i18n/locales/vi/stats.json
@@ -1,0 +1,12 @@
+{
+  "distribution": {
+    "title": "Phân bổ chi tiêu"
+  },
+  "period": {
+    "thisMonth": "Tháng này",
+    "lastMonth": "Tháng trước",
+    "custom": "Tùy chỉnh"
+  },
+  "totalIncome": "Tổng thu nhập",
+  "totalExpense": "Tổng chi tiêu"
+}

--- a/frontend/src/i18n/locales/vi/validation.json
+++ b/frontend/src/i18n/locales/vi/validation.json
@@ -1,0 +1,7 @@
+{
+  "required": "Trường này là bắt buộc",
+  "invalidEmail": "Vui lòng nhập email hợp lệ",
+  "passwordTooShort": "Mật khẩu phải có ít nhất 8 ký tự",
+  "passwordMismatch": "Mật khẩu không khớp",
+  "invalidAmount": "Vui lòng nhập số tiền hợp lệ"
+}

--- a/frontend/src/i18n/locales/zh-CN/auth.json
+++ b/frontend/src/i18n/locales/zh-CN/auth.json
@@ -1,0 +1,15 @@
+{
+  "login": {
+    "title": "登录",
+    "submit": "登录",
+    "noAccount": "还没有账号？"
+  },
+  "register": {
+    "title": "注册",
+    "submit": "注册",
+    "hasAccount": "已有账号？"
+  },
+  "email": "电子邮件",
+  "password": "密码",
+  "name": "姓名"
+}

--- a/frontend/src/i18n/locales/zh-CN/categories.json
+++ b/frontend/src/i18n/locales/zh-CN/categories.json
@@ -1,0 +1,12 @@
+{
+  "food": "饮食",
+  "transport": "交通",
+  "entertainment": "娱乐",
+  "shopping": "购物",
+  "housing": "居住",
+  "medical": "医疗",
+  "education": "教育",
+  "other": "其他",
+  "salary": "薪资",
+  "investment": "投资"
+}

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -1,0 +1,17 @@
+{
+  "save": "保存",
+  "cancel": "取消",
+  "confirm": "确认",
+  "delete": "删除",
+  "edit": "编辑",
+  "loading": "加载中...",
+  "error": "发生错误",
+  "retry": "重试",
+  "back": "返回",
+  "next": "下一步",
+  "done": "完成",
+  "close": "关闭",
+  "search": "搜索",
+  "noData": "暂无数据",
+  "currency": "CNY"
+}

--- a/frontend/src/i18n/locales/zh-CN/dashboard.json
+++ b/frontend/src/i18n/locales/zh-CN/dashboard.json
@@ -1,0 +1,10 @@
+{
+  "budgetCard": {
+    "title": "本月预算"
+  },
+  "recentTransactions": "最近交易",
+  "voiceInput": {
+    "placeholder": "说说你花了什么...",
+    "recording": "录音中..."
+  }
+}

--- a/frontend/src/i18n/locales/zh-CN/history.json
+++ b/frontend/src/i18n/locales/zh-CN/history.json
@@ -1,0 +1,10 @@
+{
+  "filter": {
+    "category": "类别",
+    "dateRange": "日期范围",
+    "type": "类型"
+  },
+  "aiQuery": {
+    "placeholder": "用自然语言搜索交易记录..."
+  }
+}

--- a/frontend/src/i18n/locales/zh-CN/settings.json
+++ b/frontend/src/i18n/locales/zh-CN/settings.json
@@ -1,0 +1,14 @@
+{
+  "language": {
+    "title": "语言设置"
+  },
+  "persona": {
+    "title": "AI 人设",
+    "sarcastic": "毒舌",
+    "gentle": "温柔",
+    "guilt_trip": "情勒"
+  },
+  "budget": {
+    "title": "月预算"
+  }
+}

--- a/frontend/src/i18n/locales/zh-CN/stats.json
+++ b/frontend/src/i18n/locales/zh-CN/stats.json
@@ -1,0 +1,12 @@
+{
+  "distribution": {
+    "title": "支出分布"
+  },
+  "period": {
+    "thisMonth": "本月",
+    "lastMonth": "上月",
+    "custom": "自定义"
+  },
+  "totalIncome": "总收入",
+  "totalExpense": "总支出"
+}

--- a/frontend/src/i18n/locales/zh-CN/validation.json
+++ b/frontend/src/i18n/locales/zh-CN/validation.json
@@ -1,0 +1,7 @@
+{
+  "required": "此字段为必填",
+  "invalidEmail": "请输入有效的电子邮件",
+  "passwordTooShort": "密码至少需要 8 个字符",
+  "passwordMismatch": "密码不一致",
+  "invalidAmount": "请输入有效金额"
+}

--- a/frontend/src/i18n/locales/zh-TW/auth.json
+++ b/frontend/src/i18n/locales/zh-TW/auth.json
@@ -1,0 +1,15 @@
+{
+  "login": {
+    "title": "登入",
+    "submit": "登入",
+    "noAccount": "還沒有帳號？"
+  },
+  "register": {
+    "title": "註冊",
+    "submit": "註冊",
+    "hasAccount": "已有帳號？"
+  },
+  "email": "電子郵件",
+  "password": "密碼",
+  "name": "姓名"
+}

--- a/frontend/src/i18n/locales/zh-TW/categories.json
+++ b/frontend/src/i18n/locales/zh-TW/categories.json
@@ -1,0 +1,12 @@
+{
+  "food": "飲食",
+  "transport": "交通",
+  "entertainment": "娛樂",
+  "shopping": "購物",
+  "housing": "居住",
+  "medical": "醫療",
+  "education": "教育",
+  "other": "其他",
+  "salary": "薪資",
+  "investment": "投資"
+}

--- a/frontend/src/i18n/locales/zh-TW/common.json
+++ b/frontend/src/i18n/locales/zh-TW/common.json
@@ -1,0 +1,17 @@
+{
+  "save": "儲存",
+  "cancel": "取消",
+  "confirm": "確認",
+  "delete": "刪除",
+  "edit": "編輯",
+  "loading": "載入中...",
+  "error": "發生錯誤",
+  "retry": "重試",
+  "back": "返回",
+  "next": "下一步",
+  "done": "完成",
+  "close": "關閉",
+  "search": "搜尋",
+  "noData": "暫無資料",
+  "currency": "TWD"
+}

--- a/frontend/src/i18n/locales/zh-TW/dashboard.json
+++ b/frontend/src/i18n/locales/zh-TW/dashboard.json
@@ -1,0 +1,10 @@
+{
+  "budgetCard": {
+    "title": "本月預算"
+  },
+  "recentTransactions": "最近交易",
+  "voiceInput": {
+    "placeholder": "說說你花了什麼...",
+    "recording": "錄音中..."
+  }
+}

--- a/frontend/src/i18n/locales/zh-TW/history.json
+++ b/frontend/src/i18n/locales/zh-TW/history.json
@@ -1,0 +1,10 @@
+{
+  "filter": {
+    "category": "類別",
+    "dateRange": "日期範圍",
+    "type": "類型"
+  },
+  "aiQuery": {
+    "placeholder": "用自然語言搜尋交易記錄..."
+  }
+}

--- a/frontend/src/i18n/locales/zh-TW/settings.json
+++ b/frontend/src/i18n/locales/zh-TW/settings.json
@@ -1,0 +1,14 @@
+{
+  "language": {
+    "title": "語言設定"
+  },
+  "persona": {
+    "title": "AI 人設",
+    "sarcastic": "毒舌",
+    "gentle": "溫柔",
+    "guilt_trip": "情勒"
+  },
+  "budget": {
+    "title": "月預算"
+  }
+}

--- a/frontend/src/i18n/locales/zh-TW/stats.json
+++ b/frontend/src/i18n/locales/zh-TW/stats.json
@@ -1,0 +1,12 @@
+{
+  "distribution": {
+    "title": "支出分布"
+  },
+  "period": {
+    "thisMonth": "本月",
+    "lastMonth": "上月",
+    "custom": "自訂"
+  },
+  "totalIncome": "總收入",
+  "totalExpense": "總支出"
+}

--- a/frontend/src/i18n/locales/zh-TW/validation.json
+++ b/frontend/src/i18n/locales/zh-TW/validation.json
@@ -1,0 +1,7 @@
+{
+  "required": "此欄位為必填",
+  "invalidEmail": "請輸入有效的電子郵件",
+  "passwordTooShort": "密碼至少需要 8 個字元",
+  "passwordMismatch": "密碼不一致",
+  "invalidAmount": "請輸入有效金額"
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8,12 +8,17 @@ const api = axios.create({
   },
 })
 
-// Request interceptor — 可在此加入 auth token
+// Request interceptor — 附加 auth token 與 Accept-Language
 api.interceptors.request.use((config) => {
   const token = localStorage.getItem('auth_token')
   if (token) {
     config.headers.Authorization = `Bearer ${token}`
   }
+
+  // 附加 Accept-Language Header（值為 i18next 當前語言）
+  const lang = localStorage.getItem('i18nextLng') || 'zh-TW'
+  config.headers['Accept-Language'] = lang
+
   return config
 })
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
+import './i18n/index.ts' // i18n 初始化（必須在 App 渲染前執行）
 import './index.css'
 import App from './App.tsx'
 

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,1 +1,2 @@
 import '@testing-library/jest-dom/vitest'
+import '../i18n/index.ts'

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -7,6 +7,7 @@
     "module": "ESNext",
     "types": ["vite/client", "vitest/globals"],
     "skipLibCheck": true,
+    "resolveJsonModule": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
## 變更摘要
在前端建立 i18n 國際化基礎架構：安裝 react-i18next、建立 8 個 namespace x 4 語言的翻譯資源檔、實作 useLocaleFormatter hook、更新 Axios 自動附加 Accept-Language Header，為後續 UI 多語化（T-605）提供基礎。

## 關聯 Issue
Closes #140

## 變更清單
- 安裝 `react-i18next`、`i18next`、`i18next-browser-languagedetector`
- 建立 `frontend/src/i18n/index.ts`（i18next 初始化：語言偵測順序 localStorage → navigator → fallback zh-TW）
- 建立 32 個翻譯檔（4 語言 x 8 namespace：common, dashboard, stats, history, settings, auth, categories, validation）
- 建立 `frontend/src/hooks/useLocaleFormatter.ts`（formatNumber / formatCurrency / formatDate）
- 更新 `frontend/src/lib/api.ts`：Axios interceptor 自動附加 `Accept-Language` Header
- 更新 `frontend/src/main.tsx`：匯入 i18n 初始化
- 更新 `frontend/tsconfig.app.json`：啟用 `resolveJsonModule`
- 更新 `frontend/src/test/setup.ts`：測試環境 i18n 初始化

## 測試結果
- 單元測試：✅ 136/136 全部通過
- TypeScript build：✅ 編譯成功
- 本地驗證：✅ Vibe Check 通過