### PR TITLE
feat: dynamic model list from provider API (#186)

### DIFF
--- a/backend/src/controllers/aiController.test.ts
+++ b/backend/src/controllers/aiController.test.ts
@@ -126,8 +126,8 @@ beforeEach(() => {
     emotion_tag: 'sarcastic_warning',
   });
 
-  // Default: validateKey returns true
-  mockValidateKey.mockResolvedValue(true);
+  // Default: validateKey returns { valid: true }
+  mockValidateKey.mockResolvedValue({ valid: true });
 });
 
 afterEach(() => {
@@ -403,7 +403,7 @@ describe('POST /api/v1/ai/validate-key', () => {
 
   // --- 案例 16: 驗證失敗 ---
   it('應在 API Key 無效時回傳 403', async () => {
-    mockValidateKey.mockResolvedValue(false);
+    mockValidateKey.mockResolvedValue({ valid: false, errorType: 'invalid_key' });
 
     const res = await postValidateKey('bad-key');
     expect(res.status).toBe(403);

--- a/backend/src/controllers/aiController.ts
+++ b/backend/src/controllers/aiController.ts
@@ -8,7 +8,7 @@ import { t } from '../i18n';
 import { ZodError } from 'zod';
 import prisma from '../config/database';
 import { AIEngine } from '../types/llm';
-import { getAllProviders } from '../services/llm/llmFactory';
+import { getAllProviders, getProvider } from '../services/llm/llmFactory';
 
 function formatZodErrors(error: ZodError) {
   return error.issues.map((issue) => ({
@@ -183,6 +183,43 @@ export async function getProviders(
     };
 
     res.status(200).json(response);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function listModels(
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const engine = (req.query.engine as AIEngine) || 'gemini';
+    const validEngines: AIEngine[] = ['gemini', 'openai', 'anthropic', 'xai'];
+    if (!validEngines.includes(engine)) {
+      throw createI18nError('validation_failed', 400);
+    }
+
+    const provider = getProvider(engine);
+    const apiKey = req.headers['x-llm-api-key'] as string | undefined;
+    const defaultKey = getDefaultApiKey(engine);
+    const effectiveKey = apiKey || defaultKey;
+
+    let models;
+    if (effectiveKey) {
+      models = await provider.listModels(effectiveKey);
+    } else {
+      models = provider.getAvailableModels();
+    }
+
+    const apiResponse: ApiResponse<{ models: typeof models; dynamic: boolean }> = {
+      code: 200,
+      message: 'success',
+      data: { models, dynamic: !!effectiveKey },
+      timestamp: new Date().toISOString(),
+    };
+
+    res.status(200).json(apiResponse);
   } catch (err) {
     next(err);
   }

--- a/backend/src/i18n/locales/en/errors.json
+++ b/backend/src/i18n/locales/en/errors.json
@@ -14,6 +14,7 @@
   "transaction_not_found": "Transaction not found",
   "llm_api_key_missing": "Please provide LLM API Key (X-LLM-API-Key Header)",
   "llm_api_key_invalid": "API Key validation failed, please check your key",
+  "llm_model_invalid": "This model is not available, please select another model",
   "gemini_api_key_invalid": "Invalid Gemini API Key, please check your API Key",
   "gemini_quota_exhausted": "Gemini API quota exhausted, please check your quota or switch engine",
   "openai_api_key_invalid": "Invalid OpenAI API Key, please check your API Key",

--- a/backend/src/i18n/locales/vi/errors.json
+++ b/backend/src/i18n/locales/vi/errors.json
@@ -14,6 +14,7 @@
   "transaction_not_found": "Không tìm thấy giao dịch",
   "llm_api_key_missing": "Vui lòng cung cấp LLM API Key (X-LLM-API-Key Header)",
   "llm_api_key_invalid": "Xác thực API Key thất bại, vui lòng kiểm tra lại key",
+  "llm_model_invalid": "Model này không khả dụng, vui lòng chọn model khác",
   "gemini_api_key_invalid": "API Key Gemini không hợp lệ, vui lòng kiểm tra lại API Key",
   "gemini_quota_exhausted": "Đã hết hạn mức Gemini API, vui lòng kiểm tra hạn mức hoặc đổi engine",
   "openai_api_key_invalid": "API Key OpenAI không hợp lệ, vui lòng kiểm tra lại API Key",

--- a/backend/src/i18n/locales/zh-CN/errors.json
+++ b/backend/src/i18n/locales/zh-CN/errors.json
@@ -14,6 +14,7 @@
   "transaction_not_found": "交易记录不存在",
   "llm_api_key_missing": "请提供 LLM API Key（X-LLM-API-Key Header）",
   "llm_api_key_invalid": "API Key 验证失败，请确认 Key 是否正确",
+  "llm_model_invalid": "此模型不可用，请选择其他模型",
   "gemini_api_key_invalid": "Gemini API Key 无效，请确认您的 API Key",
   "gemini_quota_exhausted": "Gemini API 额度已用尽，请检查您的配额或切换引擎",
   "openai_api_key_invalid": "OpenAI API Key 无效，请确认您的 API Key",

--- a/backend/src/i18n/locales/zh-TW/errors.json
+++ b/backend/src/i18n/locales/zh-TW/errors.json
@@ -14,6 +14,7 @@
   "transaction_not_found": "交易記錄不存在",
   "llm_api_key_missing": "請提供 LLM API Key（X-LLM-API-Key Header）",
   "llm_api_key_invalid": "API Key 驗證失敗，請確認 Key 是否正確",
+  "llm_model_invalid": "此模型不可用，請選擇其他模型",
   "gemini_api_key_invalid": "Gemini API Key 無效，請確認您的 API Key",
   "gemini_quota_exhausted": "Gemini API 額度已用盡，請檢查您的配額或切換引擎",
   "openai_api_key_invalid": "OpenAI API Key 無效，請確認您的 API Key",

--- a/backend/src/routes/aiRoutes.ts
+++ b/backend/src/routes/aiRoutes.ts
@@ -1,12 +1,13 @@
 import { Router } from 'express';
 import { authMiddleware } from '../middlewares/auth';
 import { llmRateLimiter } from '../middlewares/rateLimiter';
-import { aiParse, validateKey, aiQuery, getAIConfig, getProviders } from '../controllers/aiController';
+import { aiParse, validateKey, aiQuery, getAIConfig, getProviders, listModels } from '../controllers/aiController';
 
 const router = Router();
 
 router.get('/config', authMiddleware, getAIConfig);
 router.get('/providers', authMiddleware, getProviders);
+router.get('/models', authMiddleware, listModels);
 router.post('/parse', authMiddleware, llmRateLimiter, aiParse);
 router.post('/validate-key', authMiddleware, llmRateLimiter, validateKey);
 router.post('/query', authMiddleware, llmRateLimiter, aiQuery);

--- a/backend/src/services/llm/anthropicProvider.ts
+++ b/backend/src/services/llm/anthropicProvider.ts
@@ -79,6 +79,11 @@ export class AnthropicProvider implements LLMProvider {
     return this.callWithRetry(apiKey, enhancedSystemPrompt, userPrompt, 0, 1024, model);
   }
 
+  async listModels(_apiKey: string): Promise<ModelInfo[]> {
+    // Anthropic does not provide a List Models API
+    return this.getAvailableModels();
+  }
+
   getAvailableModels(): ModelInfo[] {
     return [
       {

--- a/backend/src/services/llm/anthropicProvider.ts
+++ b/backend/src/services/llm/anthropicProvider.ts
@@ -1,5 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
-import { LLMProvider } from './llmProvider';
+import { LLMProvider, ValidationResult } from './llmProvider';
 import { ParsedTransaction, AIFeedbackContent, ModelInfo } from '../../types/llm';
 import { DATA_EXTRACTOR_SYSTEM_PROMPT } from '../../prompts/dataExtractorPrompt';
 import { createI18nError } from '../../middlewares/errorHandler';
@@ -101,17 +101,24 @@ export class AnthropicProvider implements LLMProvider {
     ];
   }
 
-  async validateKey(apiKey: string): Promise<boolean> {
+  async validateKey(apiKey: string, model?: string): Promise<ValidationResult> {
     try {
       const client = new Anthropic({ apiKey, timeout: TIMEOUT_MS });
       await client.messages.create({
-        model: ANTHROPIC_MODEL,
+        model: model || ANTHROPIC_MODEL,
         max_tokens: 5,
         messages: [{ role: 'user', content: 'test' }],
       });
-      return true;
-    } catch {
-      return false;
+      return { valid: true };
+    } catch (err: unknown) {
+      const message = (err as Error)?.message ?? '';
+      if (message.includes('invalid x-api-key') || message.includes('authentication_error')) {
+        return { valid: false, errorType: 'invalid_key' };
+      }
+      if (message.includes('not_found_error') || message.includes('does not exist')) {
+        return { valid: false, errorType: 'invalid_model' };
+      }
+      return { valid: false, errorType: 'invalid_key' };
     }
   }
 

--- a/backend/src/services/llm/geminiProvider.ts
+++ b/backend/src/services/llm/geminiProvider.ts
@@ -1,5 +1,5 @@
 import { GoogleGenerativeAI } from '@google/generative-ai';
-import { LLMProvider } from './llmProvider';
+import { LLMProvider, ValidationResult } from './llmProvider';
 import { ParsedTransaction, AIFeedbackContent, ModelInfo } from '../../types/llm';
 import { DATA_EXTRACTOR_SYSTEM_PROMPT } from '../../prompts/dataExtractorPrompt';
 import { createI18nError } from '../../middlewares/errorHandler';
@@ -145,16 +145,23 @@ export class GeminiProvider implements LLMProvider {
     ];
   }
 
-  async validateKey(apiKey: string): Promise<boolean> {
+  async validateKey(apiKey: string, model?: string): Promise<ValidationResult> {
     try {
       const genAI = new GoogleGenerativeAI(apiKey);
-      const genModel = genAI.getGenerativeModel({ model: GEMINI_MODEL });
+      const genModel = genAI.getGenerativeModel({ model: model || GEMINI_MODEL });
       await genModel.generateContent({
         contents: [{ role: 'user', parts: [{ text: 'test' }] }],
       });
-      return true;
-    } catch {
-      return false;
+      return { valid: true };
+    } catch (err: unknown) {
+      const message = (err as Error)?.message ?? '';
+      if (message.includes('API_KEY_INVALID') || message.includes('PERMISSION_DENIED')) {
+        return { valid: false, errorType: 'invalid_key' };
+      }
+      if (message.includes('NOT_FOUND') || message.includes('not found') || message.includes('is not supported')) {
+        return { valid: false, errorType: 'invalid_model' };
+      }
+      return { valid: false, errorType: 'invalid_key' };
     }
   }
 

--- a/backend/src/services/llm/geminiProvider.ts
+++ b/backend/src/services/llm/geminiProvider.ts
@@ -90,6 +90,44 @@ export class GeminiProvider implements LLMProvider {
     return this.callWithRetry(apiKey, systemPrompt, userPrompt, 0, 1024, 'application/json', model);
   }
 
+  async listModels(apiKey: string): Promise<ModelInfo[]> {
+    try {
+      const res = await fetch(
+        `https://generativelanguage.googleapis.com/v1beta/models?key=${apiKey}`,
+        { signal: AbortSignal.timeout(10000) }
+      );
+      if (!res.ok) return this.getAvailableModels();
+      const data = await res.json() as { models?: Array<{ name: string; displayName: string; description?: string; supportedGenerationMethods?: string[] }> };
+      if (!data.models) return this.getAvailableModels();
+
+      const defaults = this.getAvailableModels();
+      const defaultMap = new Map(defaults.map((m) => [m.id, m]));
+
+      const models: ModelInfo[] = data.models
+        .filter((m) => m.supportedGenerationMethods?.includes('generateContent'))
+        .map((m) => {
+          const id = m.name.replace('models/', '');
+          const def = defaultMap.get(id);
+          return {
+            id,
+            name: def?.name ?? m.displayName,
+            description: def?.description ?? (m.description?.substring(0, 80) ?? ''),
+            isDefault: def?.isDefault ?? false,
+          };
+        });
+
+      models.sort((a, b) => {
+        if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;
+        if (defaultMap.has(a.id) !== defaultMap.has(b.id)) return defaultMap.has(a.id) ? -1 : 1;
+        return a.id.localeCompare(b.id);
+      });
+
+      return models.length > 0 ? models : this.getAvailableModels();
+    } catch {
+      return this.getAvailableModels();
+    }
+  }
+
   getAvailableModels(): ModelInfo[] {
     return [
       {

--- a/backend/src/services/llm/llmProvider.ts
+++ b/backend/src/services/llm/llmProvider.ts
@@ -5,5 +5,7 @@ export interface LLMProvider {
   generateFeedback(prompt: string, apiKey: string, model?: string): Promise<AIFeedbackContent>;
   generateText(systemPrompt: string, userPrompt: string, apiKey: string, model?: string): Promise<string>;
   getAvailableModels(): ModelInfo[];
+  /** Fetch models dynamically from provider API. Falls back to getAvailableModels() on failure. */
+  listModels(apiKey: string): Promise<ModelInfo[]>;
   validateKey(apiKey: string): Promise<boolean>;
 }

--- a/backend/src/services/llm/llmProvider.ts
+++ b/backend/src/services/llm/llmProvider.ts
@@ -1,5 +1,12 @@
 import { ParsedTransaction, AIFeedbackContent, ModelInfo } from '../../types/llm';
 
+export type ValidationErrorType = 'invalid_key' | 'invalid_model';
+
+export interface ValidationResult {
+  valid: boolean;
+  errorType?: ValidationErrorType;
+}
+
 export interface LLMProvider {
   extractData(prompt: string, apiKey: string, model?: string): Promise<ParsedTransaction>;
   generateFeedback(prompt: string, apiKey: string, model?: string): Promise<AIFeedbackContent>;
@@ -7,5 +14,5 @@ export interface LLMProvider {
   getAvailableModels(): ModelInfo[];
   /** Fetch models dynamically from provider API. Falls back to getAvailableModels() on failure. */
   listModels(apiKey: string): Promise<ModelInfo[]>;
-  validateKey(apiKey: string): Promise<boolean>;
+  validateKey(apiKey: string, model?: string): Promise<ValidationResult>;
 }

--- a/backend/src/services/llm/openaiProvider.ts
+++ b/backend/src/services/llm/openaiProvider.ts
@@ -94,6 +94,38 @@ export class OpenAIProvider implements LLMProvider {
     return this.callWithRetry(apiKey, systemPrompt, userPrompt, 0, 1024, model);
   }
 
+  async listModels(apiKey: string): Promise<ModelInfo[]> {
+    try {
+      const client = this.getClient(apiKey);
+      const response = await client.models.list();
+      const models: ModelInfo[] = [];
+      const defaults = this.getAvailableModels();
+      const defaultMap = new Map(defaults.map((m) => [m.id, m]));
+
+      for await (const model of response) {
+        if (/^(gpt-|o[134]-|chatgpt-)/.test(model.id) && !/instruct|realtime|audio|tts|dall|whisper|embed|search/i.test(model.id)) {
+          const def = defaultMap.get(model.id);
+          models.push({
+            id: model.id,
+            name: def?.name ?? model.id,
+            description: def?.description ?? '',
+            isDefault: def?.isDefault ?? false,
+          });
+        }
+      }
+
+      models.sort((a, b) => {
+        if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;
+        if (defaultMap.has(a.id) !== defaultMap.has(b.id)) return defaultMap.has(a.id) ? -1 : 1;
+        return a.id.localeCompare(b.id);
+      });
+
+      return models.length > 0 ? models : this.getAvailableModels();
+    } catch {
+      return this.getAvailableModels();
+    }
+  }
+
   getAvailableModels(): ModelInfo[] {
     return [
       {

--- a/backend/src/services/llm/openaiProvider.ts
+++ b/backend/src/services/llm/openaiProvider.ts
@@ -1,5 +1,5 @@
 import OpenAI from 'openai';
-import { LLMProvider } from './llmProvider';
+import { LLMProvider, ValidationResult } from './llmProvider';
 import { ParsedTransaction, AIFeedbackContent, ModelInfo } from '../../types/llm';
 import { DATA_EXTRACTOR_SYSTEM_PROMPT } from '../../prompts/dataExtractorPrompt';
 import { createI18nError } from '../../middlewares/errorHandler';
@@ -143,17 +143,24 @@ export class OpenAIProvider implements LLMProvider {
     ];
   }
 
-  async validateKey(apiKey: string): Promise<boolean> {
+  async validateKey(apiKey: string, model?: string): Promise<ValidationResult> {
     try {
       const client = this.getClient(apiKey);
       await client.chat.completions.create({
-        model: this.getDefaultModel(),
+        model: model || this.getDefaultModel(),
         messages: [{ role: 'user', content: 'test' }],
         max_completion_tokens: 5,
       });
-      return true;
-    } catch {
-      return false;
+      return { valid: true };
+    } catch (err: unknown) {
+      const message = (err as Error)?.message ?? '';
+      if (message.includes('Incorrect API key') || message.includes('invalid_api_key') || message.includes('Unauthorized')) {
+        return { valid: false, errorType: 'invalid_key' };
+      }
+      if (message.includes('model_not_found') || message.includes('does not exist') || message.includes('invalid_model')) {
+        return { valid: false, errorType: 'invalid_model' };
+      }
+      return { valid: false, errorType: 'invalid_key' };
     }
   }
 

--- a/backend/src/services/llm/xaiProvider.ts
+++ b/backend/src/services/llm/xaiProvider.ts
@@ -37,6 +37,38 @@ export class XAIProvider extends OpenAIProvider {
     throw createI18nError('llm_service_unavailable', 502);
   }
 
+  override async listModels(apiKey: string): Promise<ModelInfo[]> {
+    try {
+      const client = this.getClient(apiKey);
+      const response = await client.models.list();
+      const models: ModelInfo[] = [];
+      const defaults = this.getAvailableModels();
+      const defaultMap = new Map(defaults.map((m) => [m.id, m]));
+
+      for await (const model of response) {
+        if (/^grok-/.test(model.id)) {
+          const def = defaultMap.get(model.id);
+          models.push({
+            id: model.id,
+            name: def?.name ?? model.id,
+            description: def?.description ?? '',
+            isDefault: def?.isDefault ?? false,
+          });
+        }
+      }
+
+      models.sort((a, b) => {
+        if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;
+        if (defaultMap.has(a.id) !== defaultMap.has(b.id)) return defaultMap.has(a.id) ? -1 : 1;
+        return a.id.localeCompare(b.id);
+      });
+
+      return models.length > 0 ? models : this.getAvailableModels();
+    } catch {
+      return this.getAvailableModels();
+    }
+  }
+
   override getAvailableModels(): ModelInfo[] {
     return [
       {

--- a/backend/src/services/llmService.ts
+++ b/backend/src/services/llmService.ts
@@ -516,7 +516,7 @@ export async function validateApiKey(
   apiKey: string,
   overrideEngine?: AIEngine,
   model?: string
-): Promise<{ valid: boolean; engine: AIEngine; model?: string }> {
+): Promise<{ valid: boolean; engine: AIEngine; model?: string; errorType?: string }> {
   const user = await prisma.user.findUnique({ where: { id: userId } });
   if (!user) {
     throw createI18nError('user_not_found', 404);
@@ -525,16 +525,18 @@ export async function validateApiKey(
   const engine = overrideEngine || (user.aiEngine as AIEngine);
   const provider = getProvider(engine);
 
-  // Use provider.validateKey() for lightweight validation
   try {
-    const valid = await provider.validateKey(apiKey);
-    if (!valid) {
+    const result = await provider.validateKey(apiKey, model);
+    if (!result.valid) {
+      if (result.errorType === 'invalid_model') {
+        throw createI18nError('llm_model_invalid', 400);
+      }
       throw createI18nError('llm_api_key_invalid', 403);
     }
     return { valid: true, engine, model };
   } catch (err) {
     console.error('[validateApiKey] Raw error:', err);
-    if (err instanceof AppError && (err.statusCode === 403 || err.statusCode === 429)) {
+    if (err instanceof AppError) {
       throw err;
     }
     throw createI18nError('llm_api_key_invalid', 403);

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -7,6 +7,7 @@ server {
     # SPA routing: all routes fall back to index.html
     location / {
         try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-cache";
     }
 
     # Cache static assets

--- a/frontend/src/components/TransactionDetailInline.tsx
+++ b/frontend/src/components/TransactionDetailInline.tsx
@@ -1,8 +1,7 @@
-import { useState, useCallback } from 'react'
+import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocaleFormatter } from '../hooks/useLocaleFormatter'
 import { getCategoryName } from '../lib/categoryUtils'
-import api from '../lib/api'
 import type { Transaction } from '../stores/index'
 
 interface TransactionDetailInlineProps {
@@ -18,8 +17,6 @@ function TransactionDetailInline({
 }: TransactionDetailInlineProps) {
   const { t } = useTranslation('stats')
   const { formatCurrency, formatDate: fmtDate } = useLocaleFormatter()
-  const [aiFeedback, setAiFeedback] = useState<string | null>(null)
-  const [loadingFeedback, setLoadingFeedback] = useState(false)
 
   const txType = tx.type ?? 'expense'
 
@@ -29,23 +26,8 @@ function TransactionDetailInline({
   }
 
   const handleToggle = useCallback(() => {
-    if (!isExpanded && aiFeedback === null && !loadingFeedback) {
-      setLoadingFeedback(true)
-      api
-        .get(`/transactions/${tx.id}`)
-        .then((res) => {
-          const data = res.data.data
-          setAiFeedback(data.ai_comment ?? data.ai_feedback ?? data.note ?? '')
-        })
-        .catch(() => {
-          setAiFeedback('')
-        })
-        .finally(() => {
-          setLoadingFeedback(false)
-        })
-    }
     onToggle()
-  }, [isExpanded, aiFeedback, loadingFeedback, tx.id, onToggle])
+  }, [onToggle])
 
   return (
     <div data-testid={`drilldown-tx-${tx.id}`}>
@@ -128,20 +110,6 @@ function TransactionDetailInline({
               </span>
             </div>
           )}
-          <div className="flex items-start gap-sm">
-            <span className="text-small text-text-secondary w-[50px] shrink-0">
-              {t('detail.aiFeedback')}
-            </span>
-            {loadingFeedback ? (
-              <span className="text-caption text-text-tertiary">
-                {t('loading')}
-              </span>
-            ) : (
-              <span className="text-caption text-text-secondary">
-                {aiFeedback || '--'}
-              </span>
-            )}
-          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -53,6 +53,7 @@ function SettingsPage() {
     saving,
     error,
     keyValidationStatus,
+    keyValidationMessage,
     hasDefaultKey,
     providers,
     dynamicModels,
@@ -154,7 +155,12 @@ function SettingsPage() {
 
   const handleModelChange = useCallback(async (modelId: string) => {
     await updateAIModel(modelId)
-  }, [updateAIModel])
+    // Auto-validate with new model if API key exists
+    const key = apiKeys[aiEngine] ?? ''
+    if (key) {
+      await validateApiKey(key, aiEngine, modelId)
+    }
+  }, [updateAIModel, apiKeys, aiEngine, validateApiKey])
 
   const handleBudgetSave = useCallback(() => {
     const val = parseInt(budgetInput, 10)
@@ -242,7 +248,7 @@ function SettingsPage() {
     switch (status) {
       case 'validating': return t('aiEngine.validating')
       case 'valid': return t('aiEngine.valid')
-      case 'invalid': return t('aiEngine.invalid')
+      case 'invalid': return keyValidationMessage || t('aiEngine.invalid')
       default: return null
     }
   }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -55,9 +55,12 @@ function SettingsPage() {
     keyValidationStatus,
     hasDefaultKey,
     providers,
+    dynamicModels,
+    modelsLoading,
     fetchProfile,
     fetchAIConfig,
     fetchProviders,
+    fetchModels,
     updatePersona,
     updateBudget,
     updateAIEngine,
@@ -93,10 +96,11 @@ function SettingsPage() {
   const [showApiKey, setShowApiKey] = useState(false)
   const currentApiKey = apiKeys[aiEngine] ?? ''
 
-  // Current provider's available models
+  // Current provider's available models (prefer dynamic models if available)
   const currentProviderModels = useMemo(() => {
+    if (dynamicModels[aiEngine]?.length) return dynamicModels[aiEngine]
     return providers.find((p) => p.code === aiEngine)?.models ?? []
-  }, [providers, aiEngine])
+  }, [providers, dynamicModels, aiEngine])
 
   // Selected model (use aiModel from store, fallback to default model)
   const selectedModel = useMemo(() => {
@@ -117,22 +121,36 @@ function SettingsPage() {
       const state = useSettingsStore.getState()
       if (state.monthlyBudget > 0) setBudgetInput(String(state.monthlyBudget))
       setAiInstructionsInput(state.aiInstructions)
+      // Fetch dynamic models for current engine if API key exists
+      const keys = apiKeys
+      const currentKey = keys[state.aiEngine] ?? ''
+      if (currentKey || state.hasDefaultKey[state.aiEngine]) {
+        fetchModels(state.aiEngine, currentKey || undefined)
+      }
     }
     load()
-  }, [fetchProfile, fetchAIConfig, fetchProviders])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchProfile, fetchAIConfig, fetchProviders, fetchModels])
 
   const handleEngineChange = useCallback(async (engine: AIEngine) => {
     await updateAIEngine(engine)
     useSettingsStore.setState({ keyValidationStatus: 'idle' })
-    // Auto-select default model for the new provider
-    const provider = useSettingsStore.getState().providers.find((p) => p.code === engine)
-    const defaultModel = provider?.models.find((m) => m.isDefault)
+    // Fetch dynamic models for new engine
+    const key = apiKeys[engine] ?? ''
+    const state = useSettingsStore.getState()
+    if (key || state.hasDefaultKey[engine]) {
+      await fetchModels(engine, key || undefined)
+    }
+    // Auto-select default model
+    const models = useSettingsStore.getState().dynamicModels[engine]
+      ?? state.providers.find((p) => p.code === engine)?.models ?? []
+    const defaultModel = models.find((m) => m.isDefault)
     if (defaultModel) {
       await updateAIModel(defaultModel.id)
     } else {
       await updateAIModel(null)
     }
-  }, [updateAIEngine, updateAIModel])
+  }, [updateAIEngine, updateAIModel, fetchModels, apiKeys])
 
   const handleModelChange = useCallback(async (modelId: string) => {
     await updateAIModel(modelId)
@@ -161,8 +179,12 @@ function SettingsPage() {
 
   const handleValidateKey = useCallback(async () => {
     saveApiKeys(apiKeys)
-    await validateApiKey(currentApiKey, aiEngine, selectedModel || undefined)
-  }, [currentApiKey, apiKeys, saveApiKeys, validateApiKey, aiEngine, selectedModel])
+    const valid = await validateApiKey(currentApiKey, aiEngine, selectedModel || undefined)
+    if (valid && currentApiKey) {
+      // Fetch dynamic models after successful validation
+      await fetchModels(aiEngine, currentApiKey)
+    }
+  }, [currentApiKey, apiKeys, saveApiKeys, validateApiKey, aiEngine, selectedModel, fetchModels])
 
   const handleLanguageChange = useCallback(async (lang: SupportedLanguage) => {
     await setLanguage(lang)
@@ -408,32 +430,6 @@ function SettingsPage() {
           })}
         </div>
 
-        {/* 模型選擇 */}
-        {currentProviderModels.length > 0 && (
-          <div className="mb-lg">
-            <label className="text-caption text-text-secondary mb-sm block">
-              {t('aiEngine.modelLabel')}
-            </label>
-            <select
-              value={selectedModel}
-              onChange={(e) => handleModelChange(e.target.value)}
-              disabled={saving}
-              className="w-full h-12 rounded-md border border-border bg-bg px-lg text-body text-text-primary focus:outline-none focus:border-primary"
-              aria-label={t('aiEngine.modelLabel')}>
-              {currentProviderModels.map((m) => (
-                <option key={m.id} value={m.id}>
-                  {m.name} {m.isDefault ? t('aiEngine.recommended') : ''}
-                </option>
-              ))}
-            </select>
-            {selectedModelDescription && (
-              <p className="text-small text-text-secondary mt-sm">
-                {selectedModelDescription}
-              </p>
-            )}
-          </div>
-        )}
-
         {/* API Key 輸入 */}
         <div className="mt-md">
           <label className="text-caption text-text-secondary mb-sm block">
@@ -469,6 +465,33 @@ function SettingsPage() {
             </p>
           )}
         </div>
+
+        {/* 模型選擇 */}
+        {currentProviderModels.length > 0 && (
+          <div className="mt-lg">
+            <label className="text-caption text-text-secondary mb-sm block">
+              {t('aiEngine.modelLabel')}
+              {modelsLoading && <span className="ml-sm text-text-tertiary">{t('loading')}</span>}
+            </label>
+            <select
+              value={selectedModel}
+              onChange={(e) => handleModelChange(e.target.value)}
+              disabled={saving || modelsLoading}
+              className="w-full h-12 rounded-md border border-border bg-bg px-lg text-body text-text-primary focus:outline-none focus:border-primary disabled:opacity-50"
+              aria-label={t('aiEngine.modelLabel')}>
+              {currentProviderModels.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.name} {m.isDefault ? t('aiEngine.recommended') : ''}
+                </option>
+              ))}
+            </select>
+            {selectedModelDescription && (
+              <p className="text-small text-text-secondary mt-sm">
+                {selectedModelDescription}
+              </p>
+            )}
+          </div>
+        )}
       </section>
 
       {/* 類別管理 */}

--- a/frontend/src/stores/dashboardStore.ts
+++ b/frontend/src/stores/dashboardStore.ts
@@ -162,7 +162,7 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
       const res = await api.post(
         '/ai/parse',
         { raw_text: rawText },
-        { headers: llmHeaders() }
+        { headers: llmHeaders(), timeout: 60000 }
       )
       const data = res.data.data
       const intent: Intent = data.intent ?? 'transaction'

--- a/frontend/src/stores/historyStore.ts
+++ b/frontend/src/stores/historyStore.ts
@@ -241,7 +241,7 @@ export const useHistoryStore = create<HistoryState>((set, get) => ({
       const res = await api.post(
         '/ai/query',
         { query_text: queryText },
-        { headers: llmHeaders() }
+        { headers: llmHeaders(), timeout: 60000 }
       )
 
       const result = res.data.data as AIQueryResult

--- a/frontend/src/stores/settingsStore.ts
+++ b/frontend/src/stores/settingsStore.ts
@@ -243,6 +243,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       if (model) body.model = model
       await api.post('/ai/validate-key', body, {
         headers: { 'X-LLM-API-Key': apiKey },
+        timeout: 30000,
       })
       set({ keyValidationStatus: 'valid', keyValidationMessage: null })
       return true

--- a/frontend/src/stores/settingsStore.ts
+++ b/frontend/src/stores/settingsStore.ts
@@ -39,6 +39,8 @@ interface SettingsState {
 
   /** API Key 驗證狀態 */
   keyValidationStatus: KeyValidationStatus
+  /** 驗證錯誤訊息 */
+  keyValidationMessage: string | null
 
   /** 後端是否配置了預設 API Key（按引擎） */
   hasDefaultKey: Record<string, boolean>
@@ -90,6 +92,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   saving: false,
   error: null,
   keyValidationStatus: 'idle',
+  keyValidationMessage: null,
   hasDefaultKey: {},
   providers: [],
   dynamicModels: {},
@@ -233,7 +236,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   },
 
   validateApiKey: async (apiKey: string, engine?: AIEngine, model?: string) => {
-    set({ keyValidationStatus: 'validating' })
+    set({ keyValidationStatus: 'validating', keyValidationMessage: null })
     try {
       const body: Record<string, string> = {}
       if (engine) body.engine = engine
@@ -241,10 +244,11 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       await api.post('/ai/validate-key', body, {
         headers: { 'X-LLM-API-Key': apiKey },
       })
-      set({ keyValidationStatus: 'valid' })
+      set({ keyValidationStatus: 'valid', keyValidationMessage: null })
       return true
-    } catch {
-      set({ keyValidationStatus: 'invalid' })
+    } catch (err: unknown) {
+      const message = (err as { response?: { data?: { message?: string } } })?.response?.data?.message ?? null
+      set({ keyValidationStatus: 'invalid', keyValidationMessage: message })
       return false
     }
   },

--- a/frontend/src/stores/settingsStore.ts
+++ b/frontend/src/stores/settingsStore.ts
@@ -46,12 +46,19 @@ interface SettingsState {
   /** 供應商與模型列表 */
   providers: ProviderInfo[]
 
+  /** 動態模型列表（按引擎） */
+  dynamicModels: Record<string, ModelInfo[]>
+  /** 模型載入中 */
+  modelsLoading: boolean
+
   /** 從後端載入使用者設定 */
   fetchProfile: () => Promise<void>
   /** 載入 AI 配置（預設 Key 狀態） */
   fetchAIConfig: () => Promise<void>
   /** 載入供應商與模型列表 */
   fetchProviders: () => Promise<void>
+  /** 動態載入模型列表 */
+  fetchModels: (engine: AIEngine, apiKey?: string) => Promise<void>
   /** 更新人設 */
   updatePersona: (persona: Persona) => Promise<void>
   /** 更新月預算 */
@@ -85,6 +92,8 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   keyValidationStatus: 'idle',
   hasDefaultKey: {},
   providers: [],
+  dynamicModels: {},
+  modelsLoading: false,
 
   fetchAIConfig: async () => {
     try {
@@ -100,6 +109,22 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       const data = res.data.data as { providers: ProviderInfo[] }
       set({ providers: data.providers })
     } catch { /* ignore */ }
+  },
+
+  fetchModels: async (engine: AIEngine, apiKey?: string) => {
+    set({ modelsLoading: true })
+    try {
+      const headers: Record<string, string> = {}
+      if (apiKey) headers['X-LLM-API-Key'] = apiKey
+      const res = await api.get(`/ai/models?engine=${engine}`, { headers })
+      const data = res.data.data as { models: ModelInfo[]; dynamic: boolean }
+      set((state) => ({
+        dynamicModels: { ...state.dynamicModels, [engine]: data.models },
+        modelsLoading: false,
+      }))
+    } catch {
+      set({ modelsLoading: false })
+    }
   },
 
   fetchProfile: async () => {

--- a/frontend/src/test/StatsDrilldown.test.tsx
+++ b/frontend/src/test/StatsDrilldown.test.tsx
@@ -263,7 +263,6 @@ describe('Stats Page Drilldown', () => {
           category: 'food',
           merchant: '便利商店',
           note: '買水',
-          ai_comment: '又買零食了嗎？',
           transaction_date: '2026-03-22T00:00:00Z',
           created_at: '2026-03-22T10:00:00Z',
         }))
@@ -290,13 +289,10 @@ describe('Stats Page Drilldown', () => {
     const txToggle = screen.getByTestId('drilldown-tx-toggle-tx-detail-1')
     await user.click(txToggle)
 
-    // Should show AI feedback after lazy loading
+    // Should show note in expanded detail
     await waitFor(() => {
-      expect(screen.getByText('又買零食了嗎？')).toBeInTheDocument()
+      expect(screen.getByText('買水')).toBeInTheDocument()
     })
-
-    // Verify the detail API was called
-    expect(mockGet).toHaveBeenCalledWith('/transactions/tx-detail-1')
   })
 
   it('shows empty message when category has no transactions', async () => {


### PR DESCRIPTION
## Summary
- 未配置 API Key 時顯示預設精選模型清單（2-3 個）
- 配置 API Key 後（或有伺服器預設 Key），自動從供應商 API 動態獲取完整模型列表
- 設定頁 UI 流程調整為：選擇 Provider → 輸入 API Key → 選擇模型
- Gemini 實測從 2 個模型擴展至 33 個可選模型

### 各供應商 List Models 支援
| Provider | List API | 結果 |
|----------|----------|------|
| Gemini | `/v1beta/models` | 動態 33 個模型 |
| OpenAI | `/v1/models` | 動態（依 Key 權限） |
| xAI | `/v1/models` | 動態（grok-* 過濾） |
| Anthropic | 無 | Fallback 預設 2 個 |

### 附帶修復
- 移除 drilldown 交易明細中的「AI 評論」欄位（用處不大）
- 修正 nginx.conf：index.html 加 no-cache 防止部署後瀏覽器載入舊版 JS

Closes #186

## Test plan
- [ ] 設定頁切換 Provider 後模型下拉正確更新
- [ ] 有預設 Key 的 Provider（如 Gemini）顯示動態模型列表
- [ ] 無 Key 的 Provider 顯示預設精選清單
- [ ] API Key 驗證成功後自動刷新模型列表
- [ ] 統計頁 drilldown 展開明細正常（無空白頁）