### PR TITLE
fix(ci): override VITE_API_BASE_URL & CORS_ORIGIN for E2E job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Create .env for docker-compose
-        run: cp .env.example .env
+        run: |
+          cp .env.example .env
+          # E2E 專用 override：避免 frontend build 時注入 production URL
+          # 原因：.env.example 的 VITE_API_BASE_URL / CORS_ORIGIN 指向 production
+          # 導致 browser login 會打到 Cloudflare Tunnel 外部端點而非 CI backend
+          sed -i 's|^VITE_API_BASE_URL=.*|VITE_API_BASE_URL=http://localhost:3000/api/v1|' .env
+          sed -i 's|^CORS_ORIGIN=.*|CORS_ORIGIN=http://localhost|' .env
 
       - name: Start services with docker-compose
         run: docker compose up -d --build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,11 @@ jobs:
           # 導致 browser login 會打到 Cloudflare Tunnel 外部端點而非 CI backend
           sed -i 's|^VITE_API_BASE_URL=.*|VITE_API_BASE_URL=http://localhost:3000/api/v1|' .env
           sed -i 's|^CORS_ORIGIN=.*|CORS_ORIGIN=http://localhost|' .env
+          # 調高 rate limit：E2E 跑 57 個 test，每個 test beforeEach 都會註冊使用者
+          # 預設 RATE_LIMIT_AUTH_PER_MIN=10 會在第 6 個 test 起全數 429
+          sed -i 's|^RATE_LIMIT_AUTH_PER_MIN=.*|RATE_LIMIT_AUTH_PER_MIN=10000|' .env
+          sed -i 's|^RATE_LIMIT_API_PER_MIN=.*|RATE_LIMIT_API_PER_MIN=10000|' .env
+          sed -i 's|^RATE_LIMIT_LLM_PER_MIN=.*|RATE_LIMIT_LLM_PER_MIN=10000|' .env
 
       - name: Start services with docker-compose
         run: docker compose up -d --build


### PR DESCRIPTION
Fixes #203

## Summary
修復 main 分支 E2E job 從 2026-03-26 起連續紅燈的**第二層根因**：
`.env.example` 的 `VITE_API_BASE_URL` 與 `CORS_ORIGIN` 指向 production，導致 CI 的 frontend build 後會打外部 Cloudflare Tunnel 端點而非 CI backend container。

## 時序圖

```
失敗 1（~03-26 ~ #202）：
  backend container 因 DATABASE_URL=SQLite 啟不來 → E2E 超時
  ↓ PR #202 修復
失敗 2（#202 合併後 ~ 本 PR）：
  backend 起得來，但 frontend bake 了 production URL
  → browser login 打 Cloudflare Tunnel（沒後端，回 502/timeout）
  → loginViaUI 的 waitForURL timeout
  → 所有依賴登入的 test 全掛（錯誤訊息誤導為 AI 解析問題）
  ↓ 本 PR 修復
預期結果：
  Backend 起得來 + Frontend 打 CI backend + CORS 允許 localhost
  → 登入成功 → 測試繼續 → AI 測試走 Playwright route mock（已存在）
```

## 診斷重點（修正了原本對 #203 的誤判）

原本 #203 假設根因是「CI 缺 LLM API key」，**這個診斷是錯的**：

1. ❌ 假設：E2E 需要真實 LLM key
2. ✅ 實際：`tests/fixtures/test-helpers.ts:162` 的 `mockAIParseResponse()` 已用 `page.route('**/api/v1/ai/parse', ...)` 攔截，AI 層根本不走真實 LLM
3. 實地檢視 Playwright 失敗訊息 `page.waitForURL: timeout 30000ms exceeded`，唯一的 `page.waitForURL` 在 `loginViaUI()` 裡 → 失敗點是**登入**而非 AI
4. 追查 frontend build args + backend CORS middleware → 確認兩個 production URL 的問題

## 變更

```diff
# .github/workflows/ci.yml
  - name: Create .env for docker-compose
-   run: cp .env.example .env
+   run: |
+     cp .env.example .env
+     sed -i 's|^VITE_API_BASE_URL=.*|VITE_API_BASE_URL=http://localhost:3000/api/v1|' .env
+     sed -i 's|^CORS_ORIGIN=.*|CORS_ORIGIN=http://localhost|' .env
```

**設計原則**：最小入侵 — 不動 `.env.example`（保留為 production 基準），僅 CI E2E 路徑受影響。

## Test plan
- [ ] CI 跑完，預期 Backend/Frontend 綠、E2E 從 ❌ fail 轉為 ✅ pass（至少前幾個 test case 不再 timeout）
- [ ] 若仍有部分 test 失敗，查看具體是哪個 step（代表還有更裡層的 regression）

## 殘餘風險
- 若 backend 有其他 runtime 問題（例如 LLM provider init 抛錯），修這個只會解開登入層、後續 AI 測試仍可能失敗
- 但機率低：原本 Backend CI（單元測試）就能通過，代表 runtime 層面是 OK 的