### PR TITLE
fix(ci): correct DATABASE_URL in .env.example to PostgreSQL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,9 @@ API_PORT=3000
 # JWT 密鑰（正式環境請使用強隨機字串）
 JWT_SECRET=your-jwt-secret-change-me
 
-# 資料庫（SQLite）
-DATABASE_URL=file:/app/data/dev.db
+# 資料庫（PostgreSQL，由 docker-compose 內建 postgres 服務提供）
+# host = postgres（compose service 名稱），user/password/db 對應 docker-compose.yml fallback 預設值
+DATABASE_URL=postgresql://vibe:vibe_password@postgres:5432/vibe_money_book
 
 # CORS 允許的來源
 CORS_ORIGIN=https://moneybook.smart-codings.com


### PR DESCRIPTION
## Summary
- 修復 main 從 2026-03-26 起連續紅燈的 E2E job
- `.env.example` 內 `DATABASE_URL` 仍是過時的 SQLite URL，但 backend 已改用 PostgreSQL，CI E2E 第一步 `cp .env.example .env` 導致錯誤的 URL 被注入 backend container
- 改為與 `docker-compose.yml` `postgres` 服務 fallback 一致的 PostgreSQL connection string

## 根因

CI workflow `ci.yml:64` 執行 `cp .env.example .env`，所以 `.env.example` 即 CI 的事實環境變數來源。`.env.example` 第 18-19 行原為：

```
# 資料庫（SQLite）
DATABASE_URL=file:/app/data/dev.db
```

而 `backend/prisma/schema.prisma` 是：

```
datasource db {
  provider = "postgresql"
  url      = env("DATABASE_URL")
}
```

Prisma 啟動時驗證失敗：

```
Error validating datasource `db`:
the URL must start with the protocol `postgresql://` or `postgres://`.
```

backend container 反覆 crash → 健康檢查 timeout → E2E job FAIL。

## 修正

```diff
- # 資料庫（SQLite）
- DATABASE_URL=file:/app/data/dev.db
+ # 資料庫（PostgreSQL，由 docker-compose 內建 postgres 服務提供）
+ # host = postgres（compose service 名稱），user/password/db 對應 docker-compose.yml fallback 預設值
+ DATABASE_URL=postgresql://vibe:vibe_password@postgres:5432/vibe_money_book
```

User/password/db 沿用 `docker-compose.yml` postgres 服務的 fallback 預設值（`vibe / vibe_password / vibe_money_book`）。

## Test plan
- [ ] PR CI 跑完，預期 E2E job 從 FAIL 轉為 SUCCESS
- [ ] 本地開發者首次 clone 後 `cp .env.example .env && docker compose up` 應能正常啟動 backend

## 為何只改 .env.example，不動 docker-compose.yml
`docker-compose.yml` 已經有正確的 fallback (`${DATABASE_URL:-postgresql://...}`)，問題只是 `.env.example` 的值會 override 這個 fallback。修最小範圍即可。