### PR TITLE
feat: add language selector to Login and Register pages

### DIFF
--- a/frontend/src/components/LanguageSelector.tsx
+++ b/frontend/src/components/LanguageSelector.tsx
@@ -1,0 +1,90 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { SupportedLanguage } from '../i18n/index'
+
+/** 語言選項（使用原生語言名稱，不需翻譯） */
+const LANGUAGE_OPTIONS: { value: SupportedLanguage; label: string }[] = [
+  { value: 'zh-TW', label: '繁體中文' },
+  { value: 'en', label: 'English' },
+  { value: 'zh-CN', label: '简体中文' },
+  { value: 'vi', label: 'Tiếng Việt' },
+]
+
+/**
+ * 語言選擇器 — 一個小型的 globe icon 下拉選單，
+ * 適用於 Login / Register 等未登入頁面。
+ */
+function LanguageSelector() {
+  const { i18n } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const currentLang = i18n.language as SupportedLanguage
+  const currentLabel = LANGUAGE_OPTIONS.find((o) => o.value === currentLang)?.label ?? '繁體中文'
+
+  const handleSelect = useCallback(
+    (lang: SupportedLanguage) => {
+      i18n.changeLanguage(lang)
+      setOpen(false)
+    },
+    [i18n],
+  )
+
+  // 點擊外部關閉下拉選單
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    if (open) {
+      document.addEventListener('mousedown', handleClickOutside)
+    }
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [open])
+
+  return (
+    <div ref={containerRef} className="relative inline-block" data-testid="language-selector">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-xs px-md py-xs rounded-md text-caption text-text-secondary hover:text-text-primary hover:bg-surface transition-colors"
+        aria-label="Switch language"
+        aria-expanded={open}
+        aria-haspopup="listbox"
+      >
+        <span className="text-base" aria-hidden="true">🌐</span>
+        <span>{currentLabel}</span>
+        <span className="text-[10px] ml-[2px]" aria-hidden="true">{open ? '▲' : '▼'}</span>
+      </button>
+
+      {open && (
+        <ul
+          role="listbox"
+          className="absolute right-0 mt-xs w-36 bg-surface rounded-md shadow-card border border-border py-xs z-50"
+        >
+          {LANGUAGE_OPTIONS.map((opt) => {
+            const selected = currentLang === opt.value
+            return (
+              <li key={opt.value} role="option" aria-selected={selected}>
+                <button
+                  type="button"
+                  onClick={() => handleSelect(opt.value)}
+                  className={`w-full text-left px-md py-sm text-caption transition-colors ${
+                    selected
+                      ? 'text-primary font-semibold bg-primary-light'
+                      : 'text-text-primary hover:bg-bg'
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+export default LanguageSelector

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Link, useNavigate, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useAuthStore } from '../stores/authStore.ts'
+import LanguageSelector from '../components/LanguageSelector.tsx'
 
 function isValidEmail(email: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
@@ -52,7 +53,10 @@ function LoginPage() {
   }
 
   return (
-    <div className="min-h-svh flex flex-col items-center justify-center p-2xl bg-bg">
+    <div className="min-h-svh flex flex-col items-center justify-center p-2xl bg-bg relative">
+      <div className="absolute top-md right-md">
+        <LanguageSelector />
+      </div>
       <div className="w-16 h-16 bg-primary rounded-lg flex items-center justify-center text-3xl mb-lg">
         💰
       </div>

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useAuthStore } from '../stores/authStore.ts'
+import LanguageSelector from '../components/LanguageSelector.tsx'
 
 function isValidEmail(email: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
@@ -72,7 +73,10 @@ function RegisterPage() {
   }
 
   return (
-    <div className="min-h-svh flex flex-col items-center justify-center p-2xl bg-bg">
+    <div className="min-h-svh flex flex-col items-center justify-center p-2xl bg-bg relative">
+      <div className="absolute top-md right-md">
+        <LanguageSelector />
+      </div>
       <div className="w-16 h-16 bg-primary rounded-lg flex items-center justify-center text-3xl mb-lg">
         💰
       </div>


### PR DESCRIPTION
## 變更摘要
在 Login 和 Register 頁面右上角新增語言選擇器，讓未登入的使用者也能切換 UI 語言。

## 關聯 Issue
Closes #154

## 變更清單
- 新增 `LanguageSelector` 可重用元件（globe icon + 下拉選單）
- 在 `LoginPage` 右上角加入 `LanguageSelector`
- 在 `RegisterPage` 右上角加入 `LanguageSelector`
- 使用原生語言名稱（繁體中文、English、简体中文、Tiếng Việt），無需額外翻譯 key
- 透過 `i18n.changeLanguage()` 即時切換語言，並自動由 i18next 寫入 localStorage 持久化

## 測試結果
- 單元測試：✅ 全部通過（100/100）
- Build：✅ 通過
- 本地驗證：✅ Vibe Check 通過