### PR TITLE
fix: preserve language preference after login/register

### DIFF
--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -60,11 +60,24 @@ export const useAuthStore = create<AuthState>((set) => ({
       localStorage.setItem('auth_user', JSON.stringify(user))
       set({ user, token, loading: false, error: null })
 
-      // Sync language from user profile (DB > localStorage > browser)
+      // Sync language: DB value wins if present; otherwise keep current i18n language and save it to DB
+      const supportedLanguages = ['zh-TW', 'en', 'zh-CN', 'vi']
       const userLang = (response.data.data.user as { language?: string }).language
-      if (userLang && ['zh-TW', 'en', 'zh-CN', 'vi'].includes(userLang)) {
+      if (userLang && supportedLanguages.includes(userLang)) {
+        // DB has a valid language preference — apply it
         await i18n.changeLanguage(userLang as SupportedLanguage)
         localStorage.setItem('i18nextLng', userLang)
+      } else {
+        // DB has no language preference — keep current i18n language (set by LanguageSelector)
+        // and sync it to DB so future logins remember it
+        const currentLang = i18n.language as SupportedLanguage
+        if (currentLang && supportedLanguages.includes(currentLang)) {
+          try {
+            await api.put('/users/profile', { language: currentLang })
+          } catch {
+            // Non-critical: don't block login if language sync fails
+          }
+        }
       }
     } catch (err: unknown) {
       const message = extractErrorMessage(err, i18n.t('auth:login.failed'))
@@ -85,6 +98,17 @@ export const useAuthStore = create<AuthState>((set) => ({
       localStorage.setItem('auth_token', token)
       localStorage.setItem('auth_user', JSON.stringify(user))
       set({ user, token, loading: false, error: null })
+
+      // After registration, sync current i18n language (set by LanguageSelector) to DB
+      const supportedLanguages = ['zh-TW', 'en', 'zh-CN', 'vi']
+      const currentLang = i18n.language as SupportedLanguage
+      if (currentLang && supportedLanguages.includes(currentLang)) {
+        try {
+          await api.put('/users/profile', { language: currentLang })
+        } catch {
+          // Non-critical: don't block registration if language sync fails
+        }
+      }
     } catch (err: unknown) {
       const message = extractErrorMessage(err, i18n.t('auth:register.failed'))
       set({ loading: false, error: message })


### PR DESCRIPTION
## Summary
- **Login**: When DB `user.language` is null/empty, the current i18n language (set by LanguageSelector on the login page) is now preserved instead of being silently ignored. The chosen language is also synced TO the DB for future logins.
- **Register**: After successful registration, the current i18n language is saved to the user profile in the DB.
- When DB has a valid language preference, it is still respected (DB wins).

## Root Cause
The login flow only handled the case where DB had a valid language — it applied it. But when DB had no language (null/empty, typical for new users), nothing happened, and a subsequent `fetchProfile` call could overwrite the user's selection. The register flow never synced language at all.

## Test plan
- [ ] Select English on login page, log in with a new account (no DB language) → homepage should stay in English
- [ ] Select Vietnamese on register page, register → homepage should be in Vietnamese
- [ ] Log out, log back in → language should persist (now saved in DB)
- [ ] Existing user with DB language set → DB language should still win on login

Closes #157