### PR TITLE
feat: expand Anthropic models + configurable exclude patterns (#189, #190)

### DIFF
--- a/backend/src/services/llm/anthropicProvider.ts
+++ b/backend/src/services/llm/anthropicProvider.ts
@@ -79,9 +79,48 @@ export class AnthropicProvider implements LLMProvider {
     return this.callWithRetry(apiKey, enhancedSystemPrompt, userPrompt, 0, 1024, model);
   }
 
-  async listModels(_apiKey: string): Promise<ModelInfo[]> {
-    // Anthropic does not provide a List Models API
-    return this.getAvailableModels();
+  private static readonly EXCLUDE_PATTERNS = [
+    /^claude-3-haiku/,  // deprecated
+  ];
+
+  async listModels(apiKey: string): Promise<ModelInfo[]> {
+    try {
+      const res = await fetch('https://api.anthropic.com/v1/models?limit=100', {
+        headers: {
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+        },
+        signal: AbortSignal.timeout(10000),
+      });
+      if (!res.ok) return this.getAvailableModels();
+      const data = await res.json() as { data?: Array<{ id: string; display_name: string; created_at: string }> };
+      if (!data.data?.length) return this.getAvailableModels();
+
+      const defaults = this.getAvailableModels();
+      const defaultMap = new Map(defaults.map((m) => [m.id, m]));
+
+      const models: ModelInfo[] = data.data
+        .filter((m) => !AnthropicProvider.EXCLUDE_PATTERNS.some((p) => p.test(m.id)))
+        .map((m) => {
+          const def = defaultMap.get(m.id);
+          return {
+            id: m.id,
+            name: def?.name ?? m.display_name,
+            description: def?.description ?? '',
+            isDefault: def?.isDefault ?? false,
+          };
+        });
+
+      models.sort((a, b) => {
+        if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;
+        if (defaultMap.has(a.id) !== defaultMap.has(b.id)) return defaultMap.has(a.id) ? -1 : 1;
+        return a.id.localeCompare(b.id);
+      });
+
+      return models.length > 0 ? models : this.getAvailableModels();
+    } catch {
+      return this.getAvailableModels();
+    }
   }
 
   getAvailableModels(): ModelInfo[] {
@@ -89,13 +128,19 @@ export class AnthropicProvider implements LLMProvider {
       {
         id: 'claude-haiku-4-5-20251001',
         name: 'Claude Haiku 4.5',
-        description: 'Fast and cost-effective model for everyday tasks',
+        description: 'Fastest model, ideal for everyday tasks ($1/$5 per MTok)',
         isDefault: true,
       },
       {
-        id: 'claude-sonnet-4-5-20250514',
-        name: 'Claude Sonnet 4.5',
-        description: 'Advanced model with strong reasoning and analysis',
+        id: 'claude-sonnet-4-6',
+        name: 'Claude Sonnet 4.6',
+        description: 'Best speed-intelligence balance ($3/$15 per MTok)',
+        isDefault: false,
+      },
+      {
+        id: 'claude-opus-4-6',
+        name: 'Claude Opus 4.6',
+        description: 'Most intelligent, best for agents and coding ($5/$25 per MTok)',
         isDefault: false,
       },
     ];

--- a/backend/src/services/llm/geminiProvider.ts
+++ b/backend/src/services/llm/geminiProvider.ts
@@ -90,6 +90,11 @@ export class GeminiProvider implements LLMProvider {
     return this.callWithRetry(apiKey, systemPrompt, userPrompt, 0, 1024, 'application/json', model);
   }
 
+  private static readonly EXCLUDE_PATTERNS = [
+    /embedding/i, /aqa/i, /imagen/i, /veo/i, /chirp/i, /codec/i,
+    /text-bison/i, /chat-bison/i, /gemma/i, /learnlm/i,
+  ];
+
   async listModels(apiKey: string): Promise<ModelInfo[]> {
     try {
       const res = await fetch(
@@ -114,7 +119,8 @@ export class GeminiProvider implements LLMProvider {
             description: def?.description ?? (m.description?.substring(0, 80) ?? ''),
             isDefault: def?.isDefault ?? false,
           };
-        });
+        })
+        .filter((m) => !GeminiProvider.EXCLUDE_PATTERNS.some((p) => p.test(m.id)));
 
       models.sort((a, b) => {
         if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;

--- a/backend/src/services/llm/openaiProvider.ts
+++ b/backend/src/services/llm/openaiProvider.ts
@@ -94,6 +94,14 @@ export class OpenAIProvider implements LLMProvider {
     return this.callWithRetry(apiKey, systemPrompt, userPrompt, 0, 1024, model);
   }
 
+  protected static readonly EXCLUDE_PATTERNS: RegExp[] = [
+    /instruct/i, /realtime/i, /audio/i, /tts/i, /dall/i,
+    /whisper/i, /embed/i, /search/i, /moderation/i,
+    /babbage/i, /davinci/i, /curie/i, /ada(?!ptive)/i,
+  ];
+
+  protected static readonly INCLUDE_PATTERN = /^(gpt-|o[134]-|chatgpt-)/;
+
   async listModels(apiKey: string): Promise<ModelInfo[]> {
     try {
       const client = this.getClient(apiKey);
@@ -101,9 +109,11 @@ export class OpenAIProvider implements LLMProvider {
       const models: ModelInfo[] = [];
       const defaults = this.getAvailableModels();
       const defaultMap = new Map(defaults.map((m) => [m.id, m]));
+      const excludes = (this.constructor as typeof OpenAIProvider).EXCLUDE_PATTERNS;
+      const include = (this.constructor as typeof OpenAIProvider).INCLUDE_PATTERN;
 
       for await (const model of response) {
-        if (/^(gpt-|o[134]-|chatgpt-)/.test(model.id) && !/instruct|realtime|audio|tts|dall|whisper|embed|search/i.test(model.id)) {
+        if (include.test(model.id) && !excludes.some((p) => p.test(model.id))) {
           const def = defaultMap.get(model.id);
           models.push({
             id: model.id,

--- a/backend/src/services/llm/xaiProvider.ts
+++ b/backend/src/services/llm/xaiProvider.ts
@@ -37,6 +37,12 @@ export class XAIProvider extends OpenAIProvider {
     throw createI18nError('llm_service_unavailable', 502);
   }
 
+  protected static override readonly EXCLUDE_PATTERNS: RegExp[] = [
+    /embed/i, /image/i,
+  ];
+
+  protected static override readonly INCLUDE_PATTERN = /^grok-/;
+
   override async listModels(apiKey: string): Promise<ModelInfo[]> {
     try {
       const client = this.getClient(apiKey);
@@ -46,7 +52,7 @@ export class XAIProvider extends OpenAIProvider {
       const defaultMap = new Map(defaults.map((m) => [m.id, m]));
 
       for await (const model of response) {
-        if (/^grok-/.test(model.id)) {
+        if (XAIProvider.INCLUDE_PATTERN.test(model.id) && !XAIProvider.EXCLUDE_PATTERNS.some((p) => p.test(model.id))) {
           const def = defaultMap.get(model.id);
           models.push({
             id: model.id,


### PR DESCRIPTION
## 變更摘要
擴充 Anthropic 模型清單並為所有 Provider 增加可配置的正則排除清單，過濾動態模型列表中不適用的模型。

## 關聯 Issue
Closes #189
Closes #190

## 變更清單
- **Anthropic**: 新增 `listModels()` 動態獲取（透過 `GET /v1/models`）；預設清單擴充為 Haiku 4.5 / Sonnet 4.6 / Opus 4.6
- **OpenAI**: `EXCLUDE_PATTERNS` 排除 instruct/realtime/audio/tts/dall/whisper/embed/search/moderation/babbage/davinci/curie/ada
- **Gemini**: `EXCLUDE_PATTERNS` 排除 embedding/aqa/imagen/veo/chirp/codec/text-bison/chat-bison/gemma/learnlm
- **xAI**: `EXCLUDE_PATTERNS` 排除 embed/image
- 所有 patterns 定義為 `static readonly` 陣列，便於日後維護

## 測試結果
- 單元測試：✅ 全部通過（289/289）
- 本地驗證：✅ Vibe Check 通過