### PR TITLE
fix: category filter distinguishes same-name categories by type

### DIFF
--- a/backend/src/services/transactionService.ts
+++ b/backend/src/services/transactionService.ts
@@ -58,6 +58,10 @@ export async function listTransactions(userId: string, input: ListTransactionsIn
     where.category = input.category;
   }
 
+  if (input.type) {
+    where.type = input.type;
+  }
+
   if (input.start_date || input.end_date) {
     const dateFilter: Record<string, Date> = {};
     if (input.start_date) dateFilter.gte = new Date(input.start_date);

--- a/backend/src/validators/transactionValidators.ts
+++ b/backend/src/validators/transactionValidators.ts
@@ -38,6 +38,7 @@ export const listTransactionsSchema = z.object({
   page: z.coerce.number().int().min(1).default(1),
   limit: z.coerce.number().int().min(1).max(100).default(20),
   category: z.string().optional(),
+  type: z.enum(['income', 'expense']).optional(),
   start_date: z
     .string()
     .regex(/^\d{4}-\d{2}-\d{2}$/, '日期格式須為 YYYY-MM-DD')

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -90,7 +90,14 @@ function HistoryPage() {
   const handleCategoryChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
       clearAIQuery()
-      setFilters({ category: e.target.value })
+      const value = e.target.value
+      if (value && value.includes(':')) {
+        const [type, ...categoryParts] = value.split(':')
+        const category = categoryParts.join(':')
+        setFilters({ category, type })
+      } else {
+        setFilters({ category: '', type: '' })
+      }
       setTimeout(() => useHistoryStore.getState().fetchTransactions(true), 0)
     },
     [setFilters, clearAIQuery]
@@ -146,7 +153,7 @@ function HistoryPage() {
 
   const grouped = useMemo(() => groupByDate(transactions), [transactions])
 
-  const hasActiveFilters = filters.category || filters.startDate || filters.endDate || aiQueryResult
+  const hasActiveFilters = filters.category || filters.type || filters.startDate || filters.endDate || aiQueryResult
 
   return (
     <div className="p-2xl pb-32">
@@ -188,7 +195,7 @@ function HistoryPage() {
           </div>
 
           <select
-            value={filters.category}
+            value={filters.type && filters.category ? `${filters.type}:${filters.category}` : ''}
             onChange={handleCategoryChange}
             className="px-lg py-sm bg-bg rounded-xl text-caption text-text-secondary border-0 outline-none cursor-pointer"
             aria-label={t('history:filter.categoryFilter')}
@@ -198,7 +205,7 @@ function HistoryPage() {
             {expenseCategories.length > 0 && (
               <optgroup label={t('common:expense')}>
                 {expenseCategories.map((c) => (
-                  <option key={c.category} value={c.category}>
+                  <option key={`expense:${c.category}`} value={`expense:${c.category}`}>
                     {(CATEGORY_ICONS[c.category] ?? '📦') + ' ' + getCategoryName(c.category)}
                   </option>
                 ))}
@@ -207,7 +214,7 @@ function HistoryPage() {
             {incomeCategories.length > 0 && (
               <optgroup label={t('common:income')}>
                 {incomeCategories.map((c) => (
-                  <option key={c.category} value={c.category}>
+                  <option key={`income:${c.category}`} value={`income:${c.category}`}>
                     {(CATEGORY_ICONS[c.category] ?? '📦') + ' ' + getCategoryName(c.category)}
                   </option>
                 ))}

--- a/frontend/src/stores/historyStore.ts
+++ b/frontend/src/stores/historyStore.ts
@@ -5,6 +5,7 @@ import { useSettingsStore } from './settingsStore'
 
 export interface HistoryFilters {
   category: string
+  type: string
   startDate: string
   endDate: string
 }
@@ -64,6 +65,7 @@ const PAGE_SIZE = 20
 
 const defaultFilters: HistoryFilters = {
   category: '',
+  type: '',
   startDate: '',
   endDate: '',
 }
@@ -116,6 +118,7 @@ export const useHistoryStore = create<HistoryState>((set, get) => ({
         sort: 'desc',
       }
       if (state.filters.category) params.category = state.filters.category
+      if (state.filters.type) params.type = state.filters.type
       if (state.filters.startDate) params.start_date = state.filters.startDate
       if (state.filters.endDate) params.end_date = state.filters.endDate
 

--- a/frontend/src/test/HistoryPage.test.tsx
+++ b/frontend/src/test/HistoryPage.test.tsx
@@ -62,7 +62,7 @@ describe('HistoryPage', () => {
   beforeEach(() => {
     setStoreState({
       transactions: [],
-      filters: { category: '', startDate: '', endDate: '' },
+      filters: { category: '', type: '', startDate: '', endDate: '' },
       page: 1,
       hasMore: true,
       isLoading: false,
@@ -163,7 +163,7 @@ describe('HistoryPage', () => {
       transactions: [],
       hasMore: false,
       isLoading: false,
-      filters: { category: 'food', startDate: '', endDate: '' },
+      filters: { category: 'food', type: 'expense', startDate: '', endDate: '' },
     })
     render(<HistoryPage />)
     expect(screen.getByTestId('reset-filters-btn')).toBeInTheDocument()
@@ -174,7 +174,7 @@ describe('HistoryPage', () => {
       transactions: [],
       hasMore: false,
       isLoading: false,
-      filters: { category: '', startDate: '', endDate: '' },
+      filters: { category: '', type: '', startDate: '', endDate: '' },
     })
     render(<HistoryPage />)
     expect(screen.queryByTestId('reset-filters-btn')).not.toBeInTheDocument()
@@ -185,7 +185,7 @@ describe('TransactionItem interactions', () => {
   beforeEach(() => {
     setStoreState({
       transactions: mockTransactions,
-      filters: { category: '', startDate: '', endDate: '' },
+      filters: { category: '', type: '', startDate: '', endDate: '' },
       page: 1,
       hasMore: false,
       isLoading: false,


### PR DESCRIPTION
## Summary
- History page category filter now includes transaction type (income/expense) alongside category name
- Fixes the issue where filtering by expense/還款 also showed income/還款 records
- Backend GET /transactions now supports an optional `type` query parameter

## Changes
- **Backend validator** (`transactionValidators.ts`): Added optional `type` enum field to `listTransactionsSchema`
- **Backend service** (`transactionService.ts`): Added `type` filter to the Prisma where clause
- **Frontend store** (`historyStore.ts`): Added `type` to `HistoryFilters` interface and passes it to API
- **Frontend page** (`HistoryPage.tsx`): Dropdown values now encode type (e.g., `expense:還款`), decoded on selection
- **Frontend test** (`HistoryPage.test.tsx`): Updated test fixtures to include new `type` field

## Test plan
- [x] `npm run build` (frontend) passes
- [x] `npx vitest run` (backend) — 289 tests pass
- [ ] Manual: select expense/還款 in filter, verify only expense transactions shown
- [ ] Manual: select income/還款 in filter, verify only income transactions shown
- [ ] Manual: select "All Categories" resets both category and type filters

Closes #168