### PR TITLE
feat(backend): AI query range limit with persona response

### DIFF
--- a/backend/src/services/llmService.test.ts
+++ b/backend/src/services/llmService.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { getQueryRangeTooLargeMessage } from './llmService';
+
+describe('getQueryRangeTooLargeMessage', () => {
+  describe('zh-TW locale', () => {
+    it('should return sarcastic message for sarcastic persona', () => {
+      const msg = getQueryRangeTooLargeMessage('sarcastic', 'zh-TW');
+      expect(msg).toContain('半年的帳');
+      expect(msg).toContain('超級電腦');
+    });
+
+    it('should return gentle message for gentle persona', () => {
+      const msg = getQueryRangeTooLargeMessage('gentle', 'zh-TW');
+      expect(msg).toContain('數據好多');
+      expect(msg).toContain('💕');
+    });
+
+    it('should return guilt_trip message for guilt_trip persona', () => {
+      const msg = getQueryRangeTooLargeMessage('guilt_trip', 'zh-TW');
+      expect(msg).toContain('不在乎我的感受');
+      expect(msg).toContain('🥺');
+    });
+  });
+
+  describe('en locale', () => {
+    it('should return sarcastic message for sarcastic persona', () => {
+      const msg = getQueryRangeTooLargeMessage('sarcastic', 'en');
+      expect(msg).toContain('Six months');
+      expect(msg).toContain('supercomputer');
+    });
+
+    it('should return gentle message for gentle persona', () => {
+      const msg = getQueryRangeTooLargeMessage('gentle', 'en');
+      expect(msg).toContain('shorter time period');
+      expect(msg).toContain('💕');
+    });
+
+    it('should return guilt_trip message for guilt_trip persona', () => {
+      const msg = getQueryRangeTooLargeMessage('guilt_trip', 'en');
+      expect(msg).toContain('care about me');
+      expect(msg).toContain('🥺');
+    });
+  });
+
+  describe('language fallback', () => {
+    it('should use en messages for en-US', () => {
+      const msg = getQueryRangeTooLargeMessage('sarcastic', 'en-US');
+      expect(msg).toContain('Six months');
+    });
+
+    it('should use en messages for en-GB', () => {
+      const msg = getQueryRangeTooLargeMessage('gentle', 'en-GB');
+      expect(msg).toContain('shorter time period');
+    });
+
+    it('should fallback to zh-TW for unknown languages', () => {
+      const msg = getQueryRangeTooLargeMessage('sarcastic', 'ja');
+      expect(msg).toContain('半年的帳');
+    });
+  });
+});

--- a/backend/src/services/llmService.ts
+++ b/backend/src/services/llmService.ts
@@ -329,6 +329,25 @@ export async function queryTransactions(
   // 階段 1：時間範圍解析
   const timeRange = await parseTimeRange(queryText, currentDateTime, apiKey, provider, taipeiDate);
 
+  // 階段 1.5：檢查查詢範圍是否超過 180 天（6 個月）
+  const rangeStartDate = new Date(timeRange.start_date);
+  const rangeEndDate = new Date(timeRange.end_date);
+  const rangeDays = Math.ceil((rangeEndDate.getTime() - rangeStartDate.getTime()) / (1000 * 60 * 60 * 24));
+
+  if (rangeDays > 180) {
+    const personaMessage = getQueryRangeTooLargeMessage(persona, userLanguage);
+    return {
+      summary: {
+        text: personaMessage,
+        emotion_tag: 'neutral',
+        total_amount: 0,
+        match_count: 0,
+      },
+      matched_transaction_ids: [],
+      time_range: timeRange,
+    };
+  }
+
   // 階段 2a：查詢 DB 取得交易記錄
   const startDate = new Date(timeRange.start_date);
   const endDate = new Date(timeRange.end_date);
@@ -376,6 +395,27 @@ export async function queryTransactions(
     matched_transaction_ids: matchResult.matched_ids,
     time_range: timeRange,
   };
+}
+
+// ─── 查詢範圍過大時的人設回應 ───
+
+const QUERY_RANGE_TOO_LARGE_MESSAGES: Record<string, Record<Persona, string>> = {
+  'zh-TW': {
+    sarcastic: '半年的帳？你是要我加班到死嗎？把範圍縮小一點再來，我又不是超級電腦。',
+    gentle: '這段時間的數據好多呢～可以試試查詢某個月份嗎？這樣我能給你更精確的分析喔 💕',
+    guilt_trip: '你要我一次看這麼多數據...是不是不在乎我的感受？拜託一次查一個月好不好嘛 🥺',
+  },
+  en: {
+    sarcastic: "Six months of expenses? Am I your personal accountant? Narrow it down, I'm not a supercomputer.",
+    gentle: "That's a lot of data to go through~ Could you try a shorter time period? I can give you much better insights that way 💕",
+    guilt_trip: 'You want me to look through all that data at once... Do you even care about me? Please try one month at a time 🥺',
+  },
+};
+
+export function getQueryRangeTooLargeMessage(persona: Persona, language: string): string {
+  const lang = language.startsWith('en') ? 'en' : 'zh-TW';
+  const messages = QUERY_RANGE_TOO_LARGE_MESSAGES[lang] || QUERY_RANGE_TOO_LARGE_MESSAGES['zh-TW'];
+  return messages[persona] || messages['sarcastic'];
 }
 
 async function parseTimeRange(

--- a/backend/src/services/llmService.ts
+++ b/backend/src/services/llmService.ts
@@ -410,10 +410,21 @@ const QUERY_RANGE_TOO_LARGE_MESSAGES: Record<string, Record<Persona, string>> = 
     gentle: "That's a lot of data to go through~ Could you try a shorter time period? I can give you much better insights that way 💕",
     guilt_trip: 'You want me to look through all that data at once... Do you even care about me? Please try one month at a time 🥺',
   },
+  'zh-CN': {
+    sarcastic: '半年的账？你是要我加班到死吗？把范围缩小一点再来，我又不是超级电脑。',
+    gentle: '这段时间的数据好多呢～可以试试查询某个月份吗？这样我能给你更精确的分析哦 💕',
+    guilt_trip: '你要我一次看这么多数据...是不是不在乎我的感受？拜托一次查一个月好不好嘛 🥺',
+  },
+  vi: {
+    sarcastic: 'Nửa năm chi tiêu? Tôi là kế toán riêng của bạn à? Thu hẹp phạm vi lại đi, tôi không phải siêu máy tính đâu.',
+    gentle: 'Dữ liệu nhiều quá đi~ Bạn thử hỏi theo từng tháng được không? Như vậy mình phân tích chính xác hơn nè 💕',
+    guilt_trip: 'Bạn muốn mình xem nhiều dữ liệu vậy sao... Bạn có quan tâm mình không? Hỏi từng tháng thôi mà 🥺',
+  },
 };
 
 export function getQueryRangeTooLargeMessage(persona: Persona, language: string): string {
-  const lang = language.startsWith('en') ? 'en' : 'zh-TW';
+  const langMap: Record<string, string> = { 'zh-TW': 'zh-TW', 'zh-CN': 'zh-CN', en: 'en', vi: 'vi' };
+  const lang = langMap[language] || (language.startsWith('en') ? 'en' : language.startsWith('zh') ? 'zh-TW' : 'zh-TW');
   const messages = QUERY_RANGE_TOO_LARGE_MESSAGES[lang] || QUERY_RANGE_TOO_LARGE_MESSAGES['zh-TW'];
   return messages[persona] || messages['sarcastic'];
 }


### PR DESCRIPTION
## Summary
- When AI semantic query date range exceeds 180 days (6 months), the backend now returns a persona-styled message instead of sending hundreds of transactions to the LLM (which caused GPT-4o-mini to return empty results)
- After `parseTimeRange`, calculates range in days; if > 180, skips `matchTransactions` entirely and returns early with hardcoded persona message
- Supports all 3 personas (sarcastic, gentle, guilt_trip) in both zh-TW and en locales

## Test plan
- [x] Unit tests for `getQueryRangeTooLargeMessage` covering all 3 personas x 2 languages + language fallback (9 tests, all passing)
- [ ] Manual test: query "去年到今年的花費" should return persona message instead of empty results

Closes #163