### PR TITLE
feat: support .env override for model include/exclude patterns (#193)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,9 +42,37 @@ OPENAI_MODEL=gpt-5.4-mini
 # DEFAULT_GEMINI_API_KEY=AIzaSy...
 # DEFAULT_OPENAI_API_KEY=sk-proj-...
 
+# Anthropic 模型（預設：claude-haiku-4-5-20251001）
+ANTHROPIC_MODEL=claude-haiku-4-5-20251001
+
+# xAI 模型（預設：grok-3-mini-fast）
+XAI_MODEL=grok-3-mini-fast
+
+# 預設 API Key — Anthropic / xAI（可選）
+# DEFAULT_ANTHROPIC_API_KEY=sk-ant-...
+# DEFAULT_XAI_API_KEY=xai-...
+
 # LLM 請求逾時（毫秒）
 # Gemini 預設 30000ms，OpenAI 預設 10000ms
 LLM_TIMEOUT_MS=30000
+
+# --------------------------------------------
+# 模型列表過濾（可選，覆蓋預設 include/exclude 正則）
+# --------------------------------------------
+# 逗號分隔的正則表達式，case-insensitive
+# 設定後完全覆蓋程式碼預設值；不設定則使用預設
+
+# GEMINI_MODEL_INCLUDE=^gemini-
+# GEMINI_MODEL_EXCLUDE=embedding,-image,tts,robotics,computer.?use,nano,customtools
+
+# OPENAI_MODEL_INCLUDE=^gpt-5\\.4,^o4-
+# OPENAI_MODEL_EXCLUDE=image,codex,-chat-latest$
+
+# XAI_MODEL_INCLUDE=^grok-
+# XAI_MODEL_EXCLUDE=embed,image
+
+# ANTHROPIC_MODEL_INCLUDE=^claude-
+# ANTHROPIC_MODEL_EXCLUDE=^claude-3-haiku
 
 # --------------------------------------------
 # 速率限制（每分鐘請求數）

--- a/backend/src/services/llm/anthropicProvider.ts
+++ b/backend/src/services/llm/anthropicProvider.ts
@@ -1,5 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { LLMProvider, ValidationResult } from './llmProvider';
+import { loadModelFilters } from './modelFilterConfig';
 import { ParsedTransaction, AIFeedbackContent, ModelInfo } from '../../types/llm';
 import { DATA_EXTRACTOR_SYSTEM_PROMPT } from '../../prompts/dataExtractorPrompt';
 import { createI18nError } from '../../middlewares/errorHandler';
@@ -79,15 +80,13 @@ export class AnthropicProvider implements LLMProvider {
     return this.callWithRetry(apiKey, enhancedSystemPrompt, userPrompt, 0, 1024, model);
   }
 
-  /** Include patterns: model ID must match at least one */
-  private static readonly INCLUDE_PATTERNS: RegExp[] = [
-    /^claude-/i,
-  ];
+  private static readonly DEFAULT_INCLUDES: RegExp[] = [/^claude-/i];
+  private static readonly DEFAULT_EXCLUDES: RegExp[] = [/^claude-3-haiku/];
 
-  /** Exclude patterns: applied after include filter */
-  private static readonly EXCLUDE_PATTERNS: RegExp[] = [
-    /^claude-3-haiku/,  // deprecated
-  ];
+  private static readonly MODEL_FILTERS = loadModelFilters(
+    'ANTHROPIC_MODEL_INCLUDE', 'ANTHROPIC_MODEL_EXCLUDE',
+    AnthropicProvider.DEFAULT_INCLUDES, AnthropicProvider.DEFAULT_EXCLUDES,
+  );
 
   async listModels(apiKey: string): Promise<ModelInfo[]> {
     try {
@@ -107,8 +106,9 @@ export class AnthropicProvider implements LLMProvider {
 
       const models: ModelInfo[] = data.data
         .filter((m) => {
-          const included = AnthropicProvider.INCLUDE_PATTERNS.length === 0 || AnthropicProvider.INCLUDE_PATTERNS.some((p) => p.test(m.id));
-          return included && !AnthropicProvider.EXCLUDE_PATTERNS.some((p) => p.test(m.id));
+          const { includes, excludes } = AnthropicProvider.MODEL_FILTERS;
+          const included = includes.length === 0 || includes.some((p) => p.test(m.id));
+          return included && !excludes.some((p) => p.test(m.id));
         })
         .map((m) => {
           const def = defaultMap.get(m.id);

--- a/backend/src/services/llm/geminiProvider.ts
+++ b/backend/src/services/llm/geminiProvider.ts
@@ -1,5 +1,6 @@
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { LLMProvider, ValidationResult } from './llmProvider';
+import { loadModelFilters } from './modelFilterConfig';
 import { ParsedTransaction, AIFeedbackContent, ModelInfo } from '../../types/llm';
 import { DATA_EXTRACTOR_SYSTEM_PROMPT } from '../../prompts/dataExtractorPrompt';
 import { createI18nError } from '../../middlewares/errorHandler';
@@ -90,16 +91,16 @@ export class GeminiProvider implements LLMProvider {
     return this.callWithRetry(apiKey, systemPrompt, userPrompt, 0, 1024, 'application/json', model);
   }
 
-  /** Include patterns: model ID must match at least one */
-  private static readonly INCLUDE_PATTERNS: RegExp[] = [
-    /^gemini-/i,
-  ];
-
-  /** Exclude patterns: applied after include filter */
-  private static readonly EXCLUDE_PATTERNS: RegExp[] = [
+  private static readonly DEFAULT_INCLUDES: RegExp[] = [/^gemini-/i];
+  private static readonly DEFAULT_EXCLUDES: RegExp[] = [
     /embedding/i, /-image(?:-|$)/i, /tts/i,
     /robotics/i, /computer.?use/i, /nano/i, /customtools/i,
   ];
+
+  private static readonly MODEL_FILTERS = loadModelFilters(
+    'GEMINI_MODEL_INCLUDE', 'GEMINI_MODEL_EXCLUDE',
+    GeminiProvider.DEFAULT_INCLUDES, GeminiProvider.DEFAULT_EXCLUDES,
+  );
 
   async listModels(apiKey: string): Promise<ModelInfo[]> {
     try {
@@ -127,8 +128,9 @@ export class GeminiProvider implements LLMProvider {
           };
         })
         .filter((m) => {
-          const included = GeminiProvider.INCLUDE_PATTERNS.length === 0 || GeminiProvider.INCLUDE_PATTERNS.some((p) => p.test(m.id));
-          return included && !GeminiProvider.EXCLUDE_PATTERNS.some((p) => p.test(m.id));
+          const { includes, excludes } = GeminiProvider.MODEL_FILTERS;
+          const included = includes.length === 0 || includes.some((p) => p.test(m.id));
+          return included && !excludes.some((p) => p.test(m.id));
         });
 
       models.sort((a, b) => {

--- a/backend/src/services/llm/modelFilterConfig.ts
+++ b/backend/src/services/llm/modelFilterConfig.ts
@@ -1,0 +1,31 @@
+/**
+ * Parse comma-separated regex patterns from environment variable.
+ * Returns undefined if env var is not set or empty (use default patterns).
+ * Logs warning and returns undefined if any pattern fails to parse.
+ */
+export function parseEnvPatterns(envVar: string | undefined): RegExp[] | undefined {
+  if (!envVar?.trim()) return undefined;
+
+  try {
+    return envVar.split(',').map((p) => new RegExp(p.trim(), 'i'));
+  } catch (err) {
+    console.warn(`[ModelFilter] Failed to parse patterns "${envVar}":`, err);
+    return undefined;
+  }
+}
+
+/**
+ * Load include/exclude patterns for a provider.
+ * Environment variable overrides take precedence over code defaults.
+ */
+export function loadModelFilters(
+  includeEnvKey: string,
+  excludeEnvKey: string,
+  defaultIncludes: RegExp[],
+  defaultExcludes: RegExp[],
+): { includes: RegExp[]; excludes: RegExp[] } {
+  return {
+    includes: parseEnvPatterns(process.env[includeEnvKey]) ?? defaultIncludes,
+    excludes: parseEnvPatterns(process.env[excludeEnvKey]) ?? defaultExcludes,
+  };
+}

--- a/backend/src/services/llm/openaiProvider.ts
+++ b/backend/src/services/llm/openaiProvider.ts
@@ -1,5 +1,6 @@
 import OpenAI from 'openai';
 import { LLMProvider, ValidationResult } from './llmProvider';
+import { loadModelFilters } from './modelFilterConfig';
 import { ParsedTransaction, AIFeedbackContent, ModelInfo } from '../../types/llm';
 import { DATA_EXTRACTOR_SYSTEM_PROMPT } from '../../prompts/dataExtractorPrompt';
 import { createI18nError } from '../../middlewares/errorHandler';
@@ -94,15 +95,13 @@ export class OpenAIProvider implements LLMProvider {
     return this.callWithRetry(apiKey, systemPrompt, userPrompt, 0, 1024, model);
   }
 
-  /** Include patterns: model ID must match at least one */
-  protected static readonly INCLUDE_PATTERNS: RegExp[] = [
-    /^gpt-5\.4/i, /^o4-/i,
-  ];
+  protected static readonly DEFAULT_INCLUDES: RegExp[] = [/^gpt-5\.4/i, /^o4-/i];
+  protected static readonly DEFAULT_EXCLUDES: RegExp[] = [/image/i, /codex/i, /-chat-latest$/i];
 
-  /** Exclude patterns: applied after include filter */
-  protected static readonly EXCLUDE_PATTERNS: RegExp[] = [
-    /image/i, /codex/i, /-chat-latest$/i,
-  ];
+  protected static readonly MODEL_FILTERS = loadModelFilters(
+    'OPENAI_MODEL_INCLUDE', 'OPENAI_MODEL_EXCLUDE',
+    OpenAIProvider.DEFAULT_INCLUDES, OpenAIProvider.DEFAULT_EXCLUDES,
+  );
 
   async listModels(apiKey: string): Promise<ModelInfo[]> {
     try {
@@ -111,8 +110,7 @@ export class OpenAIProvider implements LLMProvider {
       const models: ModelInfo[] = [];
       const defaults = this.getAvailableModels();
       const defaultMap = new Map(defaults.map((m) => [m.id, m]));
-      const includes = (this.constructor as typeof OpenAIProvider).INCLUDE_PATTERNS;
-      const excludes = (this.constructor as typeof OpenAIProvider).EXCLUDE_PATTERNS;
+      const { includes, excludes } = (this.constructor as typeof OpenAIProvider).MODEL_FILTERS;
 
       for await (const model of response) {
         const included = includes.length === 0 || includes.some((p) => p.test(model.id));

--- a/backend/src/services/llm/xaiProvider.ts
+++ b/backend/src/services/llm/xaiProvider.ts
@@ -2,6 +2,7 @@ import OpenAI from 'openai';
 import { OpenAIProvider } from './openaiProvider';
 import { ModelInfo } from '../../types/llm';
 import { createI18nError } from '../../middlewares/errorHandler';
+import { loadModelFilters } from './modelFilterConfig';
 
 const XAI_MODEL = process.env.XAI_MODEL || 'grok-3-mini-fast';
 const TIMEOUT_MS = Number(process.env.LLM_TIMEOUT_MS) || 30000;
@@ -37,13 +38,13 @@ export class XAIProvider extends OpenAIProvider {
     throw createI18nError('llm_service_unavailable', 502);
   }
 
-  protected static override readonly INCLUDE_PATTERNS: RegExp[] = [
-    /^grok-/i,
-  ];
+  protected static override readonly DEFAULT_INCLUDES: RegExp[] = [/^grok-/i];
+  protected static override readonly DEFAULT_EXCLUDES: RegExp[] = [/embed/i, /image/i];
 
-  protected static override readonly EXCLUDE_PATTERNS: RegExp[] = [
-    /embed/i, /image/i,
-  ];
+  protected static override readonly MODEL_FILTERS = loadModelFilters(
+    'XAI_MODEL_INCLUDE', 'XAI_MODEL_EXCLUDE',
+    XAIProvider.DEFAULT_INCLUDES, XAIProvider.DEFAULT_EXCLUDES,
+  );
 
   override async listModels(apiKey: string): Promise<ModelInfo[]> {
     try {
@@ -54,8 +55,9 @@ export class XAIProvider extends OpenAIProvider {
       const defaultMap = new Map(defaults.map((m) => [m.id, m]));
 
       for await (const model of response) {
-        const included = XAIProvider.INCLUDE_PATTERNS.length === 0 || XAIProvider.INCLUDE_PATTERNS.some((p) => p.test(model.id));
-        if (included && !XAIProvider.EXCLUDE_PATTERNS.some((p) => p.test(model.id))) {
+        const { includes, excludes } = XAIProvider.MODEL_FILTERS;
+        const included = includes.length === 0 || includes.some((p) => p.test(model.id));
+        if (included && !excludes.some((p) => p.test(model.id))) {
           const def = defaultMap.get(model.id);
           models.push({
             id: model.id,


### PR DESCRIPTION
## 變更摘要
各 Provider 的模型 include/exclude 過濾清單現在可透過 `.env` 環境變數覆蓋，無需改程式碼即可調整過濾規則。

## 關聯 Issue
Closes #193

## 變更清單
- 新增 `modelFilterConfig.ts`：`parseEnvPatterns()` 解析逗號分隔正則、`loadModelFilters()` 載入配置
- Gemini: 讀取 `GEMINI_MODEL_INCLUDE` / `GEMINI_MODEL_EXCLUDE`
- OpenAI: 讀取 `OPENAI_MODEL_INCLUDE` / `OPENAI_MODEL_EXCLUDE`
- xAI: 讀取 `XAI_MODEL_INCLUDE` / `XAI_MODEL_EXCLUDE`
- Anthropic: 讀取 `ANTHROPIC_MODEL_INCLUDE` / `ANTHROPIC_MODEL_EXCLUDE`
- `.env.example` 更新：新增 Anthropic/xAI 模型配置與過濾環境變數範例

## 測試結果
- 單元測試：✅ 全部通過（289/289）
- 本地驗證：✅ Vibe Check 通過
- 未設定環境變數時行為不變（使用程式碼預設值）