### PR TITLE
fix: AI parsed Note field follows user's language setting

### DIFF
--- a/backend/src/__tests__/i18nPrompts.test.ts
+++ b/backend/src/__tests__/i18nPrompts.test.ts
@@ -137,6 +137,64 @@ describe('T-603: AI Prompt i18n', () => {
       expect(prompt).toContain('yesterday');
       expect(prompt).toContain('hôm qua');
     });
+
+    it('should instruct note field to use zh-TW by default', () => {
+      const prompt = buildDataExtractorPrompt({
+        rawText: 'test',
+        categories: ['food'],
+        currentDateTime: '2026年3月22日',
+      });
+      expect(prompt).toContain('繁體中文');
+      expect(prompt).toMatch(/note.*必須使用繁體中文撰寫/);
+    });
+
+    it('should instruct note field to use English when targetLanguage is "en"', () => {
+      const prompt = buildDataExtractorPrompt({
+        rawText: 'bought a t-shirt',
+        categories: ['daily'],
+        currentDateTime: '2026年3月22日',
+        targetLanguage: 'en',
+      });
+      expect(prompt).toMatch(/note.*必須使用English撰寫/);
+    });
+
+    it('should instruct note field to use zh-CN when targetLanguage is "zh-CN"', () => {
+      const prompt = buildDataExtractorPrompt({
+        rawText: '买了一件衣服',
+        categories: ['daily'],
+        currentDateTime: '2026年3月22日',
+        targetLanguage: 'zh-CN',
+      });
+      expect(prompt).toMatch(/note.*必須使用简体中文撰寫/);
+    });
+
+    it('should instruct note field to use Vietnamese when targetLanguage is "vi"', () => {
+      const prompt = buildDataExtractorPrompt({
+        rawText: 'mua áo',
+        categories: ['daily'],
+        currentDateTime: '2026年3月22日',
+        targetLanguage: 'vi',
+      });
+      expect(prompt).toMatch(/note.*必須使用Tiếng Việt撰寫/);
+    });
+
+    it('should instruct note field in all supported languages', () => {
+      const langMap: Record<string, string> = {
+        'zh-TW': '繁體中文',
+        'en': 'English',
+        'zh-CN': '简体中文',
+        'vi': 'Tiếng Việt',
+      };
+      for (const [lang, name] of Object.entries(langMap)) {
+        const prompt = buildDataExtractorPrompt({
+          rawText: 'test',
+          categories: ['food'],
+          currentDateTime: '2026年3月22日',
+          targetLanguage: lang,
+        });
+        expect(prompt).toContain(`必須使用${name}撰寫`);
+      }
+    });
   });
 
   describe('intentDetectorPrompt', () => {

--- a/backend/src/prompts/dataExtractorPrompt.ts
+++ b/backend/src/prompts/dataExtractorPrompt.ts
@@ -1,5 +1,16 @@
 import { DataExtractorInput } from '../types/llm';
 
+const LANGUAGE_NAMES: Record<string, string> = {
+  'zh-TW': '繁體中文',
+  'en': 'English',
+  'zh-CN': '简体中文',
+  'vi': 'Tiếng Việt',
+};
+
+function getLanguageName(lang: string): string {
+  return LANGUAGE_NAMES[lang] || LANGUAGE_NAMES['zh-TW'];
+}
+
 export function buildDataExtractorPrompt(input: DataExtractorInput): string {
   // Build categorized list if available, otherwise use flat list
   // Category name mapping for display in prompt
@@ -87,7 +98,7 @@ ${input.aiInstructions ? `\n## 使用者自訂指示（請優先遵從）\n${inp
 | catalogtype_confidence | number (0-1) | 類別匹配度：所選 category 與使用者輸入內容的語義匹配程度。1.0=完全匹配（如「拉麵」→food），0.5=勉強匹配（如「飛行傘」→entertainment），0=完全不匹配 |
 | is_new_category | boolean | **強制規則：catalogtype_confidence < 0.8 時必須為 true**（見規則5） |
 | suggested_category | string 或 null | is_new_category 為 true 時，填入建議的中文類別名稱 |
-| note | string 或 null | 備註：無法歸入結構化欄位的有價值上下文（店名、地點、對象、購買原因等），不超過100字，若已完整涵蓋則為 null |
+| note | string 或 null | 備註：無法歸入結構化欄位的有價值上下文（店名、地點、對象、購買原因等），不超過100字，若已完整涵蓋則為 null。**必須使用${getLanguageName(input.targetLanguage || 'zh-TW')}撰寫** |
 
 JSON 結構：
 {

--- a/backend/src/services/llmService.ts
+++ b/backend/src/services/llmService.ts
@@ -109,6 +109,7 @@ export async function parseTransaction(
     categoriesWithType,
     currentDateTime,
     aiInstructions: user.aiInstructions,
+    targetLanguage,
   });
 
 

--- a/backend/src/types/llm.ts
+++ b/backend/src/types/llm.ts
@@ -42,6 +42,7 @@ export interface DataExtractorInput {
   categoriesWithType?: CategoryWithType[];
   currentDateTime: string;
   aiInstructions?: string | null;
+  targetLanguage?: string;
 }
 
 export interface RecentTransaction {


### PR DESCRIPTION
## 變更摘要
修正 AI 資料萃取器產生的 note 欄位未遵循使用者語言設定的問題。當使用者切換至英文並使用英文語音輸入記帳時，note 欄位現在會以使用者設定的語言輸出，而非預設中文。

## 關聯 Issue
Closes #153

## 變更清單
- `backend/src/types/llm.ts`：`DataExtractorInput` 介面新增 `targetLanguage` 可選欄位
- `backend/src/prompts/dataExtractorPrompt.ts`：新增語言名稱對照表，在 note 欄位說明中加入「必須使用{目標語言}撰寫」指令
- `backend/src/services/llmService.ts`：呼叫 `buildDataExtractorPrompt` 時傳入 `targetLanguage`
- `backend/src/__tests__/i18nPrompts.test.ts`：新增 6 個測試案例，驗證 note 欄位語言指令涵蓋所有支援語言（zh-TW、en、zh-CN、vi）

## 測試結果
- 單元測試：✅ 全部通過（276/276）
- 本地驗證：✅ Vibe Check 通過