### PR TITLE
feat: add stats page category bar chart drilldown (T-703)

### DIFF
--- a/frontend/src/components/CategoryTransactionList.tsx
+++ b/frontend/src/components/CategoryTransactionList.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import api from '../lib/api'
+import type { Transaction } from '../stores/index'
+import TransactionDetailInline from './TransactionDetailInline'
+
+interface CategoryTransactionListProps {
+  category: string
+  startDate: string
+  endDate: string
+  type: 'expense' | 'income'
+}
+
+function CategoryTransactionList({
+  category,
+  startDate,
+  endDate,
+  type,
+}: CategoryTransactionListProps) {
+  const { t } = useTranslation('stats')
+  const [transactions, setTransactions] = useState<Transaction[]>([])
+  const [loading, setLoading] = useState(true)
+  const [expandedTxId, setExpandedTxId] = useState<string | null>(null)
+
+  const fetchTransactions = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await api.get('/transactions', {
+        params: {
+          category,
+          start_date: startDate,
+          end_date: endDate,
+          type,
+          sort: 'desc',
+          limit: 50,
+        },
+      })
+      const items: Transaction[] = (res.data.data.items ?? []).map(
+        (t: Record<string, unknown>) => ({
+          id: t.id as string,
+          type: (t.type as 'income' | 'expense') ?? 'expense',
+          amount: t.amount as number,
+          category: t.category as string,
+          merchant: t.merchant as string,
+          rawText: (t.raw_text as string) ?? '',
+          note: (t.note as string) ?? undefined,
+          transactionDate: t.transaction_date as string,
+          createdAt: t.created_at as string,
+        })
+      )
+      setTransactions(items)
+    } catch {
+      setTransactions([])
+    } finally {
+      setLoading(false)
+    }
+  }, [category, startDate, endDate, type])
+
+  useEffect(() => {
+    void fetchTransactions()
+  }, [fetchTransactions])
+
+  const handleToggleTx = useCallback((txId: string) => {
+    setExpandedTxId((prev) => (prev === txId ? null : txId))
+  }, [])
+
+  if (loading) {
+    return (
+      <div className="py-md px-lg" data-testid="category-tx-loading">
+        <div className="animate-pulse space-y-sm">
+          <div className="h-3 bg-border rounded w-3/4" />
+          <div className="h-3 bg-border rounded w-1/2" />
+          <div className="h-3 bg-border rounded w-2/3" />
+        </div>
+      </div>
+    )
+  }
+
+  if (transactions.length === 0) {
+    return (
+      <div className="py-md px-lg" data-testid="category-tx-empty">
+        <p className="text-caption text-text-tertiary text-center">
+          {t('noTransactionsInCategory')}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="py-xs" data-testid="category-tx-list">
+      {transactions.map((tx) => (
+        <TransactionDetailInline
+          key={tx.id}
+          transaction={tx}
+          isExpanded={expandedTxId === tx.id}
+          onToggle={() => handleToggleTx(tx.id)}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default CategoryTransactionList

--- a/frontend/src/components/TransactionDetailInline.tsx
+++ b/frontend/src/components/TransactionDetailInline.tsx
@@ -1,0 +1,151 @@
+import { useState, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useLocaleFormatter } from '../hooks/useLocaleFormatter'
+import { getCategoryName } from '../lib/categoryUtils'
+import api from '../lib/api'
+import type { Transaction } from '../stores/index'
+
+interface TransactionDetailInlineProps {
+  transaction: Transaction
+  isExpanded: boolean
+  onToggle: () => void
+}
+
+function TransactionDetailInline({
+  transaction: tx,
+  isExpanded,
+  onToggle,
+}: TransactionDetailInlineProps) {
+  const { t } = useTranslation('stats')
+  const { formatCurrency, formatDate: fmtDate } = useLocaleFormatter()
+  const [aiFeedback, setAiFeedback] = useState<string | null>(null)
+  const [loadingFeedback, setLoadingFeedback] = useState(false)
+
+  const txType = tx.type ?? 'expense'
+
+  const formatDateStr = (dateStr: string): string => {
+    if (!dateStr) return '--'
+    return dateStr.split('T')[0]
+  }
+
+  const handleToggle = useCallback(() => {
+    if (!isExpanded && aiFeedback === null && !loadingFeedback) {
+      setLoadingFeedback(true)
+      api
+        .get(`/transactions/${tx.id}`)
+        .then((res) => {
+          const data = res.data.data
+          setAiFeedback(data.ai_comment ?? data.ai_feedback ?? data.note ?? '')
+        })
+        .catch(() => {
+          setAiFeedback('')
+        })
+        .finally(() => {
+          setLoadingFeedback(false)
+        })
+    }
+    onToggle()
+  }, [isExpanded, aiFeedback, loadingFeedback, tx.id, onToggle])
+
+  return (
+    <div data-testid={`drilldown-tx-${tx.id}`}>
+      {/* Summary row */}
+      <button
+        type="button"
+        onClick={handleToggle}
+        className="w-full flex items-center gap-md py-sm px-md hover:bg-bg transition-colors rounded-md"
+        aria-expanded={isExpanded}
+        data-testid={`drilldown-tx-toggle-${tx.id}`}
+      >
+        <div className="flex-1 min-w-0 text-left">
+          <div className="flex justify-between items-center">
+            <span className="text-caption text-text-secondary">
+              {formatDateStr(tx.transactionDate)}
+            </span>
+            <span
+              className={`text-body font-semibold ${txType === 'income' ? 'text-success' : 'text-danger'}`}
+            >
+              {txType === 'income' ? '+' : '-'}
+              {formatCurrency(tx.amount)}
+            </span>
+          </div>
+          <p className="text-body text-text-primary truncate">
+            {tx.merchant || getCategoryName(tx.category)}
+          </p>
+        </div>
+        <span
+          className={`text-text-tertiary text-xs transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
+        >
+          ▼
+        </span>
+      </button>
+
+      {/* Expanded detail */}
+      <div
+        className={`overflow-hidden transition-all duration-300 ease-in-out ${
+          isExpanded ? 'max-h-[300px] opacity-100' : 'max-h-0 opacity-0'
+        }`}
+      >
+        <div className="pl-md pr-md pb-sm pt-xs space-y-xs border-l-2 border-primary ml-md">
+          <div className="flex items-center gap-sm">
+            <span className="text-small text-text-secondary w-[50px] shrink-0">
+              {t('detail.amount')}
+            </span>
+            <span
+              className={`text-body font-semibold ${txType === 'income' ? 'text-success' : 'text-danger'}`}
+            >
+              {txType === 'income' ? '+' : '-'}
+              {formatCurrency(tx.amount)}
+            </span>
+          </div>
+          <div className="flex items-center gap-sm">
+            <span className="text-small text-text-secondary w-[50px] shrink-0">
+              {t('detail.merchant')}
+            </span>
+            <span className="text-body text-text-primary">
+              {tx.merchant || '--'}
+            </span>
+          </div>
+          <div className="flex items-center gap-sm">
+            <span className="text-small text-text-secondary w-[50px] shrink-0">
+              {t('detail.date')}
+            </span>
+            <span className="text-body text-text-primary">
+              {fmtDate(new Date(tx.transactionDate), {
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+              })}
+            </span>
+          </div>
+          {tx.note && (
+            <div className="flex items-start gap-sm">
+              <span className="text-small text-text-secondary w-[50px] shrink-0">
+                {t('detail.note')}
+              </span>
+              <span className="text-caption text-text-secondary">
+                {tx.note}
+              </span>
+            </div>
+          )}
+          <div className="flex items-start gap-sm">
+            <span className="text-small text-text-secondary w-[50px] shrink-0">
+              {t('detail.aiFeedback')}
+            </span>
+            {loadingFeedback ? (
+              <span className="text-caption text-text-tertiary">
+                {t('loading')}
+              </span>
+            ) : (
+              <span className="text-caption text-text-secondary">
+                {aiFeedback || '--'}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default TransactionDetailInline

--- a/frontend/src/i18n/locales/en/stats.json
+++ b/frontend/src/i18n/locales/en/stats.json
@@ -25,5 +25,14 @@
   "noIncomeRecords": "No income records this month",
   "noRecords": "No records this month",
   "startDate": "Start Date",
-  "endDate": "End Date"
+  "endDate": "End Date",
+  "noTransactionsInCategory": "No transactions in this category",
+  "loading": "Loading...",
+  "detail": {
+    "amount": "Amount",
+    "merchant": "Merchant",
+    "date": "Date",
+    "note": "Note",
+    "aiFeedback": "AI Feedback"
+  }
 }

--- a/frontend/src/i18n/locales/vi/stats.json
+++ b/frontend/src/i18n/locales/vi/stats.json
@@ -25,5 +25,14 @@
   "noIncomeRecords": "Chưa có thu nhập tháng này",
   "noRecords": "Chưa có giao dịch tháng này",
   "startDate": "Ngày bắt đầu",
-  "endDate": "Ngày kết thúc"
+  "endDate": "Ngày kết thúc",
+  "noTransactionsInCategory": "Không có giao dịch trong danh mục này",
+  "loading": "Đang tải...",
+  "detail": {
+    "amount": "Số tiền",
+    "merchant": "Cửa hàng",
+    "date": "Ngày",
+    "note": "Ghi chú",
+    "aiFeedback": "Phản hồi AI"
+  }
 }

--- a/frontend/src/i18n/locales/zh-CN/stats.json
+++ b/frontend/src/i18n/locales/zh-CN/stats.json
@@ -25,5 +25,14 @@
   "noIncomeRecords": "本月暂无收入记录",
   "noRecords": "本月暂无消费记录",
   "startDate": "开始日期",
-  "endDate": "结束日期"
+  "endDate": "结束日期",
+  "noTransactionsInCategory": "此类别无交易记录",
+  "loading": "加载中...",
+  "detail": {
+    "amount": "金额",
+    "merchant": "商家",
+    "date": "日期",
+    "note": "备注",
+    "aiFeedback": "AI 评论"
+  }
 }

--- a/frontend/src/i18n/locales/zh-TW/stats.json
+++ b/frontend/src/i18n/locales/zh-TW/stats.json
@@ -25,5 +25,14 @@
   "noIncomeRecords": "本月尚無收入記錄",
   "noRecords": "本月尚無消費記錄",
   "startDate": "開始日期",
-  "endDate": "結束日期"
+  "endDate": "結束日期",
+  "noTransactionsInCategory": "此類別無交易記錄",
+  "loading": "載入中...",
+  "detail": {
+    "amount": "金額",
+    "merchant": "商家",
+    "date": "日期",
+    "note": "備註",
+    "aiFeedback": "AI 評論"
+  }
 }

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocaleFormatter } from '../hooks/useLocaleFormatter'
 import api from '../lib/api'
 import BudgetBar from '../components/BudgetBar'
 import DistributionChart from '../components/DistributionChart'
 import type { DistributionItem } from '../components/DistributionChart'
+import CategoryTransactionList from '../components/CategoryTransactionList'
 import { getCategoryColor, getCategoryName } from '../lib/categoryUtils'
 
 interface BudgetSummaryData {
@@ -27,6 +28,7 @@ function StatsPage() {
   const [distribution, setDistribution] = useState<DistributionItem[]>([])
   const [totalAmount, setTotalAmount] = useState(0)
   const [loading, setLoading] = useState(true)
+  const [expandedCategory, setExpandedCategory] = useState<string | null>(null)
 
   const today = new Date().toISOString().slice(0, 10)
   const firstOfMonth = new Date(new Date().getFullYear(), new Date().getMonth(), 1).toISOString().slice(0, 10)
@@ -95,8 +97,39 @@ function StatsPage() {
 
   const formatMoney = (n: number) => formatCurrency(n)
 
+  // Reset expanded category when filters change
+  useEffect(() => {
+    setExpandedCategory(null)
+  }, [timeFilter, typeTab, customStart, customEnd])
+
   const ranked = [...distribution].sort((a, b) => b.amount - a.amount)
   const maxAmount = ranked.length > 0 ? ranked[0].amount : 0
+
+  // Compute explicit date range for transaction queries
+  const dateRange = useMemo(() => {
+    if (timeFilter === 'custom') {
+      return { start: customStart, end: customEnd }
+    }
+    const now = new Date()
+    if (timeFilter === 'week') {
+      const dayOfWeek = now.getDay()
+      const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek
+      const monday = new Date(now.getFullYear(), now.getMonth(), now.getDate() + mondayOffset)
+      return {
+        start: monday.toISOString().slice(0, 10),
+        end: now.toISOString().slice(0, 10),
+      }
+    }
+    // month
+    return {
+      start: new Date(now.getFullYear(), now.getMonth(), 1).toISOString().slice(0, 10),
+      end: now.toISOString().slice(0, 10),
+    }
+  }, [timeFilter, customStart, customEnd])
+
+  const handleCategoryClick = useCallback((category: string) => {
+    setExpandedCategory((prev) => (prev === category ? null : category))
+  }, [])
 
   const isExpense = typeTab === 'expense'
 
@@ -235,35 +268,65 @@ function StatsPage() {
                 {t('categoryRanking')}
               </h2>
               <div className="space-y-md">
-                {ranked.map((item, index) => (
-                  <div
-                    key={item.category}
-                    className="bg-surface rounded-lg shadow-card p-md flex items-center gap-md"
-                  >
-                    <span className="text-caption font-bold text-text-secondary w-6 text-center">
-                      {index + 1}
-                    </span>
-                    <div className="flex-1 min-w-0">
-                      <div className="flex justify-between items-center mb-xs">
-                        <span className="text-body font-semibold text-text-primary">
-                          {getCategoryName(item.category)}
+                {ranked.map((item, index) => {
+                  const isExpanded = expandedCategory === item.category
+                  return (
+                    <div key={item.category}>
+                      <button
+                        type="button"
+                        onClick={() => handleCategoryClick(item.category)}
+                        className="w-full bg-surface rounded-lg shadow-card p-md flex items-center gap-md cursor-pointer hover:bg-bg transition-colors"
+                        aria-expanded={isExpanded}
+                        data-testid={`category-bar-${item.category}`}
+                      >
+                        <span className="text-caption font-bold text-text-secondary w-6 text-center">
+                          {index + 1}
                         </span>
-                        <span className="text-body text-text-primary">
-                          {formatMoney(item.amount)}
+                        <div className="flex-1 min-w-0">
+                          <div className="flex justify-between items-center mb-xs">
+                            <span className="text-body font-semibold text-text-primary">
+                              {getCategoryName(item.category)}
+                            </span>
+                            <span className="text-body text-text-primary">
+                              {formatMoney(item.amount)}
+                            </span>
+                          </div>
+                          <div className="h-1.5 rounded-full bg-border overflow-hidden">
+                            <div
+                              className="h-full rounded-full"
+                              style={{
+                                width: maxAmount > 0 ? `${(item.amount / maxAmount) * 100}%` : '0%',
+                                backgroundColor: getCategoryColor(item.category, index),
+                              }}
+                            />
+                          </div>
+                        </div>
+                        <span
+                          className={`text-text-tertiary text-xs transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
+                        >
+                          ▼
                         </span>
-                      </div>
-                      <div className="h-1.5 rounded-full bg-border overflow-hidden">
-                        <div
-                          className="h-full rounded-full"
-                          style={{
-                            width: maxAmount > 0 ? `${(item.amount / maxAmount) * 100}%` : '0%',
-                            backgroundColor: getCategoryColor(item.category, index),
-                          }}
-                        />
+                      </button>
+                      {/* Expandable transaction list */}
+                      <div
+                        className={`overflow-hidden transition-all duration-300 ease-in-out ${
+                          isExpanded ? 'max-h-[600px] opacity-100' : 'max-h-0 opacity-0'
+                        }`}
+                      >
+                        {isExpanded && (
+                          <div className="bg-surface rounded-b-lg shadow-card px-md pb-md -mt-1">
+                            <CategoryTransactionList
+                              category={item.category}
+                              startDate={dateRange.start}
+                              endDate={dateRange.end}
+                              type={typeTab}
+                            />
+                          </div>
+                        )}
                       </div>
                     </div>
-                  </div>
-                ))}
+                  )
+                })}
               </div>
             </section>
           )}

--- a/frontend/src/test/StatsDrilldown.test.tsx
+++ b/frontend/src/test/StatsDrilldown.test.tsx
@@ -1,0 +1,334 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import StatsPage from '../pages/StatsPage'
+
+// Mock recharts
+vi.mock('recharts', () => {
+  const MockResponsiveContainer = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  )
+  const MockPieChart = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="pie-chart">{children}</div>
+  )
+  const MockPie = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="pie">{children}</div>
+  )
+  const MockCell = ({ fill }: { fill: string }) => (
+    <div data-testid="cell" data-fill={fill} />
+  )
+  const MockTooltip = () => <div data-testid="tooltip" />
+
+  return {
+    ResponsiveContainer: MockResponsiveContainer,
+    PieChart: MockPieChart,
+    Pie: MockPie,
+    Cell: MockCell,
+    Tooltip: MockTooltip,
+  }
+})
+
+// Mock api module
+const mockGet = vi.fn()
+vi.mock('../lib/api.ts', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    put: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+function renderStatsPage() {
+  return render(
+    <MemoryRouter>
+      <StatsPage />
+    </MemoryRouter>,
+  )
+}
+
+const mockDistributionResponse = (items: Array<{ category: string; amount: number; ratio: number }>) => ({
+  data: {
+    code: 200,
+    data: {
+      month: '2026-03',
+      total: items.reduce((sum, i) => sum + i.amount, 0),
+      distribution: items,
+    },
+  },
+})
+
+const mockBudgetResponse = (budget = 50000, spent = 30000) => ({
+  data: {
+    code: 200,
+    data: {
+      month: '2026-03',
+      monthly_budget: budget,
+      total_spent: spent,
+      remaining: budget - spent,
+      used_ratio: spent / budget,
+    },
+  },
+})
+
+const mockTransactionsResponse = (items: Array<Record<string, unknown>>) => ({
+  data: {
+    code: 200,
+    data: {
+      items,
+      total: items.length,
+    },
+  },
+})
+
+const mockTransactionDetailResponse = (data: Record<string, unknown>) => ({
+  data: {
+    code: 200,
+    data,
+  },
+})
+
+describe('Stats Page Drilldown', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows expand arrow on category bars and expands on click', async () => {
+    const user = userEvent.setup()
+
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/stats/distribution') {
+        return Promise.resolve(mockDistributionResponse([
+          { category: 'food', amount: 7000, ratio: 0.7 },
+          { category: 'transport', amount: 3000, ratio: 0.3 },
+        ]))
+      }
+      if (url === '/budget/summary') {
+        return Promise.resolve(mockBudgetResponse())
+      }
+      if (url === '/transactions') {
+        return Promise.resolve(mockTransactionsResponse([
+          {
+            id: 'tx-1',
+            type: 'expense',
+            amount: 500,
+            category: 'food',
+            merchant: '午餐店',
+            raw_text: '午餐 500',
+            transaction_date: '2026-03-20T00:00:00Z',
+            created_at: '2026-03-20T12:00:00Z',
+          },
+        ]))
+      }
+      return Promise.resolve({ data: { data: {} } })
+    })
+
+    renderStatsPage()
+
+    // Wait for stats to load
+    await waitFor(() => {
+      expect(screen.getByTestId('category-bar-food')).toBeInTheDocument()
+    })
+
+    // Category bar should exist and not be expanded
+    const foodBar = screen.getByTestId('category-bar-food')
+    expect(foodBar).toHaveAttribute('aria-expanded', 'false')
+
+    // Click the food category bar
+    await user.click(foodBar)
+
+    // Should now be expanded
+    expect(foodBar).toHaveAttribute('aria-expanded', 'true')
+
+    // Should fetch transactions
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith('/transactions', expect.objectContaining({
+        params: expect.objectContaining({ category: 'food' }),
+      }))
+    })
+
+    // Transaction list should appear
+    await waitFor(() => {
+      expect(screen.getByTestId('category-tx-list')).toBeInTheDocument()
+    })
+  })
+
+  it('collapses when clicking the same category again', async () => {
+    const user = userEvent.setup()
+
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/stats/distribution') {
+        return Promise.resolve(mockDistributionResponse([
+          { category: 'food', amount: 7000, ratio: 0.7 },
+        ]))
+      }
+      if (url === '/budget/summary') {
+        return Promise.resolve(mockBudgetResponse())
+      }
+      if (url === '/transactions') {
+        return Promise.resolve(mockTransactionsResponse([]))
+      }
+      return Promise.resolve({ data: { data: {} } })
+    })
+
+    renderStatsPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('category-bar-food')).toBeInTheDocument()
+    })
+
+    const foodBar = screen.getByTestId('category-bar-food')
+
+    // Expand
+    await user.click(foodBar)
+    expect(foodBar).toHaveAttribute('aria-expanded', 'true')
+
+    // Collapse
+    await user.click(foodBar)
+    expect(foodBar).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('only one category expanded at a time', async () => {
+    const user = userEvent.setup()
+
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/stats/distribution') {
+        return Promise.resolve(mockDistributionResponse([
+          { category: 'food', amount: 7000, ratio: 0.7 },
+          { category: 'transport', amount: 3000, ratio: 0.3 },
+        ]))
+      }
+      if (url === '/budget/summary') {
+        return Promise.resolve(mockBudgetResponse())
+      }
+      if (url === '/transactions') {
+        return Promise.resolve(mockTransactionsResponse([]))
+      }
+      return Promise.resolve({ data: { data: {} } })
+    })
+
+    renderStatsPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('category-bar-food')).toBeInTheDocument()
+      expect(screen.getByTestId('category-bar-transport')).toBeInTheDocument()
+    })
+
+    const foodBar = screen.getByTestId('category-bar-food')
+    const transportBar = screen.getByTestId('category-bar-transport')
+
+    // Expand food
+    await user.click(foodBar)
+    expect(foodBar).toHaveAttribute('aria-expanded', 'true')
+    expect(transportBar).toHaveAttribute('aria-expanded', 'false')
+
+    // Click transport → food should collapse, transport should expand
+    await user.click(transportBar)
+    expect(foodBar).toHaveAttribute('aria-expanded', 'false')
+    expect(transportBar).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('renders transaction detail inline when clicking a transaction', async () => {
+    const user = userEvent.setup()
+
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/stats/distribution') {
+        return Promise.resolve(mockDistributionResponse([
+          { category: 'food', amount: 7000, ratio: 1.0 },
+        ]))
+      }
+      if (url === '/budget/summary') {
+        return Promise.resolve(mockBudgetResponse())
+      }
+      if (url === '/transactions') {
+        return Promise.resolve(mockTransactionsResponse([
+          {
+            id: 'tx-detail-1',
+            type: 'expense',
+            amount: 350,
+            category: 'food',
+            merchant: '便利商店',
+            raw_text: '便利商店 350',
+            note: '買水',
+            transaction_date: '2026-03-22T00:00:00Z',
+            created_at: '2026-03-22T10:00:00Z',
+          },
+        ]))
+      }
+      if (url === '/transactions/tx-detail-1') {
+        return Promise.resolve(mockTransactionDetailResponse({
+          id: 'tx-detail-1',
+          type: 'expense',
+          amount: 350,
+          category: 'food',
+          merchant: '便利商店',
+          note: '買水',
+          ai_comment: '又買零食了嗎？',
+          transaction_date: '2026-03-22T00:00:00Z',
+          created_at: '2026-03-22T10:00:00Z',
+        }))
+      }
+      return Promise.resolve({ data: { data: {} } })
+    })
+
+    renderStatsPage()
+
+    // Wait for data to load
+    await waitFor(() => {
+      expect(screen.getByTestId('category-bar-food')).toBeInTheDocument()
+    })
+
+    // Expand the food category
+    await user.click(screen.getByTestId('category-bar-food'))
+
+    // Wait for transaction list to appear
+    await waitFor(() => {
+      expect(screen.getByTestId('category-tx-list')).toBeInTheDocument()
+    })
+
+    // Click the transaction to expand inline detail
+    const txToggle = screen.getByTestId('drilldown-tx-toggle-tx-detail-1')
+    await user.click(txToggle)
+
+    // Should show AI feedback after lazy loading
+    await waitFor(() => {
+      expect(screen.getByText('又買零食了嗎？')).toBeInTheDocument()
+    })
+
+    // Verify the detail API was called
+    expect(mockGet).toHaveBeenCalledWith('/transactions/tx-detail-1')
+  })
+
+  it('shows empty message when category has no transactions', async () => {
+    const user = userEvent.setup()
+
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/stats/distribution') {
+        return Promise.resolve(mockDistributionResponse([
+          { category: 'food', amount: 7000, ratio: 1.0 },
+        ]))
+      }
+      if (url === '/budget/summary') {
+        return Promise.resolve(mockBudgetResponse())
+      }
+      if (url === '/transactions') {
+        return Promise.resolve(mockTransactionsResponse([]))
+      }
+      return Promise.resolve({ data: { data: {} } })
+    })
+
+    renderStatsPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('category-bar-food')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByTestId('category-bar-food'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('category-tx-empty')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('此類別無交易記錄')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- 統計頁條狀圖新增點擊展開/收合功能，點擊類別可展開查看該類別下的交易明細（T-703）
- 新增 `CategoryTransactionList` 與 `TransactionDetailInline` 元件
- 新增多語系翻譯（zh-TW, zh-CN, en, vi）
- 新增 5 個專屬單元測試，全數通過

## Related Issues
Closes #175

## Test plan
- [x] StatsDrilldown.test.tsx — 5 tests passed
- [ ] 統計頁交互展開視覺驗收（#178）