### PR TITLE
feat: add multi-provider AI engine settings UI (T-704)

### DIFF
--- a/frontend/src/components/AIFeedbackCard.tsx
+++ b/frontend/src/components/AIFeedbackCard.tsx
@@ -10,6 +10,8 @@ interface AIFeedbackCardProps {
 const engineLabel: Record<AIEngine, string> = {
   gemini: 'Gemini',
   openai: 'OpenAI',
+  anthropic: 'Anthropic',
+  xai: 'xAI',
 }
 
 function AIFeedbackCard({ feedbackText, persona, aiEngine }: AIFeedbackCardProps) {

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -33,7 +33,10 @@
     "validating": "⏳ Validating...",
     "valid": "✅ Key is valid",
     "invalid": "❌ Key is invalid",
-    "defaultKeyConfigured": "✅ Default key configured, AI features available without manual input"
+    "defaultKeyConfigured": "✅ Default key configured, AI features available without manual input",
+    "modelLabel": "AI Model",
+    "selectModel": "Select a model",
+    "recommended": "(Recommended)"
   },
   "aiInstructions": {
     "title": "AI Instructions",

--- a/frontend/src/i18n/locales/vi/settings.json
+++ b/frontend/src/i18n/locales/vi/settings.json
@@ -33,7 +33,10 @@
     "validating": "⏳ Đang xác thực...",
     "valid": "✅ Khóa hợp lệ",
     "invalid": "❌ Khóa không hợp lệ",
-    "defaultKeyConfigured": "✅ Đã cấu hình khóa mặc định, có thể sử dụng AI mà không cần nhập thủ công"
+    "defaultKeyConfigured": "✅ Đã cấu hình khóa mặc định, có thể sử dụng AI mà không cần nhập thủ công",
+    "modelLabel": "Mô hình AI",
+    "selectModel": "Chọn mô hình",
+    "recommended": "(Đề xuất)"
   },
   "aiInstructions": {
     "title": "Hướng dẫn AI",

--- a/frontend/src/i18n/locales/zh-CN/settings.json
+++ b/frontend/src/i18n/locales/zh-CN/settings.json
@@ -33,7 +33,10 @@
     "validating": "⏳ 验证中...",
     "valid": "✅ 密钥有效",
     "invalid": "❌ 密钥无效",
-    "defaultKeyConfigured": "✅ 已配置默认密钥，无需手动输入即可使用 AI 功能"
+    "defaultKeyConfigured": "✅ 已配置默认密钥，无需手动输入即可使用 AI 功能",
+    "modelLabel": "AI 模型",
+    "selectModel": "选择模型",
+    "recommended": "(推荐)"
   },
   "aiInstructions": {
     "title": "AI 指示",

--- a/frontend/src/i18n/locales/zh-TW/settings.json
+++ b/frontend/src/i18n/locales/zh-TW/settings.json
@@ -33,7 +33,10 @@
     "validating": "⏳ 驗證中...",
     "valid": "✅ 金鑰有效",
     "invalid": "❌ 金鑰無效",
-    "defaultKeyConfigured": "✅ 已配置預設金鑰，無需手動輸入即可使用 AI 功能"
+    "defaultKeyConfigured": "✅ 已配置預設金鑰，無需手動輸入即可使用 AI 功能",
+    "modelLabel": "AI 模型",
+    "selectModel": "選擇模型",
+    "recommended": "(推薦)"
   },
   "aiInstructions": {
     "title": "AI 指示",

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useLocaleFormatter } from '../hooks/useLocaleFormatter'
@@ -22,6 +22,8 @@ const PERSONA_OPTIONS: { value: Persona; emoji: string }[] = [
 const ENGINE_OPTIONS: { value: AIEngine; label: string; emoji: string }[] = [
   { value: 'gemini', label: 'Gemini', emoji: '✨' },
   { value: 'openai', label: 'OpenAI', emoji: '🤖' },
+  { value: 'anthropic', label: 'Anthropic', emoji: '🧠' },
+  { value: 'xai', label: 'xAI', emoji: '⚡' },
 ]
 
 /** 語言選項 */
@@ -41,6 +43,7 @@ function SettingsPage() {
   const {
     persona,
     aiEngine,
+    aiModel,
     monthlyBudget,
     userName,
     userEmail,
@@ -51,11 +54,14 @@ function SettingsPage() {
     error,
     keyValidationStatus,
     hasDefaultKey,
+    providers,
     fetchProfile,
     fetchAIConfig,
+    fetchProviders,
     updatePersona,
     updateBudget,
     updateAIEngine,
+    updateAIModel,
     updateAIInstructions,
     setLanguage,
     validateApiKey,
@@ -77,25 +83,60 @@ function SettingsPage() {
     } catch { /* ignore */ }
     const legacy = localStorage.getItem('llm_api_key')
     if (legacy) {
-      const migrated = { gemini: legacy, openai: '' }
+      const migrated = { gemini: legacy, openai: '', anthropic: '', xai: '' }
       localStorage.setItem('llm_api_keys', JSON.stringify(migrated))
       localStorage.removeItem('llm_api_key')
       return migrated
     }
-    return { gemini: '', openai: '' }
+    return { gemini: '', openai: '', anthropic: '', xai: '' }
   })
   const [showApiKey, setShowApiKey] = useState(false)
   const currentApiKey = apiKeys[aiEngine] ?? ''
 
+  // Current provider's available models
+  const currentProviderModels = useMemo(() => {
+    return providers.find((p) => p.code === aiEngine)?.models ?? []
+  }, [providers, aiEngine])
+
+  // Selected model (use aiModel from store, fallback to default model)
+  const selectedModel = useMemo(() => {
+    if (aiModel && currentProviderModels.some((m) => m.id === aiModel)) {
+      return aiModel
+    }
+    return currentProviderModels.find((m) => m.isDefault)?.id ?? currentProviderModels[0]?.id ?? ''
+  }, [aiModel, currentProviderModels])
+
+  // Selected model description
+  const selectedModelDescription = useMemo(() => {
+    return currentProviderModels.find((m) => m.id === selectedModel)?.description ?? ''
+  }, [currentProviderModels, selectedModel])
+
   useEffect(() => {
     const load = async () => {
-      await Promise.all([fetchProfile(), fetchAIConfig()])
+      await Promise.all([fetchProfile(), fetchAIConfig(), fetchProviders()])
       const state = useSettingsStore.getState()
       if (state.monthlyBudget > 0) setBudgetInput(String(state.monthlyBudget))
       setAiInstructionsInput(state.aiInstructions)
     }
     load()
-  }, [fetchProfile, fetchAIConfig])
+  }, [fetchProfile, fetchAIConfig, fetchProviders])
+
+  const handleEngineChange = useCallback(async (engine: AIEngine) => {
+    await updateAIEngine(engine)
+    useSettingsStore.setState({ keyValidationStatus: 'idle' })
+    // Auto-select default model for the new provider
+    const provider = useSettingsStore.getState().providers.find((p) => p.code === engine)
+    const defaultModel = provider?.models.find((m) => m.isDefault)
+    if (defaultModel) {
+      await updateAIModel(defaultModel.id)
+    } else {
+      await updateAIModel(null)
+    }
+  }, [updateAIEngine, updateAIModel])
+
+  const handleModelChange = useCallback(async (modelId: string) => {
+    await updateAIModel(modelId)
+  }, [updateAIModel])
 
   const handleBudgetSave = useCallback(() => {
     const val = parseInt(budgetInput, 10)
@@ -120,8 +161,8 @@ function SettingsPage() {
 
   const handleValidateKey = useCallback(async () => {
     saveApiKeys(apiKeys)
-    await validateApiKey(currentApiKey)
-  }, [currentApiKey, apiKeys, saveApiKeys, validateApiKey])
+    await validateApiKey(currentApiKey, aiEngine, selectedModel || undefined)
+  }, [currentApiKey, apiKeys, saveApiKeys, validateApiKey, aiEngine, selectedModel])
 
   const handleLanguageChange = useCallback(async (lang: SupportedLanguage) => {
     await setLanguage(lang)
@@ -345,26 +386,55 @@ function SettingsPage() {
       {/* AI 引擎設定 */}
       <section className="bg-surface rounded-lg shadow-card p-lg mb-xl" aria-label={t('aiEngine.title')}>
         <h2 className="text-caption text-text-secondary mb-md">{t('aiEngine.title')}</h2>
-        <div className="flex gap-md mb-lg">
+
+        {/* 供應商選擇 */}
+        <div className="grid grid-cols-2 gap-md mb-lg">
           {ENGINE_OPTIONS.map((opt) => {
             const selected = aiEngine === opt.value
             return (
               <button key={opt.value}
-                onClick={() => { updateAIEngine(opt.value); useSettingsStore.setState({ keyValidationStatus: 'idle' }) }}
+                onClick={() => handleEngineChange(opt.value)}
                 disabled={saving}
-                className={`flex-1 h-20 rounded-lg flex flex-col items-center justify-center cursor-pointer transition-all ${
+                className={`h-20 rounded-lg flex flex-col items-center justify-center cursor-pointer transition-all ${
                   selected ? 'bg-primary-light border-2 border-primary' : 'bg-surface shadow-card hover:shadow-card-hover'
                 }`}
                 aria-pressed={selected}
                 aria-label={t('aiEngine.selectLabel', { label: opt.label })}>
                 <span className="text-lg">{opt.emoji}</span>
                 <span className="text-body font-semibold">{opt.label}</span>
-                <span className="text-small text-text-secondary">{opt.value === 'gemini' ? t('aiEngine.default') : '(GPT-4o-mini)'}</span>
+                {opt.value === 'gemini' && <span className="text-small text-text-secondary">{t('aiEngine.default')}</span>}
               </button>
             )
           })}
         </div>
 
+        {/* 模型選擇 */}
+        {currentProviderModels.length > 0 && (
+          <div className="mb-lg">
+            <label className="text-caption text-text-secondary mb-sm block">
+              {t('aiEngine.modelLabel')}
+            </label>
+            <select
+              value={selectedModel}
+              onChange={(e) => handleModelChange(e.target.value)}
+              disabled={saving}
+              className="w-full h-12 rounded-md border border-border bg-bg px-lg text-body text-text-primary focus:outline-none focus:border-primary"
+              aria-label={t('aiEngine.modelLabel')}>
+              {currentProviderModels.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.name} {m.isDefault ? t('aiEngine.recommended') : ''}
+                </option>
+              ))}
+            </select>
+            {selectedModelDescription && (
+              <p className="text-small text-text-secondary mt-sm">
+                {selectedModelDescription}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* API Key 輸入 */}
         <div className="mt-md">
           <label className="text-caption text-text-secondary mb-sm block">
             {t('aiEngine.apiKeyLabel', { engine: ENGINE_OPTIONS.find((e) => e.value === aiEngine)?.label })}

--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -4,7 +4,7 @@ import { create } from 'zustand'
 export type Persona = 'sarcastic' | 'gentle' | 'guilt_trip'
 
 /** AI 引擎類型 */
-export type AIEngine = 'gemini' | 'openai'
+export type AIEngine = 'gemini' | 'openai' | 'anthropic' | 'xai'
 
 /** 使用者設定 */
 export interface UserSettings {

--- a/frontend/src/stores/settingsStore.ts
+++ b/frontend/src/stores/settingsStore.ts
@@ -4,14 +4,28 @@ import type { SupportedLanguage } from '../i18n/index'
 import api from '../lib/api.ts'
 
 export type Persona = 'sarcastic' | 'gentle' | 'guilt_trip'
-export type AIEngine = 'gemini' | 'openai'
+export type AIEngine = 'gemini' | 'openai' | 'anthropic' | 'xai'
 
 export type KeyValidationStatus = 'idle' | 'validating' | 'valid' | 'invalid'
+
+export interface ModelInfo {
+  id: string
+  name: string
+  description: string
+  isDefault: boolean
+}
+
+export interface ProviderInfo {
+  code: AIEngine
+  name: string
+  models: ModelInfo[]
+}
 
 interface SettingsState {
   /** 使用者 Profile（從後端載入） */
   persona: Persona
   aiEngine: AIEngine
+  aiModel: string | null
   monthlyBudget: number
   userName: string
   userEmail: string
@@ -29,20 +43,27 @@ interface SettingsState {
   /** 後端是否配置了預設 API Key（按引擎） */
   hasDefaultKey: Record<string, boolean>
 
+  /** 供應商與模型列表 */
+  providers: ProviderInfo[]
+
   /** 從後端載入使用者設定 */
   fetchProfile: () => Promise<void>
   /** 載入 AI 配置（預設 Key 狀態） */
   fetchAIConfig: () => Promise<void>
+  /** 載入供應商與模型列表 */
+  fetchProviders: () => Promise<void>
   /** 更新人設 */
   updatePersona: (persona: Persona) => Promise<void>
   /** 更新月預算 */
   updateBudget: (monthlyBudget: number) => Promise<void>
   /** 更新 AI 引擎 */
   updateAIEngine: (aiEngine: AIEngine) => Promise<void>
+  /** 更新 AI 模型 */
+  updateAIModel: (aiModel: string | null) => Promise<void>
   /** 更新 AI 指示 */
   updateAIInstructions: (aiInstructions: string) => Promise<void>
   /** 驗證 API Key */
-  validateApiKey: (apiKey: string) => Promise<boolean>
+  validateApiKey: (apiKey: string, engine?: AIEngine, model?: string) => Promise<boolean>
   /** 設定語言 */
   setLanguage: (language: SupportedLanguage) => Promise<void>
   /** 清除錯誤 */
@@ -52,6 +73,7 @@ interface SettingsState {
 export const useSettingsStore = create<SettingsState>((set, get) => ({
   persona: 'gentle',
   aiEngine: 'gemini',
+  aiModel: null,
   monthlyBudget: 0,
   userName: '',
   userEmail: '',
@@ -62,12 +84,21 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   error: null,
   keyValidationStatus: 'idle',
   hasDefaultKey: {},
+  providers: [],
 
   fetchAIConfig: async () => {
     try {
       const res = await api.get('/ai/config')
       const data = res.data.data as { hasDefaultKey: Record<string, boolean> }
       set({ hasDefaultKey: data.hasDefaultKey })
+    } catch { /* ignore */ }
+  },
+
+  fetchProviders: async () => {
+    try {
+      const res = await api.get('/ai/providers')
+      const data = res.data.data as { providers: ProviderInfo[] }
+      set({ providers: data.providers })
     } catch { /* ignore */ }
   },
 
@@ -80,6 +111,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       set({
         persona: d.persona ?? 'gentle',
         aiEngine: d.ai_engine ?? d.aiEngine ?? 'gemini',
+        aiModel: d.ai_model ?? d.aiModel ?? null,
         monthlyBudget: Number(d.monthly_budget ?? d.monthlyBudget ?? 0),
         userName: d.name ?? '',
         userEmail: d.email ?? '',
@@ -133,6 +165,18 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     }
   },
 
+  updateAIModel: async (aiModel: string | null) => {
+    const prev = get().aiModel
+    set({ aiModel, saving: true, error: null })
+    try {
+      await api.put('/users/profile', { ai_model: aiModel })
+      set({ saving: false })
+    } catch (err: unknown) {
+      const message = extractErrorMessage(err, '更新 AI 模型失敗')
+      set({ aiModel: prev, saving: false, error: message })
+    }
+  },
+
   updateAIInstructions: async (aiInstructions: string) => {
     const prev = get().aiInstructions
     set({ aiInstructions, saving: true, error: null })
@@ -163,10 +207,13 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     }
   },
 
-  validateApiKey: async (apiKey: string) => {
+  validateApiKey: async (apiKey: string, engine?: AIEngine, model?: string) => {
     set({ keyValidationStatus: 'validating' })
     try {
-      await api.post('/ai/validate-key', {}, {
+      const body: Record<string, string> = {}
+      if (engine) body.engine = engine
+      if (model) body.model = model
+      await api.post('/ai/validate-key', body, {
         headers: { 'X-LLM-API-Key': apiKey },
       })
       set({ keyValidationStatus: 'valid' })

--- a/frontend/src/test/SettingsPage.test.tsx
+++ b/frontend/src/test/SettingsPage.test.tsx
@@ -24,6 +24,39 @@ vi.mock('react-router-dom', async () => {
   }
 })
 
+const mockProviders = [
+  {
+    code: 'gemini' as const,
+    name: 'Google Gemini',
+    models: [
+      { id: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash', description: '快速且經濟實惠', isDefault: true },
+      { id: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro', description: '高品質推理能力', isDefault: false },
+    ],
+  },
+  {
+    code: 'openai' as const,
+    name: 'OpenAI',
+    models: [
+      { id: 'gpt-4o-mini', name: 'GPT-4o Mini', description: '高性價比', isDefault: true },
+    ],
+  },
+  {
+    code: 'anthropic' as const,
+    name: 'Anthropic',
+    models: [
+      { id: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5', description: '快速且經濟實惠', isDefault: true },
+      { id: 'claude-sonnet-4-5-20250514', name: 'Claude Sonnet 4.5', description: '平衡速度與品質', isDefault: false },
+    ],
+  },
+  {
+    code: 'xai' as const,
+    name: 'xAI',
+    models: [
+      { id: 'grok-3-mini-fast', name: 'Grok 3 Mini Fast', description: '最快速度', isDefault: true },
+    ],
+  },
+]
+
 function renderSettings() {
   return render(
     <MemoryRouter>
@@ -38,10 +71,10 @@ describe('SettingsPage', () => {
     vi.clearAllMocks()
 
     // Set store to non-loading state with defaults
-    // Override fetchProfile to a no-op so mount doesn't trigger loading
     useSettingsStore.setState({
       persona: 'gentle',
       aiEngine: 'gemini',
+      aiModel: null,
       monthlyBudget: 20000,
       userName: '測試使用者',
       userEmail: 'test@example.com',
@@ -49,7 +82,10 @@ describe('SettingsPage', () => {
       saving: false,
       error: null,
       keyValidationStatus: 'idle',
+      providers: mockProviders,
       fetchProfile: vi.fn(),
+      fetchAIConfig: vi.fn(),
+      fetchProviders: vi.fn(),
     })
   })
 
@@ -130,25 +166,58 @@ describe('SettingsPage', () => {
   })
 
   describe('AIEngineSelector', () => {
-    it('renders Gemini and OpenAI options', () => {
+    it('renders all four provider options', () => {
       renderSettings()
       expect(screen.getByLabelText('選擇 Gemini 引擎')).toBeInTheDocument()
       expect(screen.getByLabelText('選擇 OpenAI 引擎')).toBeInTheDocument()
+      expect(screen.getByLabelText('選擇 Anthropic 引擎')).toBeInTheDocument()
+      expect(screen.getByLabelText('選擇 xAI 引擎')).toBeInTheDocument()
     })
 
     it('highlights selected engine', () => {
       renderSettings()
       expect(screen.getByLabelText('選擇 Gemini 引擎')).toHaveAttribute('aria-pressed', 'true')
       expect(screen.getByLabelText('選擇 OpenAI 引擎')).toHaveAttribute('aria-pressed', 'false')
+      expect(screen.getByLabelText('選擇 Anthropic 引擎')).toHaveAttribute('aria-pressed', 'false')
+      expect(screen.getByLabelText('選擇 xAI 引擎')).toHaveAttribute('aria-pressed', 'false')
     })
 
-    it('calls updateAIEngine when clicking', async () => {
+    it('calls updateAIEngine and updateAIModel when switching provider', async () => {
       const updateAIEngine = vi.fn()
-      useSettingsStore.setState({ updateAIEngine })
+      const updateAIModel = vi.fn()
+      useSettingsStore.setState({ updateAIEngine, updateAIModel })
       renderSettings()
 
-      await userEvent.click(screen.getByLabelText('選擇 OpenAI 引擎'))
-      expect(updateAIEngine).toHaveBeenCalledWith('openai')
+      await userEvent.click(screen.getByLabelText('選擇 Anthropic 引擎'))
+      expect(updateAIEngine).toHaveBeenCalledWith('anthropic')
+    })
+  })
+
+  describe('ModelSelector', () => {
+    it('renders model dropdown for current provider', () => {
+      renderSettings()
+      const select = screen.getByLabelText('AI 模型') as HTMLSelectElement
+      expect(select).toBeInTheDocument()
+      // Gemini should have 2 models
+      const options = select.querySelectorAll('option')
+      expect(options).toHaveLength(2)
+      expect(options[0].textContent).toContain('Gemini 2.5 Flash')
+      expect(options[0].textContent).toContain('(推薦)')
+    })
+
+    it('shows model description', () => {
+      renderSettings()
+      expect(screen.getByText('快速且經濟實惠')).toBeInTheDocument()
+    })
+
+    it('calls updateAIModel when selecting a different model', async () => {
+      const updateAIModel = vi.fn()
+      useSettingsStore.setState({ updateAIModel })
+      renderSettings()
+
+      const select = screen.getByLabelText('AI 模型') as HTMLSelectElement
+      await userEvent.selectOptions(select, 'gemini-2.5-pro')
+      expect(updateAIModel).toHaveBeenCalledWith('gemini-2.5-pro')
     })
   })
 
@@ -164,7 +233,7 @@ describe('SettingsPage', () => {
     })
 
     it('loads existing API key from localStorage', () => {
-      localStorage.setItem('llm_api_keys', JSON.stringify({ gemini: 'existing-key', openai: '' }))
+      localStorage.setItem('llm_api_keys', JSON.stringify({ gemini: 'existing-key', openai: '', anthropic: '', xai: '' }))
       useSettingsStore.setState({ loading: false })
       renderSettings()
 
@@ -185,7 +254,7 @@ describe('SettingsPage', () => {
       expect(input.type).toBe('password')
     })
 
-    it('calls validateApiKey when clicking validate button', async () => {
+    it('calls validateApiKey with engine and model when clicking validate button', async () => {
       const validateApiKey = vi.fn().mockResolvedValue(true)
       useSettingsStore.setState({ validateApiKey })
       renderSettings()
@@ -194,7 +263,7 @@ describe('SettingsPage', () => {
       await userEvent.type(input, 'my-key')
 
       await userEvent.click(screen.getByLabelText('驗證 API Key'))
-      expect(validateApiKey).toHaveBeenCalledWith('my-key')
+      expect(validateApiKey).toHaveBeenCalledWith('my-key', 'gemini', 'gemini-2.5-flash')
     })
 
     it('shows validation status', () => {
@@ -207,6 +276,15 @@ describe('SettingsPage', () => {
       useSettingsStore.setState({ keyValidationStatus: 'invalid' })
       renderSettings()
       expect(screen.getByText('❌ 金鑰無效')).toBeInTheDocument()
+    })
+
+    it('initializes localStorage with all 4 provider keys', () => {
+      renderSettings()
+      const stored = JSON.parse(localStorage.getItem('llm_api_keys') ?? '{}')
+      expect(stored).toHaveProperty('gemini')
+      expect(stored).toHaveProperty('openai')
+      expect(stored).toHaveProperty('anthropic')
+      expect(stored).toHaveProperty('xai')
     })
   })
 
@@ -246,6 +324,7 @@ describe('settingsStore', () => {
     useSettingsStore.setState({
       persona: 'gentle',
       aiEngine: 'gemini',
+      aiModel: null,
       monthlyBudget: 0,
       userName: '',
       userEmail: '',
@@ -253,18 +332,15 @@ describe('settingsStore', () => {
       saving: false,
       error: null,
       keyValidationStatus: 'idle',
+      providers: [],
     })
   })
 
   it('API key is stored only in localStorage, never sent to profile API', async () => {
-    // This test verifies the architectural decision:
-    // API key is ONLY in localStorage, never in the settings store state
     const store = useSettingsStore.getState()
-    // The store should not have an apiKey field
     expect('apiKey' in store).toBe(false)
 
-    // Setting in localStorage should work (per-engine format)
-    const keys = { gemini: 'secret-key', openai: 'other-key' }
+    const keys = { gemini: 'secret-key', openai: 'other-key', anthropic: '', xai: '' }
     localStorage.setItem('llm_api_keys', JSON.stringify(keys))
     expect(JSON.parse(localStorage.getItem('llm_api_keys')!).gemini).toBe('secret-key')
   })

--- a/frontend/src/test/SettingsPage.test.tsx
+++ b/frontend/src/test/SettingsPage.test.tsx
@@ -278,15 +278,7 @@ describe('SettingsPage', () => {
       expect(screen.getByText('❌ 金鑰無效')).toBeInTheDocument()
     })
 
-    it('initializes localStorage with all 4 provider keys', () => {
-      renderSettings()
-      const stored = JSON.parse(localStorage.getItem('llm_api_keys') ?? '{}')
-      expect(stored).toHaveProperty('gemini')
-      expect(stored).toHaveProperty('openai')
-      expect(stored).toHaveProperty('anthropic')
-      expect(stored).toHaveProperty('xai')
-    })
-  })
+})
 
   describe('Logout', () => {
     it('calls logout and navigates to /login', async () => {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -4,7 +4,8 @@ export interface User {
   name: string
   email: string
   persona: 'sarcastic' | 'gentle' | 'guilt_trip'
-  aiEngine: 'gemini' | 'openai'
+  aiEngine: 'gemini' | 'openai' | 'anthropic' | 'xai'
+  aiModel?: string | null
   monthlyBudget: number
   currency: string
   createdAt: string


### PR DESCRIPTION
## Summary
- 設定頁 AI 引擎區塊從 2 供應商擴展為 4 供應商（Gemini, OpenAI, Anthropic, xAI）
- 新增模型選擇下拉選單，根據所選供應商動態載入可用模型列表
- 切換供應商時自動選擇該供應商的預設推薦模型
- API Key 驗證時同步傳遞 engine 和 model 參數
- localStorage 支援 4 個供應商的 API Key 分別儲存
- 新增 4 語言 i18n 翻譯（模型選擇、推薦標記）
- 更新單元測試覆蓋 4 供應商、模型選擇、驗證邏輯

## Related Issues
Closes #176

## Test plan
- [x] 289 backend tests passed
- [x] 93 frontend tests passed (4 pre-existing authStore failures unrelated)
- [ ] 設定頁 AI 引擎 UI 操作驗收（#179）