### PR TITLE
feat: change CategoryBudget unique constraint to userId+type+category

### DIFF
--- a/backend/prisma/migrations/20260322000000_change_category_unique_constraint/migration.sql
+++ b/backend/prisma/migrations/20260322000000_change_category_unique_constraint/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX "category_budgets_user_id_category_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "category_budgets_user_id_type_category_key" ON "category_budgets"("user_id", "type", "category");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -43,7 +43,7 @@ model CategoryBudget {
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@unique([userId, category])
+  @@unique([userId, type, category])
   @@index([userId])
   @@map("category_budgets")
 }

--- a/backend/prisma/seed-demo.js
+++ b/backend/prisma/seed-demo.js
@@ -55,7 +55,7 @@ async function main() {
 
   for (const cat of categories) {
     await p.categoryBudget.upsert({
-      where: { userId_category: { userId, category: cat.category } },
+      where: { userId_type_category: { userId, type: cat.type, category: cat.category } },
       update: {},
       create: {
         userId,

--- a/backend/src/routes/budgetRoutes.test.ts
+++ b/backend/src/routes/budgetRoutes.test.ts
@@ -307,14 +307,14 @@ describe('Budget Routes', () => {
       });
 
       const res = await request(app)
-        .delete('/api/v1/budget/categories/snacks');
+        .delete('/api/v1/budget/categories/snacks?type=expense');
 
       expect(res.status).toBe(200);
       expect(res.body.message).toContain('刪除成功');
 
       // Verify transactions were reassigned to "other"
       expect(mockedPrisma.transaction.updateMany).toHaveBeenCalledWith({
-        where: { userId: 'test-user-id', category: 'snacks' },
+        where: { userId: 'test-user-id', category: 'snacks', type: 'expense' },
         data: { category: 'other' },
       });
     });
@@ -332,7 +332,7 @@ describe('Budget Routes', () => {
       });
 
       const res = await request(app)
-        .delete('/api/v1/budget/categories/food');
+        .delete('/api/v1/budget/categories/food?type=expense');
 
       expect(res.status).toBe(400);
       expect(res.body.message).toContain('系統預設');
@@ -342,7 +342,7 @@ describe('Budget Routes', () => {
       mockedPrisma.categoryBudget.findUnique.mockResolvedValue(null);
 
       const res = await request(app)
-        .delete('/api/v1/budget/categories/nonexistent');
+        .delete('/api/v1/budget/categories/nonexistent?type=expense');
 
       expect(res.status).toBe(404);
     });

--- a/backend/src/routes/budgetRoutes.ts
+++ b/backend/src/routes/budgetRoutes.ts
@@ -35,7 +35,7 @@ router.post('/categories', authMiddleware, async (req: AuthRequest, res: Respons
 
     // Check duplicate
     const existing = await prisma.categoryBudget.findUnique({
-      where: { userId_category: { userId, category: trimmed } },
+      where: { userId_type_category: { userId, type: categoryType, category: trimmed } },
     });
 
     if (existing) {
@@ -119,8 +119,9 @@ router.put('/categories', authMiddleware, async (req: AuthRequest, res: Response
         throw createI18nError('category_budget_limit_invalid', 400, undefined, { category: item.category });
       }
 
+      const itemType = item.type || 'expense';
       const existing = await prisma.categoryBudget.findUnique({
-        where: { userId_category: { userId, category: item.category } },
+        where: { userId_type_category: { userId, type: itemType, category: item.category } },
       });
 
       if (!existing) {
@@ -128,7 +129,7 @@ router.put('/categories', authMiddleware, async (req: AuthRequest, res: Response
       }
 
       const updated = await prisma.categoryBudget.update({
-        where: { userId_category: { userId, category: item.category } },
+        where: { userId_type_category: { userId, type: itemType, category: item.category } },
         data: { budgetLimit: Number(item.budget_limit) },
       });
 
@@ -156,9 +157,14 @@ router.delete('/categories/:category', authMiddleware, async (req: AuthRequest, 
   try {
     const userId = req.userId!;
     const category = req.params.category as string;
+    const type = (req.query.type as string) || 'expense';
+
+    if (type !== 'income' && type !== 'expense') {
+      throw createI18nError('category_type_invalid', 400);
+    }
 
     const existing = await prisma.categoryBudget.findUnique({
-      where: { userId_category: { userId, category } },
+      where: { userId_type_category: { userId, type, category } },
     });
 
     if (!existing) {
@@ -171,13 +177,13 @@ router.delete('/categories/:category', authMiddleware, async (req: AuthRequest, 
 
     // Update related transactions to "other"
     await prisma.transaction.updateMany({
-      where: { userId, category },
-      data: { category: 'other' },
+      where: { userId, category, type },
+      data: { category: type === 'income' ? 'other_income' : 'other' },
     });
 
     // Delete the category
     await prisma.categoryBudget.delete({
-      where: { userId_category: { userId, category } },
+      where: { userId_type_category: { userId, type, category } },
     });
 
     const response: ApiResponse<{ category: string }> = {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -160,11 +160,11 @@ function SettingsPage() {
     }
   }, [newCategoryName, newCategoryType, createCategoryAction])
 
-  const handleDeleteCategory = useCallback(async (category: string) => {
+  const handleDeleteCategory = useCallback(async (category: string, type: 'income' | 'expense') => {
     const name = getCategoryName(category)
     if (!window.confirm(t('categories.deleteConfirm', { name }))) return
     try {
-      await deleteCategoryAction(category)
+      await deleteCategoryAction(category, type)
     } catch {
       // Error handled by store
     }
@@ -412,7 +412,7 @@ function SettingsPage() {
               <span key={c.category} className={`px-md py-xs rounded-md text-caption ${getCategoryTypeColorClass('expense')} bg-[#FFF0F0] inline-flex items-center gap-xs`}>
                 {getCategoryName(c.category)}
                 {c.isCustom && (
-                  <button type="button" onClick={() => handleDeleteCategory(c.category)}
+                  <button type="button" onClick={() => handleDeleteCategory(c.category, 'expense')}
                     className="ml-xs text-danger hover:text-red-700 font-bold leading-none"
                     aria-label={t('categories.deleteCategoryLabel', { name: getCategoryName(c.category) })}>
                     ✕
@@ -430,7 +430,7 @@ function SettingsPage() {
               <span key={c.category} className={`px-md py-xs rounded-md text-caption ${getCategoryTypeColorClass('income')} bg-[#F0FFF0] inline-flex items-center gap-xs`}>
                 {getCategoryName(c.category)}
                 {c.isCustom && (
-                  <button type="button" onClick={() => handleDeleteCategory(c.category)}
+                  <button type="button" onClick={() => handleDeleteCategory(c.category, 'income')}
                     className="ml-xs text-danger hover:text-red-700 font-bold leading-none"
                     aria-label={t('categories.deleteCategoryLabel', { name: getCategoryName(c.category) })}>
                     ✕

--- a/frontend/src/stores/dashboardStore.ts
+++ b/frontend/src/stores/dashboardStore.ts
@@ -109,7 +109,7 @@ interface DashboardState {
     feedback?: AIFeedbackContent
   }) => Promise<void>
   createCategory: (category: string, type?: 'income' | 'expense') => Promise<void>
-  deleteCategory: (category: string) => Promise<void>
+  deleteCategory: (category: string, type?: 'income' | 'expense') => Promise<void>
   updateTransaction: (id: string, data: { type?: 'income' | 'expense'; amount: number; category: string; merchant: string; date: string; note?: string }) => Promise<void>
   deleteTransaction: (id: string) => Promise<void>
   fetchBudgetSummary: () => Promise<void>
@@ -303,9 +303,10 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
     }
   },
 
-  deleteCategory: async (category: string) => {
+  deleteCategory: async (category: string, type?: 'income' | 'expense') => {
     try {
-      await api.delete(`/budget/categories/${encodeURIComponent(category)}`)
+      const categoryType = type || 'expense'
+      await api.delete(`/budget/categories/${encodeURIComponent(category)}`, { params: { type: categoryType } })
       await get().fetchCategories()
     } catch (err: unknown) {
       const message =


### PR DESCRIPTION
## Summary
- Change `CategoryBudget` unique constraint from `@@unique([userId, category])` to `@@unique([userId, type, category])` to allow same-name categories across different types (e.g., income/還款 + expense/還款)
- Update all backend routes (POST/PUT/DELETE) to use the new `userId_type_category` compound key
- DELETE endpoint now accepts `type` query parameter to correctly identify which category to delete
- Frontend `deleteCategory` passes `type` parameter; SettingsPage buttons pass the correct type (`'expense'` or `'income'`)
- Migration drops old unique index and creates new one; seed script updated accordingly

## Test plan
- [x] All 289 backend tests pass (`npx vitest run`)
- [x] Frontend builds successfully (`npm run build`)
- [ ] Manual test: create two categories with the same name but different types
- [ ] Manual test: delete a custom income category and verify it works
- [ ] Manual test: delete a custom expense category and verify it works

Closes #166