### PR TITLE
feat: add M7 E2E tests (T-705)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules/
 .claude/worktrees/
 .tunnel.pid
 *.db
+test-results/
+playwright-report/
+launchd.log

--- a/tests/e2e/ai-engine-settings.spec.ts
+++ b/tests/e2e/ai-engine-settings.spec.ts
@@ -1,0 +1,366 @@
+import { test, expect } from '@playwright/test';
+import {
+  registerUserViaAPI,
+  TEST_PASSWORD,
+  loginViaUI,
+} from '../fixtures/test-helpers';
+
+/**
+ * AI 引擎進階設定 (PRD-F-017 / T-704)
+ */
+test.describe('AI 引擎設定', () => {
+  let authEmail: string;
+
+  const mockProviders = [
+    {
+      code: 'gemini',
+      name: 'Google Gemini',
+      models: [
+        { id: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash', description: '快速且經濟實惠', isDefault: true },
+        { id: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro', description: '高品質推理能力', isDefault: false },
+      ],
+    },
+    {
+      code: 'openai',
+      name: 'OpenAI',
+      models: [
+        { id: 'gpt-4o', name: 'GPT-4o', description: '多模態旗艦模型', isDefault: true },
+        { id: 'gpt-4o-mini', name: 'GPT-4o Mini', description: '經濟實惠的小型模型', isDefault: false },
+      ],
+    },
+    {
+      code: 'anthropic',
+      name: 'Anthropic',
+      models: [
+        { id: 'claude-sonnet-4-5-20250514', name: 'Claude Sonnet 4.5', description: '高效的推理與代碼生成', isDefault: true },
+      ],
+    },
+    {
+      code: 'xai',
+      name: 'xAI',
+      models: [
+        { id: 'grok-3', name: 'Grok 3', description: '新一代推理模型', isDefault: true },
+      ],
+    },
+  ];
+
+  test.beforeEach(async ({ page, request }) => {
+    const user = await registerUserViaAPI(request);
+    authEmail = user.email;
+
+    // Mock providers API
+    await page.route('**/api/v1/ai/providers', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: 200,
+          message: 'OK',
+          data: { providers: mockProviders },
+          timestamp: new Date().toISOString(),
+        }),
+      });
+    });
+
+    // Mock AI config API
+    await page.route('**/api/v1/ai/config', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: 200,
+          message: 'OK',
+          data: {
+            hasDefaultKey: { gemini: true, openai: false, anthropic: false, xai: false },
+          },
+          timestamp: new Date().toISOString(),
+        }),
+      });
+    });
+
+    // Mock profile API
+    await page.route('**/api/v1/users/profile', (route, request) => {
+      if (request.method() === 'GET') {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            code: 200,
+            message: 'OK',
+            data: {
+              name: 'E2E Tester',
+              email: authEmail,
+              persona: 'gentle',
+              ai_engine: 'gemini',
+              ai_model: 'gemini-2.5-flash',
+              monthly_budget: 0,
+              ai_instructions: '',
+              language: 'zh-TW',
+            },
+            timestamp: new Date().toISOString(),
+          }),
+        });
+      } else {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            code: 200,
+            message: 'OK',
+            data: { success: true },
+            timestamp: new Date().toISOString(),
+          }),
+        });
+      }
+    });
+
+    // Mock categories API
+    await page.route('**/api/v1/categories*', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: 200,
+          message: 'OK',
+          data: { categories: [] },
+          timestamp: new Date().toISOString(),
+        }),
+      });
+    });
+  });
+
+  test('顯示四個供應商選項且 Gemini 為預設選中', async ({ page }) => {
+    await loginViaUI(page, authEmail, TEST_PASSWORD);
+    await page.goto('/settings');
+
+    // 等待 AI 引擎設定區塊載入
+    const section = page.getByLabel('AI 引擎設定');
+    await expect(section).toBeVisible({ timeout: 10000 });
+
+    // 四個供應商按鈕
+    await expect(page.getByLabel('選擇 Gemini 引擎')).toBeVisible();
+    await expect(page.getByLabel('選擇 OpenAI 引擎')).toBeVisible();
+    await expect(page.getByLabel('選擇 Anthropic 引擎')).toBeVisible();
+    await expect(page.getByLabel('選擇 xAI 引擎')).toBeVisible();
+
+    // Gemini 為預設選中
+    await expect(page.getByLabel('選擇 Gemini 引擎')).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.getByLabel('選擇 OpenAI 引擎')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  test('切換供應商時自動選擇預設模型', async ({ page }) => {
+    await loginViaUI(page, authEmail, TEST_PASSWORD);
+    await page.goto('/settings');
+
+    const section = page.getByLabel('AI 引擎設定');
+    await expect(section).toBeVisible({ timeout: 10000 });
+
+    // 初始為 Gemini，模型應為 Gemini 2.5 Flash
+    const modelSelect = page.getByLabel('AI 模型');
+    await expect(modelSelect).toBeVisible();
+    await expect(modelSelect).toHaveValue('gemini-2.5-flash');
+
+    // 切換到 Anthropic
+    await page.getByLabel('選擇 Anthropic 引擎').click();
+    await expect(page.getByLabel('選擇 Anthropic 引擎')).toHaveAttribute('aria-pressed', 'true');
+
+    // 模型應自動切換為 Claude Sonnet 4.5
+    await expect(modelSelect).toHaveValue('claude-sonnet-4-5-20250514');
+
+    // 切換到 xAI
+    await page.getByLabel('選擇 xAI 引擎').click();
+    await expect(modelSelect).toHaveValue('grok-3');
+  });
+
+  test('模型下拉選單顯示正確的可用模型', async ({ page }) => {
+    await loginViaUI(page, authEmail, TEST_PASSWORD);
+    await page.goto('/settings');
+
+    const section = page.getByLabel('AI 引擎設定');
+    await expect(section).toBeVisible({ timeout: 10000 });
+
+    // Gemini 應有 2 個模型選項
+    const modelSelect = page.getByLabel('AI 模型');
+    const options = modelSelect.locator('option');
+    await expect(options).toHaveCount(2);
+    await expect(options.nth(0)).toContainText('Gemini 2.5 Flash');
+    await expect(options.nth(1)).toContainText('Gemini 2.5 Pro');
+
+    // 切換到 OpenAI 應有 2 個模型
+    await page.getByLabel('選擇 OpenAI 引擎').click();
+    await expect(options).toHaveCount(2);
+    await expect(options.nth(0)).toContainText('GPT-4o');
+
+    // 切換到 Anthropic 應有 1 個模型
+    await page.getByLabel('選擇 Anthropic 引擎').click();
+    await expect(options).toHaveCount(1);
+    await expect(options.nth(0)).toContainText('Claude Sonnet 4.5');
+  });
+
+  test('API Key 輸入與顯示/隱藏切換', async ({ page }) => {
+    await loginViaUI(page, authEmail, TEST_PASSWORD);
+    await page.goto('/settings');
+
+    const section = page.getByLabel('AI 引擎設定');
+    await expect(section).toBeVisible({ timeout: 10000 });
+
+    const keyInput = page.getByLabel('gemini API Key');
+    await expect(keyInput).toBeVisible();
+    await expect(keyInput).toHaveAttribute('type', 'password');
+
+    // 輸入 API Key
+    await keyInput.fill('test-api-key-12345');
+
+    // 點擊顯示按鈕
+    await page.getByLabel('顯示 API Key').click();
+    await expect(keyInput).toHaveAttribute('type', 'text');
+
+    // 點擊隱藏按鈕
+    await page.getByLabel('隱藏 API Key').click();
+    await expect(keyInput).toHaveAttribute('type', 'password');
+  });
+
+  test('驗證 API Key — 有效', async ({ page }) => {
+    // Mock validate-key API (成功)
+    await page.route('**/api/v1/ai/validate-key', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: 200,
+          message: 'Key 有效',
+          data: { valid: true },
+          timestamp: new Date().toISOString(),
+        }),
+      });
+    });
+
+    await loginViaUI(page, authEmail, TEST_PASSWORD);
+    await page.goto('/settings');
+
+    const section = page.getByLabel('AI 引擎設定');
+    await expect(section).toBeVisible({ timeout: 10000 });
+
+    // 輸入 API Key
+    await page.getByLabel('gemini API Key').fill('valid-key-12345');
+
+    // 點擊驗證按鈕
+    await page.getByLabel('驗證 API Key').click();
+
+    // 應顯示有效訊息
+    const status = page.getByRole('status');
+    await expect(status).toContainText('✅ 金鑰有效', { timeout: 10000 });
+  });
+
+  test('驗證 API Key — 無效', async ({ page }) => {
+    // Mock validate-key API (失敗)
+    await page.route('**/api/v1/ai/validate-key', (route) => {
+      route.fulfill({
+        status: 400,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: 400,
+          message: 'Invalid API Key',
+          data: null,
+          timestamp: new Date().toISOString(),
+        }),
+      });
+    });
+
+    await loginViaUI(page, authEmail, TEST_PASSWORD);
+    await page.goto('/settings');
+
+    const section = page.getByLabel('AI 引擎設定');
+    await expect(section).toBeVisible({ timeout: 10000 });
+
+    // 輸入無效 API Key
+    await page.getByLabel('gemini API Key').fill('invalid-key');
+
+    // 點擊驗證
+    await page.getByLabel('驗證 API Key').click();
+
+    // 應顯示無效訊息
+    const status = page.getByRole('status');
+    await expect(status).toContainText('❌ 金鑰無效', { timeout: 10000 });
+  });
+
+  test('未輸入 API Key 時驗證按鈕為 disabled', async ({ page }) => {
+    await loginViaUI(page, authEmail, TEST_PASSWORD);
+    await page.goto('/settings');
+
+    const section = page.getByLabel('AI 引擎設定');
+    await expect(section).toBeVisible({ timeout: 10000 });
+
+    // 驗證按鈕應為 disabled（未輸入 Key）
+    const validateBtn = page.getByLabel('驗證 API Key');
+    await expect(validateBtn).toBeDisabled();
+  });
+
+  test('Gemini 有預設 Key 時顯示提示訊息', async ({ page }) => {
+    await loginViaUI(page, authEmail, TEST_PASSWORD);
+    await page.goto('/settings');
+
+    const section = page.getByLabel('AI 引擎設定');
+    await expect(section).toBeVisible({ timeout: 10000 });
+
+    // Gemini 有預設 Key 且使用者未輸入自訂 Key，應顯示提示
+    await expect(page.getByText('✅ 已配置預設金鑰，無需手動輸入即可使用 AI 功能')).toBeVisible();
+  });
+
+  test('切換供應商後 API Key 輸入框對應更新', async ({ page }) => {
+    await loginViaUI(page, authEmail, TEST_PASSWORD);
+    await page.goto('/settings');
+
+    const section = page.getByLabel('AI 引擎設定');
+    await expect(section).toBeVisible({ timeout: 10000 });
+
+    // 在 Gemini 輸入 Key
+    await page.getByLabel('gemini API Key').fill('gemini-key-123');
+
+    // 切換到 Anthropic
+    await page.getByLabel('選擇 Anthropic 引擎').click();
+
+    // API Key 輸入框應為空（Anthropic 的 Key）
+    const anthropicKeyInput = page.getByLabel('anthropic API Key');
+    await expect(anthropicKeyInput).toBeVisible();
+    await expect(anthropicKeyInput).toHaveValue('');
+
+    // 切換回 Gemini
+    await page.getByLabel('選擇 Gemini 引擎').click();
+
+    // 應恢復之前輸入的 Key
+    const geminiKeyInput = page.getByLabel('gemini API Key');
+    await expect(geminiKeyInput).toHaveValue('gemini-key-123');
+  });
+
+  test('切換供應商後驗證狀態重置', async ({ page }) => {
+    // Mock validate-key API (成功)
+    await page.route('**/api/v1/ai/validate-key', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: 200,
+          message: 'Key 有效',
+          data: { valid: true },
+          timestamp: new Date().toISOString(),
+        }),
+      });
+    });
+
+    await loginViaUI(page, authEmail, TEST_PASSWORD);
+    await page.goto('/settings');
+
+    const section = page.getByLabel('AI 引擎設定');
+    await expect(section).toBeVisible({ timeout: 10000 });
+
+    // 在 Gemini 驗證成功
+    await page.getByLabel('gemini API Key').fill('valid-gemini-key');
+    await page.getByLabel('驗證 API Key').click();
+    await expect(page.getByRole('status')).toContainText('✅ 金鑰有效', { timeout: 10000 });
+
+    // 切換到 Anthropic — 驗證狀態應重置
+    await page.getByLabel('選擇 Anthropic 引擎').click();
+    await expect(page.getByRole('status')).not.toBeVisible();
+  });
+});

--- a/tests/e2e/stats-drilldown.spec.ts
+++ b/tests/e2e/stats-drilldown.spec.ts
@@ -1,0 +1,267 @@
+import { test, expect } from '@playwright/test';
+import {
+  registerUserViaAPI,
+  TEST_PASSWORD,
+  loginViaUI,
+} from '../fixtures/test-helpers';
+
+/**
+ * 統計頁條狀圖交互展開 (PRD-F-016 / T-703)
+ */
+test.describe('統計頁類別條狀圖展開 / 收合', () => {
+  let authEmail: string;
+
+  const mockDistribution = [
+    { category: 'food', amount: 2500, percentage: 50 },
+    { category: 'transport', amount: 1500, percentage: 30 },
+    { category: 'entertainment', amount: 1000, percentage: 20 },
+  ];
+
+  const mockTransactions = [
+    {
+      id: 'tx-drilldown-1',
+      amount: 280,
+      category: 'food',
+      merchant: '拉麵店',
+      raw_text: '拉麵店 280',
+      transaction_date: new Date().toISOString().split('T')[0],
+      type: 'expense',
+      note: '和朋友聚餐',
+      created_at: new Date().toISOString(),
+    },
+    {
+      id: 'tx-drilldown-2',
+      amount: 150,
+      category: 'food',
+      merchant: '便利商店',
+      raw_text: '便利商店 150',
+      transaction_date: new Date().toISOString().split('T')[0],
+      type: 'expense',
+      note: null,
+      created_at: new Date().toISOString(),
+    },
+  ];
+
+  test.beforeEach(async ({ page, request }) => {
+    const user = await registerUserViaAPI(request);
+    authEmail = user.email;
+
+    // Mock stats distribution API
+    await page.route('**/api/v1/stats/distribution*', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: 200,
+          message: 'OK',
+          data: { distribution: mockDistribution },
+          timestamp: new Date().toISOString(),
+        }),
+      });
+    });
+
+    // Mock budget summary API
+    await page.route('**/api/v1/budget/summary', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: 200,
+          message: 'OK',
+          data: {
+            month: new Date().toISOString().slice(0, 7),
+            monthly_budget: 30000,
+            total_spent: 5000,
+            remaining: 25000,
+            used_ratio: 0.17,
+            transaction_count: 3,
+            categories: [],
+          },
+          timestamp: new Date().toISOString(),
+        }),
+      });
+    });
+
+    // Mock transactions list API (for drilldown)
+    await page.route('**/api/v1/transactions?*', (route, request) => {
+      if (request.method() === 'GET') {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            code: 200,
+            message: 'OK',
+            data: {
+              items: mockTransactions,
+              total: mockTransactions.length,
+              page: 1,
+              limit: 50,
+            },
+            timestamp: new Date().toISOString(),
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    // Mock single transaction detail API (for AI feedback)
+    await page.route('**/api/v1/transactions/tx-drilldown-*', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: 200,
+          message: 'OK',
+          data: {
+            id: 'tx-drilldown-1',
+            amount: 280,
+            category: 'food',
+            merchant: '拉麵店',
+            transaction_date: new Date().toISOString().split('T')[0],
+            type: 'expense',
+            note: '和朋友聚餐',
+            ai_comment: '又花錢吃拉麵！不過記帳是好習慣～',
+          },
+          timestamp: new Date().toISOString(),
+        }),
+      });
+    });
+  });
+
+  test('點擊條狀圖展開交易記錄列表', async ({ page }) => {
+    await loginViaUI(page, authEmail, TEST_PASSWORD);
+    await page.goto('/stats');
+
+    // 等待類別排行載入
+    const foodBar = page.getByTestId('category-bar-food');
+    await expect(foodBar).toBeVisible({ timeout: 10000 });
+
+    // 初始狀態：未展開
+    await expect(foodBar).toHaveAttribute('aria-expanded', 'false');
+
+    // 點擊展開
+    await foodBar.click();
+    await expect(foodBar).toHaveAttribute('aria-expanded', 'true');
+
+    // 等待交易列表載入
+    const txList = page.getByTestId('category-tx-list');
+    await expect(txList).toBeVisible({ timeout: 10000 });
+
+    // 應顯示交易記錄
+    await expect(page.getByTestId('drilldown-tx-tx-drilldown-1')).toBeVisible();
+    await expect(page.getByTestId('drilldown-tx-tx-drilldown-2')).toBeVisible();
+  });
+
+  test('再次點擊條狀圖收合列表', async ({ page }) => {
+    await loginViaUI(page, authEmail, TEST_PASSWORD);
+    await page.goto('/stats');
+
+    const foodBar = page.getByTestId('category-bar-food');
+    await expect(foodBar).toBeVisible({ timeout: 10000 });
+
+    // 展開
+    await foodBar.click();
+    await expect(foodBar).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.getByTestId('category-tx-list')).toBeVisible({ timeout: 10000 });
+
+    // 收合
+    await foodBar.click();
+    await expect(foodBar).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('展開後點擊交易記錄查看明細與 AI 評論', async ({ page }) => {
+    await loginViaUI(page, authEmail, TEST_PASSWORD);
+    await page.goto('/stats');
+
+    const foodBar = page.getByTestId('category-bar-food');
+    await expect(foodBar).toBeVisible({ timeout: 10000 });
+    await foodBar.click();
+
+    // 等待交易列表載入
+    await expect(page.getByTestId('category-tx-list')).toBeVisible({ timeout: 10000 });
+
+    // 點擊第一筆交易展開明細
+    const txToggle = page.getByTestId('drilldown-tx-toggle-tx-drilldown-1');
+    await expect(txToggle).toHaveAttribute('aria-expanded', 'false');
+    await txToggle.click();
+    await expect(txToggle).toHaveAttribute('aria-expanded', 'true');
+
+    // 應顯示 AI 評論（lazy loaded）
+    await expect(page.getByText('又花錢吃拉麵！不過記帳是好習慣～')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('展開一個類別後點擊另一個類別，前一個自動收合', async ({ page }) => {
+    await loginViaUI(page, authEmail, TEST_PASSWORD);
+    await page.goto('/stats');
+
+    const foodBar = page.getByTestId('category-bar-food');
+    const transportBar = page.getByTestId('category-bar-transport');
+    await expect(foodBar).toBeVisible({ timeout: 10000 });
+
+    // 展開 food
+    await foodBar.click();
+    await expect(foodBar).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.getByTestId('category-tx-list')).toBeVisible({ timeout: 10000 });
+
+    // 點擊 transport，food 應收合
+    await transportBar.click();
+    await expect(transportBar).toHaveAttribute('aria-expanded', 'true');
+    await expect(foodBar).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('切換收入/支出 Tab 時重置展開狀態', async ({ page }) => {
+    await loginViaUI(page, authEmail, TEST_PASSWORD);
+    await page.goto('/stats');
+
+    const foodBar = page.getByTestId('category-bar-food');
+    await expect(foodBar).toBeVisible({ timeout: 10000 });
+
+    // 展開 food
+    await foodBar.click();
+    await expect(foodBar).toHaveAttribute('aria-expanded', 'true');
+
+    // 切換到收入 Tab
+    await page.getByTestId('tab-income').click();
+
+    // 切換回支出 Tab
+    await page.getByTestId('tab-expense').click();
+
+    // food 應不再展開
+    const foodBarAfter = page.getByTestId('category-bar-food');
+    await expect(foodBarAfter).toBeVisible({ timeout: 10000 });
+    await expect(foodBarAfter).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('空類別展開時顯示無交易記錄提示', async ({ page }) => {
+    // Override transactions mock to return empty
+    await page.route('**/api/v1/transactions?*', (route, request) => {
+      if (request.method() === 'GET') {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            code: 200,
+            message: 'OK',
+            data: { items: [], total: 0, page: 1, limit: 50 },
+            timestamp: new Date().toISOString(),
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await loginViaUI(page, authEmail, TEST_PASSWORD);
+    await page.goto('/stats');
+
+    const foodBar = page.getByTestId('category-bar-food');
+    await expect(foodBar).toBeVisible({ timeout: 10000 });
+    await foodBar.click();
+
+    // 應顯示空列表提示
+    const emptyHint = page.getByTestId('category-tx-empty');
+    await expect(emptyHint).toBeVisible({ timeout: 10000 });
+    await expect(emptyHint).toContainText('此類別無交易記錄');
+  });
+});


### PR DESCRIPTION
## Summary
- Add Playwright E2E tests for AI engine settings UI (provider switching, API key input, model selection, validation)
- Add Playwright E2E tests for stats page category bar chart drilldown interactions
- Update `.gitignore` to exclude test artifacts (`test-results/`, `playwright-report/`, `launchd.log`)

Closes #177

## Test plan
- [ ] `npx playwright test tests/e2e/ai-engine-settings.spec.ts` passes
- [ ] `npx playwright test tests/e2e/stats-drilldown.spec.ts` passes