### PR TITLE
docs: add SDD v1.0 & UI wireframes to comply with vibe-sdlc-spec

### DIFF
--- a/docs/01-3-SDD.md
+++ b/docs/01-3-SDD.md
@@ -1,0 +1,1021 @@
+# 01-3 系統設計文件 (SDD)
+
+> **專案名稱**：Vibe Money Book — 語音記帳應用
+> **版本**：v1.0
+> **最後更新**：2026-04-10
+
+---
+
+## 目錄
+
+1. [系統架構總覽](#1-系統架構總覽)
+2. [技術棧選型與決策](#2-技術棧選型與決策)
+3. [前後端架構設計](#3-前後端架構設計)
+4. [數據模型設計](#4-數據模型設計)
+5. [LLM 整合設計](#5-llm-整合設計)
+6. [國際化架構設計 (i18n)](#6-國際化架構設計-i18n)
+7. [設計決策記錄 (ADR)](#7-設計決策記錄-adr)
+8. [錯誤處理策略](#8-錯誤處理策略)
+9. [快取與效能設計](#9-快取與效能設計)
+10. [安全設計](#10-安全設計)
+
+---
+
+## 1. 系統架構總覽
+
+### 1.1 系統架構圖
+
+```mermaid
+graph TB
+    subgraph Client["客戶端層"]
+        User["使用者<br/>（手機/桌面瀏覽器）"]
+    end
+
+    subgraph Frontend["前端 — React SPA"]
+        SPA["React 18 + Vite<br/>TypeScript + Tailwind CSS"]
+        PWA["PWA 離線支援<br/>vite-plugin-pwa"]
+        VoiceModule["語音模組<br/>Web Speech API"]
+        I18nFE["國際化<br/>react-i18next"]
+    end
+
+    subgraph Backend["後端 — Express + TypeScript"]
+        Router["API Router<br/>RESTful /api/v1"]
+        AuthMW["認證中間件<br/>JWT 驗證"]
+        RateLimiter["限流中間件<br/>速率控制"]
+        Controllers["Controllers<br/>請求/回應處理"]
+        Services["Services<br/>業務邏輯"]
+        LLMAbstraction["LLM 抽象層<br/>LLMProvider 介面"]
+        Repositories["Repositories<br/>Prisma 資料存取"]
+        I18nBE["國際化<br/>i18next"]
+    end
+
+    subgraph LLMServices["外部 LLM 服務（PRD-F-013, F-017）"]
+        OpenAI["OpenAI API<br/>gpt-4o-mini（預設）"]
+        Gemini["Gemini API<br/>gemini-2.0-flash-lite"]
+        Anthropic["Anthropic API<br/>claude-haiku"]
+        XAI["xAI API<br/>grok-mini"]
+    end
+
+    subgraph Database["資料庫層"]
+        PostgreSQL["PostgreSQL 15+<br/>（開發環境：SQLite）"]
+    end
+
+    User -->|HTTPS| SPA
+    SPA --> VoiceModule
+    SPA --> PWA
+    SPA --> I18nFE
+    SPA -->|API 請求<br/>Authorization + Accept-Language<br/>+ X-LLM-API-Key + X-LLM-Engine/Model| Router
+
+    Router --> AuthMW --> RateLimiter --> Controllers
+    Controllers --> Services
+    Services --> LLMAbstraction
+    Services --> Repositories
+    Services --> I18nBE
+    LLMAbstraction -->|預設| OpenAI
+    LLMAbstraction -.->|可切換| Gemini
+    LLMAbstraction -.->|可切換| Anthropic
+    LLMAbstraction -.->|可切換| XAI
+    Repositories -->|Prisma ORM| PostgreSQL
+```
+
+### 1.2 各層職責說明
+
+| 層級 | 職責 | 關鍵特徵 |
+|------|------|---------|
+| **客戶端層** | 使用者透過瀏覽器存取應用 | 支援手機與桌面，PWA 離線基本功能 |
+| **前端層 (React SPA)** | UI 渲染、語音輸入、狀態管理、路由導航 | 單頁應用，Zustand 狀態管理，Web Speech API 語音辨識 |
+| **後端 API 層 (Express)** | 請求路由、認證授權、業務邏輯、LLM 代理 | RESTful API，JWT 認證，Zod 驗證 |
+| **LLM 服務層** | 自然語言解析、情緒回饋生成、語義查詢 | **多引擎抽象**（OpenAI / Gemini / Anthropic / xAI），使用者自帶 API Key 與模型（PRD-F-013, F-017） |
+| **資料庫層** | 資料持久化、交易記錄、使用者資訊 | PostgreSQL（正式）/ SQLite（開發） |
+
+### 1.3 資料流概述
+
+1. **記帳流程**：使用者語音/文字輸入 → 前端送出至後端 → LLM 萃取結構化資料 → 存入資料庫 → LLM 生成人設回饋 → 回傳前端顯示
+2. **查詢流程**：使用者自然語言查詢 → 後端 LLM 解析時間範圍 → 資料庫撈取交易 → LLM 匹配分析 → 回傳匹配結果與評語
+3. **認證流程**：登入/註冊 → JWT 簽發 → 前端 localStorage 儲存 → 後續請求 Header 攜帶 Token
+
+---
+
+## 2. 技術棧選型與決策
+
+### 2.1 前端技術棧
+
+| 技術 | 版本 | 用途 | 選擇理由 |
+|------|------|------|---------|
+| **React** | 18+ | UI 框架 | 生態成熟、社群龐大、Hooks 模式開發效率高 |
+| **Vite** | 5+ | 建構工具 | 開發環境 HMR 極快、ESM 原生支援、設定簡潔 |
+| **TypeScript** | 5+ | 型別系統 | 編譯期型別檢查降低 Runtime 錯誤、提升 AI 輔助開發精度 |
+| **Tailwind CSS** | 3.x | 樣式方案 | Utility-first 減少自訂 CSS、與 Design Tokens 整合佳 |
+| **Zustand** | 4+ | 狀態管理 | 輕量（< 1KB）、API 簡潔、內建 persist middleware |
+| **Recharts** | 2+ | 圖表繪製 | 基於 React 組件化、宣告式 API、響應式圖表 |
+| **Web Speech API** | — | 語音輸入 | 瀏覽器原生 API、無需額外後端服務、零延遲本地處理 |
+| **React Router** | v6 | 路由管理 | React 官方推薦、支援巢狀路由與 Lazy Loading |
+| **vite-plugin-pwa** | — | PWA 支援 | 基於 Workbox、Service Worker 自動生成、離線快取 |
+| **react-i18next** | — | 國際化 | React 生態最成熟 i18n 方案、支援 namespace 與 lazy loading |
+
+### 2.2 後端技術棧
+
+| 技術 | 版本 | 用途 | 選擇理由 |
+|------|------|------|---------|
+| **Node.js** | 20 LTS | Runtime | JavaScript 全棧統一語言、非同步 I/O 適合 API 服務 |
+| **Express.js** | 4.x | Web 框架 | 輕量靈活、中間件生態豐富、學習曲線低 |
+| **TypeScript** | 5+ | 型別系統 | 前後端共享型別定義、降低介面不一致風險 |
+| **Prisma** | 5+ | ORM | Type-safe 查詢、自動產生遷移、Schema 即文件 |
+| **Zod** | 3+ | 驗證 | TypeScript-first、可從 Schema 推導型別、Runtime 驗證 |
+| **JWT (jsonwebtoken)** | — | 認證 | 無狀態認證、適合 SPA、不需 Session Store |
+| **bcrypt** | — | 密碼加密 | 業界標準、自適應工作因子 |
+| **OpenAI SDK** | — | LLM 客戶端（OpenAI / xAI，相容 OpenAI API 規範） | 官方 SDK、型別完整、串流支援 |
+| **Google Generative AI SDK** | — | LLM 客戶端（Gemini） | 官方 SDK、Gemini 模型存取 |
+| **Anthropic SDK** | — | LLM 客戶端（Claude） | 官方 SDK、Claude 模型存取（PRD-F-017） |
+
+### 2.3 資料庫
+
+| 技術 | 用途 | 選擇理由 |
+|------|------|---------|
+| **PostgreSQL 15+** | 正式環境主資料庫 | 功能完整、JSONB 支援佳、Prisma 原生支援 |
+| **SQLite** | 開發環境資料庫 | 零設定、單檔部署、Prisma 支援切換、降低開發門檻 |
+
+---
+
+## 3. 前後端架構設計
+
+### 3.1 前端目錄結構與職責
+
+```
+frontend/
+  src/
+    ├── pages/           # 頁面組件（對應路由）
+    │   ├── DashboardPage.tsx    # 首頁儀表板
+    │   ├── StatsPage.tsx        # 統計分析頁
+    │   ├── HistoryPage.tsx      # 交易記錄頁（含語義查詢）
+    │   ├── SettingsPage.tsx     # 設定頁
+    │   ├── LoginPage.tsx        # 登入頁
+    │   └── RegisterPage.tsx     # 註冊頁
+    ├── components/      # 可復用組件
+    │   ├── dashboard/   # 儀表板相關（預算卡片、近期交易）
+    │   ├── budget/      # 預算相關（預算血條、類別預算）
+    │   ├── voice/       # 語音輸入組件（麥克風按鈕、語音狀態）
+    │   └── common/      # 通用組件（Header、BottomNav、Loading）
+    ├── hooks/           # 自定義 Hooks
+    │   ├── useVoice.ts          # 語音輸入封裝
+    │   ├── useAuth.ts           # 認證狀態
+    │   └── useBudget.ts         # 預算計算
+    ├── services/        # API 呼叫層（Axios 封裝）
+    │   ├── api.ts               # Axios instance + interceptors
+    │   ├── authService.ts       # 認證相關 API
+    │   ├── transactionService.ts # 交易相關 API
+    │   └── aiService.ts         # LLM 相關 API
+    ├── stores/          # Zustand Store
+    │   ├── authStore.ts         # 認證狀態
+    │   ├── transactionStore.ts  # 交易資料
+    │   └── settingsStore.ts     # 使用者設定（含 API Key）
+    ├── types/           # TypeScript 型別定義
+    ├── i18n/            # 國際化設定與翻譯檔
+    │   ├── index.ts             # i18next 初始化
+    │   └── locales/             # 翻譯資源檔
+    │       ├── zh-TW/           # 繁體中文（預設）
+    │       ├── en/              # 英文
+    │       ├── zh-CN/           # 簡體中文
+    │       └── vi/              # 越南文
+    └── utils/           # 工具函數（日期格式化、金額處理）
+```
+
+**各目錄職責**：
+
+| 目錄 | 職責 | 設計原則 |
+|------|------|---------|
+| `pages/` | 路由對應的頁面組件，負責組合子組件與資料取得 | 一個路由對應一個 Page，Page 不含業務邏輯 |
+| `components/` | 可復用的 UI 組件 | 按功能模組分目錄，props-driven 設計 |
+| `hooks/` | 封裝可復用的狀態邏輯 | 抽離複雜邏輯，保持組件簡潔 |
+| `services/` | 封裝所有 HTTP 請求 | 統一 Axios instance、攔截器處理 Token 與錯誤 |
+| `stores/` | 全域狀態管理（Zustand） | 每個 Store 對應一個領域，支援 persist |
+| `types/` | 共用型別定義 | 前後端共享的介面型別 |
+| `i18n/` | 多語系資源與初始化 | namespace 分類、lazy loading |
+
+### 3.2 後端目錄結構與職責
+
+```
+backend/
+  src/
+    ├── controllers/     # 控制層：接收請求、回應結果
+    │   ├── authController.ts
+    │   ├── transactionController.ts
+    │   ├── budgetController.ts
+    │   └── aiController.ts
+    ├── services/        # 業務邏輯層：核心處理
+    │   ├── authService.ts
+    │   ├── transactionService.ts
+    │   ├── budgetService.ts
+    │   └── llm/                 # LLM 整合服務（多引擎抽象）
+    │       ├── llmProvider.ts           # 抽象介面
+    │       ├── openaiProvider.ts        # OpenAI 實作（預設）
+    │       ├── geminiProvider.ts        # Gemini 實作
+    │       ├── anthropicProvider.ts     # Anthropic 實作（PRD-F-017）
+    │       ├── xaiProvider.ts           # xAI 實作（PRD-F-017）
+    │       ├── llmRouter.ts             # 引擎 + 模型路由
+    │       ├── dataExtractor.ts         # 資料萃取引擎
+    │       ├── personaEngine.ts         # 情緒回饋引擎
+    │       └── queryEngine.ts           # 語義查詢引擎
+    ├── repositories/    # 資料存取層：Prisma 查詢封裝
+    │   ├── userRepository.ts
+    │   ├── transactionRepository.ts
+    │   └── budgetRepository.ts
+    ├── middleware/       # 中間件
+    │   ├── auth.ts              # JWT 驗證
+    │   ├── errorHandler.ts      # 全域錯誤處理
+    │   ├── rateLimiter.ts       # API 限流
+    │   ├── validator.ts         # Zod 驗證
+    │   └── i18n.ts              # 語言偵測
+    ├── routes/          # API 路由定義
+    │   ├── index.ts             # 路由總表
+    │   ├── authRoutes.ts
+    │   ├── transactionRoutes.ts
+    │   ├── budgetRoutes.ts
+    │   └── aiRoutes.ts
+    ├── prompts/         # LLM Prompt 模板
+    │   ├── extractPrompt.ts     # 資料萃取 Prompt
+    │   ├── feedbackPrompt.ts    # 情緒回饋 Prompt
+    │   └── queryPrompt.ts       # 語義查詢 Prompt
+    ├── i18n/            # 國際化設定與翻譯檔
+    │   ├── index.ts             # i18next 初始化
+    │   └── locales/             # 翻譯資源檔（錯誤訊息）
+    ├── config/          # 配置檔
+    │   └── index.ts             # 環境變數讀取與驗證
+    ├── types/           # 型別定義
+    │   ├── express.d.ts         # Express 型別擴展
+    │   └── models.ts            # 業務模型型別
+    └── utils/           # 工具函數
+        ├── logger.ts            # 日誌工具
+        └── response.ts          # 統一回應格式
+  prisma/
+    ├── schema.prisma    # 資料模型定義
+    ├── migrations/      # 遷移檔案
+    └── seed.ts          # 種子資料
+```
+
+**各層職責**：
+
+| 層級 | 職責 | 設計原則 |
+|------|------|---------|
+| `controllers/` | 接收 HTTP 請求、呼叫 Service、回傳回應 | 不含業務邏輯，僅做請求/回應轉換 |
+| `services/` | 封裝所有業務邏輯 | 可獨立測試，不直接依賴 Express |
+| `repositories/` | 封裝資料庫存取（Prisma） | 隔離 ORM 細節，方便日後替換 |
+| `middleware/` | 請求前/後處理 | 認證、限流、驗證、錯誤處理、語言偵測 |
+| `prompts/` | LLM Prompt 模板管理 | 模板與邏輯分離，支援多語言注入 |
+
+### 3.3 前後端互動模式
+
+採用 **API First** 設計原則：
+
+1. **API 規格先行**：後端 API 規格（參見 `01-5-API_Spec.md` + `API_Spec.yaml`）作為前後端溝通合約
+2. **統一請求格式**：前端所有 API 請求皆透過 `services/api.ts` 的 Axios instance 發出，自動附加：
+   - `Authorization: Bearer <jwt-token>`（認證）
+   - `Accept-Language: <locale>`（語言偏好）
+   - `X-LLM-API-Key: <api-key>`（LLM 相關請求）
+3. **統一回應格式**：後端所有回應遵循 `{ code, message, data, timestamp }` 結構
+4. **錯誤回應格式**：`{ code, message, errors[], timestamp }`，前端統一攔截處理
+
+---
+
+## 4. 數據模型設計
+
+### 4.1 ER 圖
+
+```mermaid
+erDiagram
+    USERS ||--o{ CATEGORY_BUDGETS : "擁有類別預算"
+    USERS ||--o{ TRANSACTIONS : "建立交易記錄"
+    TRANSACTIONS ||--o| AI_FEEDBACKS : "對應 AI 回饋"
+
+    USERS {
+        uuid id PK
+        string name "使用者名稱"
+        string email UK "登入信箱"
+        string password_hash "bcrypt 加密密碼"
+        enum persona "sarcastic/gentle/guilt_trip"
+        enum ai_engine "openai/gemini/anthropic/xai"
+        string ai_model "具體模型名稱（nullable）"
+        string language "zh-TW/en/zh-CN/vi"
+        decimal monthly_budget "月預算總額"
+        string currency "幣別 default TWD"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    CATEGORY_BUDGETS {
+        uuid id PK
+        uuid user_id FK "關聯使用者"
+        string category "類別代碼"
+        decimal budget_limit "類別預算上限"
+        boolean is_custom "是否自訂類別"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    TRANSACTIONS {
+        uuid id PK
+        uuid user_id FK "關聯使用者"
+        decimal amount "交易金額"
+        string category "類別代碼"
+        string merchant "商家名稱"
+        string raw_text "原始輸入文字"
+        string note "備註"
+        date transaction_date "交易日期"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    AI_FEEDBACKS {
+        uuid id PK
+        uuid transaction_id FK "關聯交易（unique）"
+        uuid user_id FK "關聯使用者"
+        text feedback_text "AI 回饋文字"
+        string emotion_tag "情緒標籤"
+        enum persona_used "使用的人設"
+        timestamp created_at
+    }
+```
+
+### 4.2 實體欄位定義
+
+#### 4.2.1 Users（使用者）
+
+| 欄位 | 型別 | 約束 | 說明 |
+|------|------|------|------|
+| `id` | UUID | PK, auto-generated | 主鍵 |
+| `name` | VARCHAR(50) | NOT NULL | 使用者顯示名稱 |
+| `email` | VARCHAR(100) | UNIQUE, NOT NULL | 登入用信箱 |
+| `password_hash` | VARCHAR(255) | NOT NULL | bcrypt 加密後的密碼 |
+| `persona` | VARCHAR(20) | NOT NULL, DEFAULT 'gentle' | AI 人設偏好：sarcastic / gentle / guilt_trip |
+| `ai_engine` | VARCHAR(20) | NOT NULL, DEFAULT 'openai' | LLM 引擎偏好：openai / gemini / anthropic / xai（PRD-F-013, F-017） |
+| `ai_model` | VARCHAR(50) | nullable | 使用者選定的具體模型名稱；nullable 時使用引擎預設（PRD-F-017） |
+| `language` | VARCHAR(10) | NOT NULL, DEFAULT 'zh-TW' | 介面語言：zh-TW / en / zh-CN / vi |
+| `monthly_budget` | DECIMAL(12,2) | NOT NULL, DEFAULT 30000.00 | 月預算總額 |
+| `currency` | VARCHAR(10) | NOT NULL, DEFAULT 'TWD' | 預設幣別 |
+| `created_at` | TIMESTAMP | NOT NULL, DEFAULT NOW | 建立時間 |
+| `updated_at` | TIMESTAMP | NOT NULL, DEFAULT NOW | 更新時間 |
+
+#### 4.2.2 CategoryBudgets（類別預算）
+
+| 欄位 | 型別 | 約束 | 說明 |
+|------|------|------|------|
+| `id` | UUID | PK, auto-generated | 主鍵 |
+| `user_id` | UUID | FK → users(id), ON DELETE CASCADE | 所屬使用者 |
+| `category` | VARCHAR(50) | NOT NULL | 類別代碼（如 food, transport） |
+| `budget_limit` | DECIMAL(12,2) | NOT NULL, DEFAULT 0 | 該類別預算上限 |
+| `is_custom` | BOOLEAN | NOT NULL, DEFAULT false | 是否為使用者自訂類別 |
+| `created_at` | TIMESTAMP | NOT NULL, DEFAULT NOW | 建立時間 |
+| `updated_at` | TIMESTAMP | NOT NULL, DEFAULT NOW | 更新時間 |
+
+**唯一約束**：`(user_id, category)` — 每位使用者的類別不可重複。
+
+#### 4.2.3 Transactions（交易記錄）
+
+| 欄位 | 型別 | 約束 | 說明 |
+|------|------|------|------|
+| `id` | UUID | PK, auto-generated | 主鍵 |
+| `user_id` | UUID | FK → users(id), ON DELETE CASCADE | 所屬使用者 |
+| `amount` | DECIMAL(12,2) | NOT NULL | 交易金額 |
+| `category` | VARCHAR(50) | NOT NULL | 類別代碼 |
+| `merchant` | VARCHAR(100) | nullable | 商家名稱（可為空） |
+| `raw_text` | TEXT | NOT NULL | 使用者原始輸入文字 |
+| `note` | TEXT | nullable | 備註 |
+| `transaction_date` | DATE | NOT NULL, DEFAULT CURRENT_DATE | 交易日期 |
+| `created_at` | TIMESTAMP | NOT NULL, DEFAULT NOW | 建立時間 |
+| `updated_at` | TIMESTAMP | NOT NULL, DEFAULT NOW | 更新時間 |
+
+#### 4.2.4 AIFeedbacks（AI 回饋）
+
+| 欄位 | 型別 | 約束 | 說明 |
+|------|------|------|------|
+| `id` | UUID | PK, auto-generated | 主鍵 |
+| `transaction_id` | UUID | FK → transactions(id), UNIQUE, ON DELETE CASCADE | 對應交易（一對一） |
+| `user_id` | UUID | FK → users(id), ON DELETE CASCADE | 所屬使用者 |
+| `feedback_text` | TEXT | NOT NULL | AI 生成的回饋文字 |
+| `emotion_tag` | VARCHAR(30) | nullable | 情緒標籤（如 sarcastic_warning） |
+| `persona_used` | VARCHAR(20) | NOT NULL | 生成時使用的人設 |
+| `created_at` | TIMESTAMP | NOT NULL, DEFAULT NOW | 建立時間 |
+
+### 4.3 關聯關係說明
+
+| 關聯 | 類型 | 說明 |
+|------|------|------|
+| Users → CategoryBudgets | 一對多 | 一位使用者擁有多個類別預算（含預設 8 個 + 自訂） |
+| Users → Transactions | 一對多 | 一位使用者可建立多筆交易記錄 |
+| Transactions → AIFeedbacks | 一對一 | 每筆交易最多對應一則 AI 回饋 |
+
+### 4.4 索引設計
+
+| 索引名稱 | 表 | 欄位 | 用途 |
+|---------|-----|------|------|
+| `idx_users_email` | users | email | 登入查詢加速 |
+| `idx_category_budgets_user_id` | category_budgets | user_id | 查詢使用者所有類別預算 |
+| `idx_transactions_user_id` | transactions | user_id | 查詢使用者所有交易 |
+| `idx_transactions_user_date` | transactions | (user_id, transaction_date DESC) | 依日期排序的交易查詢（首頁、統計） |
+| `idx_transactions_user_category` | transactions | (user_id, category) | 依類別篩選交易 |
+| `idx_ai_feedbacks_transaction_id` | ai_feedbacks | transaction_id | 取得交易對應的 AI 回饋 |
+| `idx_ai_feedbacks_user_id` | ai_feedbacks | user_id | 查詢使用者所有 AI 回饋 |
+
+---
+
+## 5. LLM 整合設計
+
+### 5.1 多引擎架構（PRD-F-013, F-017）
+
+系統採用 LLM 多引擎設計，透過抽象層統一介面，支援 **OpenAI / Gemini / Anthropic / xAI** 四家供應商動態切換，並允許使用者自選具體模型名稱。
+
+```mermaid
+graph LR
+    subgraph Engines["LLM 業務引擎"]
+        DE["資料萃取引擎<br/>Data Extractor"]
+        PE["情緒回饋引擎<br/>Persona Engine"]
+        QE["語義查詢引擎<br/>Query Engine"]
+    end
+
+    subgraph Abstraction["抽象層"]
+        LP["LLMProvider 介面"]
+        LR["LLM Router<br/>引擎 + 模型路由"]
+    end
+
+    subgraph Providers["Provider 實作"]
+        OP["OpenAIProvider<br/>（預設）"]
+        GP["GeminiProvider"]
+        AP["AnthropicProvider"]
+        XP["XAIProvider"]
+    end
+
+    DE --> LP
+    PE --> LP
+    QE --> LP
+    LP --> LR
+    LR -->|ai_engine=openai| OP
+    LR -.->|ai_engine=gemini| GP
+    LR -.->|ai_engine=anthropic| AP
+    LR -.->|ai_engine=xai| XP
+```
+
+### 5.2 抽象層介面設計
+
+```typescript
+// llmProvider.ts — 統一介面
+interface LLMProvider {
+  /** 資料萃取：自然語言 → 結構化 JSON */
+  extractData(prompt: string, apiKey: string): Promise<ParsedTransaction>;
+
+  /** 情緒回饋：情境 → 個性化評論 */
+  generateFeedback(prompt: string, apiKey: string): Promise<AIFeedback>;
+
+  /** 通用文字生成：供語義查詢、意圖偵測等使用 */
+  generateText(
+    systemPrompt: string,
+    userPrompt: string,
+    apiKey: string,
+    options?: { temperature?: number; maxTokens?: number }
+  ): Promise<string>;
+}
+
+// 型別定義
+interface ParsedTransaction {
+  amount: number | null;
+  category: string;
+  merchant: string;
+  date: string;
+  confidence: number;
+  is_new_category: boolean;
+  suggested_category: string | null;
+}
+
+interface AIFeedback {
+  feedback: string;
+  emotion_tag: string;
+}
+```
+
+**引擎路由邏輯**（PRD-F-017）：
+
+```typescript
+// llmRouter.ts
+type AIEngine = 'openai' | 'gemini' | 'anthropic' | 'xai';
+
+function getLLMProvider(aiEngine: AIEngine, aiModel?: string): LLMProvider {
+  switch (aiEngine) {
+    case 'openai':
+      return new OpenAIProvider(aiModel);       // 預設引擎
+    case 'gemini':
+      return new GeminiProvider(aiModel);
+    case 'anthropic':
+      return new AnthropicProvider(aiModel);    // PRD-F-017
+    case 'xai':
+      return new XAIProvider(aiModel);          // PRD-F-017（共用 OpenAI SDK 規範）
+    default:
+      return new OpenAIProvider();              // fallback
+  }
+}
+```
+
+**動態模型清單**：各 Provider 在初始化時會透過對應 API（若支援）取得該帳號可用的模型清單，前端設定頁可動態呈現供使用者選擇；若 API 不支援列舉，則使用 `.env` 中的靜態清單（支援 `MODEL_INCLUDE` / `MODEL_EXCLUDE` 正則過濾，詳見 SRD §6.2）。
+
+### 5.3 Prompt 模板結構
+
+Prompt 採用模板函數設計，依據上下文動態組裝：
+
+```typescript
+// extractPrompt.ts — 資料萃取 Prompt 模板
+function buildExtractPrompt(params: {
+  rawText: string;
+  categories: string[];    // 使用者現有類別清單
+  language: string;
+}): { system: string; user: string } {
+  return {
+    system: `你是一個記帳助手。請從使用者輸入中萃取以下 JSON 欄位：
+amount (number|null), category (string), merchant (string),
+date (YYYY-MM-DD), confidence (0-1), is_new_category (boolean),
+suggested_category (string|null)。
+可用類別：${params.categories.join(', ')}。
+僅回傳 JSON，不要任何額外說明。`,
+    user: params.rawText,
+  };
+}
+
+// feedbackPrompt.ts — 情緒回饋 Prompt 模板
+function buildFeedbackPrompt(params: {
+  persona: 'sarcastic' | 'gentle' | 'guilt_trip';
+  amount: number;
+  category: string;
+  merchant: string;
+  budgetUsedRatio: number;
+  remainingBudget: number;
+  targetLanguage: string;
+}): { system: string; user: string } {
+  const personaDescriptions = {
+    sarcastic: '你是一位毒舌但關心使用者的理財顧問，用諷刺幽默的語氣評論消費',
+    gentle: '你是一位溫柔體貼的理財顧問，用鼓勵和關心的語氣評論消費',
+    guilt_trip: '你是一位擅長道德綁架的理財顧問，用令人內疚的方式評論消費',
+  };
+
+  return {
+    system: `${personaDescriptions[params.persona]}
+請用 ${params.targetLanguage} 回覆，50 字以內。
+回傳 JSON：{ "feedback": "...", "emotion_tag": "..." }`,
+    user: `消費 ${params.amount} 元於 ${params.merchant}（${params.category}），
+預算已使用 ${(params.budgetUsedRatio * 100).toFixed(0)}%，
+剩餘 ${params.remainingBudget} 元。`,
+  };
+}
+```
+
+### 5.4 資料萃取流程
+
+```mermaid
+sequenceDiagram
+    participant U as 使用者
+    participant FE as 前端
+    participant BE as 後端 API
+    participant LLM as LLM Provider
+    participant DB as 資料庫
+
+    U->>FE: 語音/文字輸入<br/>「午餐吃拉麵 180 元」
+    FE->>FE: Web Speech API 轉文字
+    FE->>BE: POST /api/v1/ai/parse<br/>{ raw_text, X-LLM-API-Key }
+    BE->>BE: Zod 驗證 + 讀取使用者類別
+    BE->>LLM: extractData(prompt, apiKey)
+    LLM-->>BE: { amount: 180, category: "food",<br/>merchant: "拉麵店", confidence: 0.95 }
+
+    alt confidence >= 0.7
+        BE->>DB: INSERT transaction
+        DB-->>BE: 交易記錄
+
+        BE->>BE: 組裝 Feedback Prompt（含預算上下文）
+        BE->>LLM: generateFeedback(prompt, apiKey)
+        LLM-->>BE: { feedback: "180 元...", emotion_tag: "..." }
+        BE->>DB: INSERT ai_feedback
+        BE-->>FE: { transaction, feedback }
+    else confidence < 0.7
+        BE-->>FE: { parsed_data, needs_confirmation: true }
+        FE->>U: 顯示確認對話框
+    end
+
+    FE->>U: 顯示記帳結果 + AI 回饋
+```
+
+### 5.5 人設回饋機制
+
+系統支援三種人設，影響 AI 回饋的語氣與風格：
+
+| 人設 | 代碼 | 語氣特徵 | 回饋範例 |
+|------|------|---------|---------|
+| 毒舌型 | `sarcastic` | 諷刺、幽默、直白 | 「650 元買壽司？你準備靠光合作用過活嗎？」 |
+| 溫柔型 | `gentle` | 鼓勵、溫暖、體貼 | 「辛苦了，偶爾犒賞自己也很重要呢！」 |
+| 罪惡感型 | `guilt_trip` | 內疚、反思、道德壓力 | 「你知道這 650 元可以買多少包泡麵嗎...」 |
+
+---
+
+## 6. 國際化架構設計 (i18n)
+
+### 6.1 前端 i18n 架構
+
+```mermaid
+graph TB
+    subgraph Frontend["前端 i18n 架構"]
+        i18next["i18next 核心"]
+        detector["語言偵測器<br/>i18next-browser-languagedetector"]
+        react["react-i18next<br/>useTranslation Hook"]
+
+        subgraph Locales["翻譯資源 (namespace)"]
+            common["common<br/>通用 UI"]
+            dashboard["dashboard<br/>儀表板"]
+            stats["stats<br/>統計頁"]
+            history["history<br/>記錄頁"]
+            settings["settings<br/>設定頁"]
+            auth["auth<br/>登入/註冊"]
+            categories["categories<br/>類別名稱"]
+            validation["validation<br/>表單驗證"]
+        end
+    end
+
+    detector --> i18next
+    i18next --> react
+    i18next --> Locales
+```
+
+**語言偵測優先順序**：
+
+```
+1. User DB 設定（已登入使用者）
+   ↓ 無設定時
+2. localStorage 暫存（曾選擇語言的未登入使用者）
+   ↓ 無暫存時
+3. 瀏覽器語言（navigator.language）
+   ↓ 無匹配時
+4. 預設語言：zh-TW
+```
+
+### 6.2 後端 i18n 架構
+
+- 使用 `i18next` + `i18next-fs-backend` 載入翻譯檔
+- 前端所有 API 請求附帶 `Accept-Language` Header
+- i18n middleware 解析 Header，將 locale 注入 `req.locale`
+- 錯誤處理 middleware 依 `req.locale` 回傳對應語言的錯誤訊息
+- 翻譯 namespace：`errors`（API 錯誤訊息）、`categories`（類別名稱 seed 用）
+
+### 6.3 翻譯資源管理
+
+| 語言 | 代碼 | 支援範圍 |
+|------|------|---------|
+| 繁體中文 | `zh-TW` | 預設語言，所有 namespace 完整翻譯 |
+| 英文 | `en` | 所有 namespace 完整翻譯 |
+| 簡體中文 | `zh-CN` | 所有 namespace 完整翻譯 |
+| 越南文 | `vi` | 所有 namespace 完整翻譯 |
+
+### 6.4 語言切換機制
+
+1. 使用者於設定頁切換語言 → 更新 Zustand Store → 觸發 `i18next.changeLanguage()`
+2. 同時更新 `localStorage` 暫存
+3. 若已登入，同步呼叫 `PUT /api/v1/users/me` 更新 DB 中的 `language` 欄位
+4. 切換後 React 組件自動重新渲染（react-i18next 內建響應式）
+
+---
+
+## 7. 設計決策記錄 (ADR)
+
+### ADR-001: 選擇 Zustand 而非 Redux 作為狀態管理
+
+- **狀態**：已採納
+- **背景**：前端需要全域狀態管理，處理認證狀態、交易資料、使用者設定等。Redux 是 React 生態最知名的狀態管理方案，但其 boilerplate 較多。
+- **決策**：選擇 Zustand 作為狀態管理方案。
+- **理由**：
+  - 極輕量（< 1KB gzip），對行動端 PWA 的載入速度友好
+  - API 極簡，無需 action creators、reducers、dispatch 等 boilerplate
+  - 內建 `persist` middleware，可直接將狀態同步至 localStorage（如 API Key 儲存）
+  - TypeScript 支援完整，型別推導自然
+  - 本專案狀態結構相對簡單，不需要 Redux 的 middleware 生態（如 redux-saga）
+- **影響**：
+  - 正面：開發效率高、程式碼簡潔、bundle size 小
+  - 負面：團隊若熟悉 Redux 需適應，DevTools 整合不如 Redux 成熟
+
+### ADR-002: 選擇 Prisma 而非 TypeORM 作為 ORM
+
+- **狀態**：已採納
+- **背景**：後端需要 ORM 來管理資料庫 Schema、遷移與查詢。主要候選方案為 Prisma 與 TypeORM。
+- **決策**：選擇 Prisma 作為 ORM。
+- **理由**：
+  - Schema 定義集中於 `schema.prisma`，作為資料模型的單一真相來源
+  - 自動產生型別安全的查詢客戶端（Prisma Client），消除手動型別維護
+  - 遷移系統成熟，支援自動產生遷移 SQL
+  - 同時支援 PostgreSQL 與 SQLite，滿足正式/開發環境切換需求
+  - 查詢 API 直覺，IDE 自動補全佳
+- **影響**：
+  - 正面：型別安全、遷移方便、開發體驗優秀
+  - 負面：複雜查詢（如 window function）需 Raw SQL、Prisma Client 產生的程式碼較大
+
+### ADR-003: LLM 雙引擎抽象層設計
+
+- **狀態**：已採納
+- **背景**：系統需整合 LLM 進行自然語言解析與回饋生成。使用者可能偏好不同的 LLM 服務商，且各服務商的 SDK 介面不同。
+- **決策**：設計 `LLMProvider` 抽象介面，由 `GeminiProvider` 與 `OpenAIProvider` 分別實作，透過引擎路由動態切換。
+- **理由**：
+  - 使用者自帶 API Key 的需求決定了必須支援多引擎
+  - 抽象層隔離了各 SDK 的差異，業務邏輯不直接耦合特定 LLM
+  - 未來新增 Provider（如 Claude、Llama）只需實作介面，不影響既有程式碼
+  - 各引擎的 Prompt 格式差異透過 Provider 內部處理，對外保持一致
+- **影響**：
+  - 正面：高擴展性、低耦合、使用者自主選擇引擎
+  - 負面：初期開發成本略高、需為每個 Provider 撰寫適配邏輯與測試
+
+### ADR-004: JWT 而非 Session-based 認證
+
+- **狀態**：已採納
+- **背景**：SPA 架構下需要實作使用者認證。主要選項為 JWT（無狀態 Token）與 Session（伺服端狀態）。
+- **決策**：採用 JWT Token 進行認證，Token 有效期 7 天，儲存於前端 localStorage。
+- **理由**：
+  - 無狀態設計，後端不需維護 Session Store，部署簡單
+  - 適合 SPA + RESTful API 架構，Token 透過 Header 傳遞
+  - 易於水平擴展，任意後端節點皆可驗證 Token
+  - 7 天有效期為行動端使用者體驗與安全性的平衡
+- **影響**：
+  - 正面：無狀態、部署簡單、水平擴展容易
+  - 負面：Token 無法主動撤銷（需等到過期）、localStorage 存在 XSS 風險（需做好 XSS 防護）
+
+---
+
+## 8. 錯誤處理策略
+
+### 8.1 全域錯誤處理機制
+
+後端採用集中式錯誤處理，所有錯誤經由 `errorHandler` middleware 統一處理：
+
+```typescript
+// 自訂錯誤類別
+class AppError extends Error {
+  constructor(
+    public statusCode: number,
+    public messageKey: string,     // i18n 翻譯 key
+    public errors?: FieldError[],  // 欄位驗證錯誤
+  ) {
+    super(messageKey);
+  }
+}
+
+class ValidationError extends AppError {
+  constructor(errors: FieldError[]) {
+    super(400, 'errors.validation_failed', errors);
+  }
+}
+
+class NotFoundError extends AppError {
+  constructor(resource: string) {
+    super(404, 'errors.not_found');
+  }
+}
+
+class UnauthorizedError extends AppError {
+  constructor() {
+    super(401, 'errors.unauthorized');
+  }
+}
+
+class RateLimitError extends AppError {
+  constructor() {
+    super(429, 'errors.rate_limit_exceeded');
+  }
+}
+```
+
+### 8.2 API 錯誤回應格式
+
+所有錯誤回應遵循統一 JSON 格式：
+
+```json
+{
+  "code": 400,
+  "message": "參數驗證失敗",
+  "errors": [
+    { "field": "amount", "reason": "金額必須為正數" },
+    { "field": "category", "reason": "類別不存在" }
+  ],
+  "timestamp": "2026-03-22T10:30:00Z"
+}
+```
+
+**HTTP 狀態碼對應**：
+
+| 狀態碼 | 情境 | message key |
+|--------|------|-------------|
+| 400 | 請求參數驗證失敗 | `errors.validation_failed` |
+| 401 | 未認證或 Token 過期 | `errors.unauthorized` |
+| 403 | 無權限存取資源 | `errors.forbidden` |
+| 404 | 資源不存在 | `errors.not_found` |
+| 429 | 超過速率限制 | `errors.rate_limit_exceeded` |
+| 500 | 伺服器內部錯誤 | `errors.internal_error` |
+| 502 | LLM 外部服務錯誤 | `errors.llm_service_error` |
+
+### 8.3 LLM 呼叫失敗 Fallback 策略
+
+```mermaid
+graph TD
+    A["LLM 呼叫"] --> B{成功？}
+    B -->|是| C["回傳結果"]
+    B -->|否| D["第 1 次重試<br/>（同引擎）"]
+    D --> E{成功？}
+    E -->|是| C
+    E -->|否| F["第 2 次重試<br/>（同引擎）"]
+    F --> G{成功？}
+    G -->|是| C
+    G -->|否| H["回傳友善錯誤訊息"]
+    H --> I["提示使用者：<br/>1. 檢查 API Key<br/>2. 切換引擎<br/>3. 稍後重試"]
+```
+
+**重試策略**：
+- 同引擎重試 2 次，間隔 1 秒（指數退避）
+- 不自動切換至另一引擎（因各引擎需不同 API Key）
+- 最終失敗時回傳 HTTP 502，包含友善錯誤提示
+- 記帳場景：LLM 失敗不影響手動輸入功能，前端可展示手動表單
+
+### 8.4 前端錯誤邊界設計
+
+```typescript
+// 全域 ErrorBoundary — 捕獲 React 渲染錯誤
+<ErrorBoundary fallback={<ErrorPage />}>
+  <App />
+</ErrorBoundary>
+
+// API 錯誤攔截 — Axios Response Interceptor
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      // Token 過期：清除狀態，導向登入頁
+      authStore.getState().logout();
+      window.location.href = '/login';
+    }
+    if (error.response?.status === 429) {
+      // 限流：顯示 Toast 提示
+      toast.warn(t('errors.rate_limit'));
+    }
+    return Promise.reject(error);
+  }
+);
+```
+
+---
+
+## 9. 快取與效能設計
+
+### 9.1 API 回應快取策略
+
+| 端點 | 快取策略 | TTL | 說明 |
+|------|---------|-----|------|
+| `GET /users/me` | 前端 Store 快取 | 至登出 | 使用者資料不頻繁變動 |
+| `GET /budgets` | 前端 Store 快取 | 5 分鐘 | 預算資料每次記帳後刷新 |
+| `GET /transactions` | 前端 Store 快取 | 即時刷新 | 交易列表需即時反映最新狀態 |
+| `POST /ai/parse` | 不快取 | — | 每次輸入皆為新請求 |
+| `GET /categories` | 前端 Store 快取 | 30 分鐘 | 類別清單變動頻率低 |
+
+### 9.2 前端資料快取（Zustand Persist）
+
+```typescript
+// 使用 Zustand persist middleware 將關鍵狀態持久化至 localStorage
+const useSettingsStore = create(
+  persist(
+    (set) => ({
+      language: 'zh-TW',
+      llmApiKey: '',          // 使用者自帶的 LLM API Key
+      aiEngine: 'gemini',
+      persona: 'gentle',
+      // ...
+    }),
+    {
+      name: 'vibe-settings',  // localStorage key
+      partialize: (state) => ({
+        language: state.language,
+        llmApiKey: state.llmApiKey,  // 僅存前端，不上傳伺服器
+        aiEngine: state.aiEngine,
+        persona: state.persona,
+      }),
+    }
+  )
+);
+```
+
+**快取失效策略**：
+- 使用者登出時清除所有 Store 狀態
+- 記帳操作完成後自動刷新交易列表與預算摘要
+- 設定變更後立即同步至 Store 與後端
+
+### 9.3 資料庫查詢優化
+
+**索引設計**（詳見 §4.4）覆蓋以下高頻查詢模式：
+
+| 查詢模式 | 使用索引 | 預期效能 |
+|---------|---------|---------|
+| 依使用者 + 日期區間查詢交易 | `idx_transactions_user_date` | < 50ms |
+| 依使用者 + 類別查詢交易 | `idx_transactions_user_category` | < 50ms |
+| 查詢使用者所有類別預算 | `idx_category_budgets_user_id` | < 10ms |
+| 查詢交易對應的 AI 回饋 | `idx_ai_feedbacks_transaction_id` | < 10ms |
+| Email 登入查詢 | `idx_users_email` (UNIQUE) | < 5ms |
+
+**查詢優化原則**：
+- 分頁查詢統一使用 `LIMIT` + `OFFSET`，預設每頁 20 筆
+- 統計查詢（月支出、類別分佈）使用聚合查詢，避免全表載入
+- 語義查詢場景限制最多 200 筆交易傳入 LLM，超出取最近 200 筆
+
+---
+
+## 10. 安全設計
+
+### 10.1 認證流程
+
+```mermaid
+sequenceDiagram
+    participant U as 使用者
+    participant FE as 前端
+    participant BE as 後端
+    participant DB as 資料庫
+
+    Note over U,DB: 註冊流程
+    U->>FE: 輸入 name, email, password
+    FE->>BE: POST /api/v1/auth/register
+    BE->>BE: Zod 驗證輸入
+    BE->>BE: bcrypt.hash(password, 10)
+    BE->>DB: INSERT INTO users
+    DB-->>BE: 使用者記錄
+    BE->>BE: jwt.sign({ userId }, SECRET, { expiresIn: '7d' })
+    BE-->>FE: { token, user }
+    FE->>FE: localStorage.setItem('token', token)
+
+    Note over U,DB: 登入流程
+    U->>FE: 輸入 email, password
+    FE->>BE: POST /api/v1/auth/login
+    BE->>DB: SELECT * FROM users WHERE email = ?
+    DB-->>BE: 使用者記錄
+    BE->>BE: bcrypt.compare(password, hash)
+    alt 密碼正確
+        BE->>BE: jwt.sign({ userId }, SECRET, { expiresIn: '7d' })
+        BE-->>FE: { token, user }
+        FE->>FE: localStorage.setItem('token', token)
+    else 密碼錯誤
+        BE-->>FE: 401 Unauthorized
+    end
+
+    Note over U,DB: API 請求驗證
+    FE->>BE: GET /api/v1/transactions<br/>Authorization: Bearer {token}
+    BE->>BE: jwt.verify(token, SECRET)
+    alt Token 有效
+        BE->>DB: 查詢資料
+        DB-->>BE: 結果
+        BE-->>FE: 200 + data
+    else Token 過期/無效
+        BE-->>FE: 401 Unauthorized
+        FE->>FE: 清除 token，導向登入頁
+    end
+```
+
+### 10.2 API 限流設計
+
+| 端點類別 | 限制 | 視窗 | 實作方式 |
+|---------|------|------|---------|
+| LLM 相關 (`/ai/*`) | 20 req/user | 1 分鐘 | 基於 userId 的滑動視窗 |
+| 一般 API | 100 req/user | 1 分鐘 | 基於 userId 的滑動視窗 |
+| 認證 API (`/auth/*`) | 10 req/IP | 1 分鐘 | 基於 IP 的固定視窗 |
+
+**限流實作**：使用 `express-rate-limit`，以記憶體（MemoryStore）儲存計數器。超出限制時回傳 HTTP 429：
+
+```json
+{
+  "code": 429,
+  "message": "請求過於頻繁，請稍後再試",
+  "timestamp": "2026-03-22T10:30:00Z"
+}
+```
+
+### 10.3 資料加密策略
+
+| 資料類型 | 加密方式 | 說明 |
+|---------|---------|------|
+| **使用者密碼** | bcrypt（工作因子 ≥ 10） | 單向雜湊，無法逆向解密 |
+| **傳輸層** | HTTPS / TLS 1.2+ | 所有通信強制 HTTPS |
+| **JWT Token** | HMAC-SHA256 簽名 | 使用 `JWT_SECRET` 環境變數簽名 |
+| **LLM API Key** | 傳輸層加密（HTTPS） | 前端 localStorage 儲存，用後即棄，不持久化於伺服器 |
+
+**安全防護措施**：
+
+| 攻擊類型 | 防護措施 |
+|---------|---------|
+| **XSS** | 輸入驗證（Zod）+ LLM 回傳文字 HTML 轉義 |
+| **SQL 注入** | Prisma ORM 參數化查詢 |
+| **CSRF** | SPA 架構 + JWT Token（非 Cookie），天然防禦 |
+| **暴力破解** | 認證 API 限流 10 req/min/IP |
+| **API Key 洩漏** | 僅前端儲存，後端用後即棄，不寫入日誌/資料庫 |
+
+---
+
+**文檔版本**: v1.0
+**最後修訂**: 2026-04-10
+
+---
+
+## 版本修訂說明
+
+| 版本 | 日期 | 修訂內容 |
+|------|------|---------|
+| v1.0 | 2026-04-10 | 專案首次新增 SDD，對齊新版 vibe-sdlc-spec 規範（SRD ↔ SDD 職責分離）。內容涵蓋 M1–M7 系統設計：系統架構總覽（含 M7 四引擎架構圖）、技術棧選型決策、前後端目錄結構與職責（含 M7 anthropicProvider / xaiProvider）、數據模型 ER 圖與索引設計（users.ai_engine 擴展為 openai/gemini/anthropic/xai、新增 ai_model 欄位）、LLM 多引擎抽象層（M5 語義查詢引擎 + M7 動態模型清單）、國際化架構（M6 i18n 多語系）、ADR 設計決策記錄（4 項）、錯誤處理策略、快取與效能設計、安全設計。**後續規劃**：SRD 內重複的「2. 技術架構指導」「3. 數據模型詳細設計」「4. LLM 整合設計」「5. 國際化架構設計」章節將於後續獨立 PR 重構為精簡「需求」層，僅保留非功能性需求與約束，設計細節指向本 SDD（issue #208） |

--- a/docs/01-6-UI_UX_Design.md
+++ b/docs/01-6-UI_UX_Design.md
@@ -134,6 +134,10 @@
 
 ### 3.1 首頁 `/`（記帳主頁）
 
+> 視覺參考：[ui/home.html](./ui/home.html)（當前保真度：wireframe）
+>
+> 元件 anchor：[Header](./ui/home.html#header) · [預算卡片](./ui/home.html#budget-card) · [AI 回饋卡片](./ui/home.html#ai-feedback) · [最近帳目](./ui/home.html#recent-transactions) · [輸入區](./ui/home.html#input-bar) · [Footer](./ui/home.html#footer) · [底部 Tab Bar](./ui/home.html#tab-bar)
+
 首頁為應用核心頁面，採用垂直堆疊佈局，從上至下分為五個區域。
 
 #### 整體結構
@@ -288,6 +292,10 @@
 
 ### 3.2 統計頁 `/stats`
 
+> 視覺參考：[ui/stats.html](./ui/stats.html)（當前保真度：wireframe）
+>
+> 元件 anchor：[時間篩選](./ui/stats.html#time-filter) · [總支出摘要](./ui/stats.html#summary-card) · [消費分佈圓餅圖](./ui/stats.html#pie-chart) · [類別排行](./ui/stats.html#category-ranking)
+
 #### 整體結構
 
 ```
@@ -361,6 +369,10 @@
 
 ### 3.3 記錄頁 `/history`
 
+> 視覺參考：[ui/history.html](./ui/history.html)(當前保真度：wireframe)
+>
+> 元件 anchor：[篩選區](./ui/history.html#filter-bar) · [記錄列表](./ui/history.html#history-list) · [交易詳情展開](./ui/history.html#transaction-detail)
+
 #### 整體結構
 
 ```
@@ -414,6 +426,10 @@
 ---
 
 ### 3.4 設定頁 `/settings`
+
+> 視覺參考：[ui/settings.html](./ui/settings.html)（當前保真度：wireframe）
+>
+> 元件 anchor：[使用者資訊](./ui/settings.html#user-info) · [人設選擇](./ui/settings.html#persona-select) · [月預算](./ui/settings.html#monthly-budget) · [類別預算](./ui/settings.html#category-budget) · [AI 引擎](./ui/settings.html#ai-engine) · [其他設定](./ui/settings.html#other-settings) · [登出](./ui/settings.html#logout)
 
 #### 整體結構
 
@@ -472,6 +488,8 @@
 
 ### 3.5 底部 Tab Bar
 
+> **視覺參考**：底部 Tab Bar 為**共享元件**，已整合在各頁面 wireframe 底部（見 [ui/home.html#tab-bar](./ui/home.html#tab-bar)、[ui/stats.html#tab-bar](./ui/stats.html#tab-bar)、[ui/history.html#tab-bar](./ui/history.html#tab-bar)、[ui/settings.html#tab-bar](./ui/settings.html#tab-bar)）。實作時應抽離為單一共用元件，各頁面透過 `aria-current="page"` 與 `data-active` 標記當前 tab。
+
 ```
 ┌──────────────────────────────────────┐
 │  [🏠 首頁]  [📊 統計]  [📋 記錄]  [⚙️ 設定] │
@@ -497,6 +515,10 @@
 ---
 
 ### 3.6 登入頁 `/login` 與註冊頁 `/register`
+
+> 視覺參考：[ui/login.html](./ui/login.html) · [ui/register.html](./ui/register.html)（當前保真度：wireframe）
+>
+> 元件 anchor：[Logo](./ui/login.html#logo) · [認證表單（登入）](./ui/login.html#auth-form) · [認證表單（註冊）](./ui/register.html#auth-form)
 
 #### 整體結構
 
@@ -867,8 +889,8 @@ AI 回覆：
 
 ---
 
-**文檔版本**: v1.1
-**最後修訂**: 2026-04-09
+**文檔版本**: v1.2
+**最後修訂**: 2026-04-10
 
 ---
 
@@ -878,3 +900,4 @@ AI 回覆：
 |------|------|---------|
 | v1.0 | 2026-03-17 | 初版定稿（M1-M4 UI/UX 設計規格、Design Tokens、頁面佈局、互動動畫、響應式設計、無障礙設計） |
 | v1.1 | 2026-04-09 | 規格文件改名對齊新版 vibe-sdlc-spec：本檔由 `01-4-UI_UX_Design.md` 改名為 `01-6-UI_UX_Design.md`、關聯文件表更新 API Spec 連結為 `01-5-API_Spec.md`、標題同步更新；首次建立完整版本修訂說明區塊 |
+| v1.2 | 2026-04-10 | 對齊 vibe-sdlc-spec UI/UX Writing Guidelines §9：為 §3.1–§3.6 全部頁面章節補上 `ui/*.html` wireframe 視覺參考與元件層級 anchor link；新增 `/docs/ui/` 目錄含 6 個低保真 HTML + Tailwind wireframe（home/stats/history/settings/login/register）。markdown 規格書仍為實作權威，HTML wireframe 為視覺輔助（issue #209） |

--- a/docs/ui/history.html
+++ b/docs/ui/history.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="fidelity" content="wireframe">
+  <meta name="spec-ref" content="../01-6-UI_UX_Design.md#33-記錄頁-history">
+  <title>記錄 - Vibe Money Book Wireframe</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            primary: '#9CA3AF',
+            'primary-light': '#F3F4F6',
+            'primary-dark': '#6B7280',
+          },
+          borderRadius: { 'sm': '8px', 'md': '12px', 'lg': '16px', 'xl': '20px' },
+          spacing: { 'xs': '4px', 'sm': '8px', 'md': '12px', 'lg': '16px', 'xl': '20px', '2xl': '24px' }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="bg-gray-100 min-h-screen font-sans text-gray-700">
+
+  <!-- 此為低保真 wireframe。實作以 01-6-UI_UX_Design.md §3.3 為權威。 -->
+
+  <div class="max-w-md mx-auto bg-white min-h-screen shadow-sm pb-20">
+
+    <!-- Header -->
+    <header id="header" class="h-14 border-b border-gray-200 flex items-center justify-between px-2xl bg-white">
+      <h1 class="text-base font-semibold text-gray-800">記錄</h1>
+      <button class="w-8 h-8 flex items-center justify-center text-gray-500" aria-label="搜尋">🔍</button>
+    </header>
+
+    <!-- 篩選區 -->
+    <div id="filter-bar" class="flex gap-sm px-2xl py-md bg-white border-b border-gray-100">
+      <button class="flex-1 h-9 rounded-xl bg-gray-100 text-xs text-gray-700 flex items-center justify-center gap-1">
+        <span>全部類別</span><span class="text-gray-400">▼</span>
+      </button>
+      <button class="flex-1 h-9 rounded-xl bg-gray-100 text-xs text-gray-700 flex items-center justify-center gap-1">
+        <span>本月</span><span class="text-gray-400">▼</span>
+      </button>
+    </div>
+
+    <main id="history-list">
+
+      <!-- 日期分組：今天 -->
+      <div class="sticky top-0 bg-gray-50 px-2xl py-md text-xs font-semibold text-gray-500 border-b border-gray-100">
+        2026/03/17（今天）
+      </div>
+      <div class="bg-white divide-y divide-gray-100">
+        <div class="flex items-center gap-md p-md px-2xl">
+          <div class="w-10 h-10 bg-gray-200 rounded-md flex items-center justify-center shrink-0">🍜</div>
+          <div class="flex-1 min-w-0">
+            <div class="text-sm font-semibold text-gray-800">拉麵</div>
+            <div class="text-xs text-gray-500">
+              <span class="inline-block bg-gray-100 rounded-sm px-2 py-0.5 mr-2">飲食</span>
+              <span>01:07</span>
+            </div>
+          </div>
+          <div class="text-base font-semibold text-gray-700">-$250</div>
+        </div>
+        <div class="flex items-center gap-md p-md px-2xl">
+          <div class="w-10 h-10 bg-gray-200 rounded-md flex items-center justify-center shrink-0">🚌</div>
+          <div class="flex-1 min-w-0">
+            <div class="text-sm font-semibold text-gray-800">捷運</div>
+            <div class="text-xs text-gray-500">
+              <span class="inline-block bg-gray-100 rounded-sm px-2 py-0.5 mr-2">交通</span>
+              <span>08:30</span>
+            </div>
+          </div>
+          <div class="text-base font-semibold text-gray-700">-$35</div>
+        </div>
+      </div>
+
+      <!-- 日期分組：昨天 -->
+      <div class="sticky top-0 bg-gray-50 px-2xl py-md text-xs font-semibold text-gray-500 border-y border-gray-100">
+        2026/03/16（昨天）
+      </div>
+      <div class="bg-white divide-y divide-gray-100">
+        <div class="flex items-center gap-md p-md px-2xl">
+          <div class="w-10 h-10 bg-gray-200 rounded-md flex items-center justify-center shrink-0">☕</div>
+          <div class="flex-1 min-w-0">
+            <div class="text-sm font-semibold text-gray-800">咖啡</div>
+            <div class="text-xs text-gray-500">
+              <span class="inline-block bg-gray-100 rounded-sm px-2 py-0.5 mr-2">飲食</span>
+              <span>09:15</span>
+            </div>
+          </div>
+          <div class="text-base font-semibold text-gray-700">-$120</div>
+        </div>
+        <div class="flex items-center gap-md p-md px-2xl">
+          <div class="w-10 h-10 bg-gray-200 rounded-md flex items-center justify-center shrink-0">🎬</div>
+          <div class="flex-1 min-w-0">
+            <div class="text-sm font-semibold text-gray-800">電影票</div>
+            <div class="text-xs text-gray-500">
+              <span class="inline-block bg-gray-100 rounded-sm px-2 py-0.5 mr-2">娛樂</span>
+              <span>19:30</span>
+            </div>
+          </div>
+          <div class="text-base font-semibold text-gray-700">-$320</div>
+        </div>
+      </div>
+
+      <!-- 交易詳情展開面板（範例，點擊交易項目時展開） -->
+      <details id="transaction-detail" class="bg-white border-b border-gray-100">
+        <summary class="p-md px-2xl text-xs text-gray-400 cursor-pointer select-none">▼ 交易詳情展開面板（範例）</summary>
+        <div class="p-lg border-t border-gray-100 space-y-md">
+          <div class="flex justify-between items-baseline">
+            <div class="text-sm font-semibold text-gray-800">拉麵</div>
+            <div class="text-base font-semibold text-gray-700">-$250</div>
+          </div>
+          <div class="text-xs text-gray-500">飲食 · 2026/03/17 01:07</div>
+          <hr class="border-gray-100">
+          <div class="text-xs space-y-sm">
+            <div><span class="text-gray-500">原始輸入：</span><span class="text-gray-700">「半夜吃拉麵 250」</span></div>
+            <div><span class="text-gray-500">AI 評論：</span><span class="text-gray-700">「享受美味是很重要的...」</span></div>
+            <div><span class="text-gray-500">情緒標籤：</span><span class="inline-block bg-gray-100 rounded-sm px-2 py-0.5">鼓勵</span></div>
+          </div>
+          <hr class="border-gray-100">
+          <button class="w-full h-10 rounded-md border border-gray-300 text-xs text-gray-600">刪除此筆記錄</button>
+        </div>
+      </details>
+
+    </main>
+
+    <!-- 底部 Tab Bar -->
+    <nav id="tab-bar" class="fixed bottom-0 left-0 right-0 max-w-md mx-auto h-14 bg-white border-t border-gray-200 flex" aria-label="底部導覽">
+      <button class="flex-1 flex flex-col items-center justify-center text-xs text-gray-400">
+        <span class="text-lg">🏠</span><span class="mt-0.5">首頁</span>
+      </button>
+      <button class="flex-1 flex flex-col items-center justify-center text-xs text-gray-400">
+        <span class="text-lg">📊</span><span class="mt-0.5">統計</span>
+      </button>
+      <button class="flex-1 flex flex-col items-center justify-center text-xs text-gray-800" aria-current="page">
+        <span class="text-lg">📋</span><span class="mt-0.5">記錄</span>
+        <div class="w-1 h-1 rounded-full bg-gray-800 mt-0.5"></div>
+      </button>
+      <button class="flex-1 flex flex-col items-center justify-center text-xs text-gray-400">
+        <span class="text-lg">⚙️</span><span class="mt-0.5">設定</span>
+      </button>
+    </nav>
+
+  </div>
+
+</body>
+</html>

--- a/docs/ui/home.html
+++ b/docs/ui/home.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="fidelity" content="wireframe">
+  <meta name="spec-ref" content="../01-6-UI_UX_Design.md#31-首頁-記帳主頁">
+  <title>首頁 - Vibe Money Book Wireframe</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    // 從 01-6-UI_UX_Design.md §2 Design Tokens 同步
+    // wireframe 階段：僅保留必要 tokens 用於 CTA 標示，其餘使用 gray-* 灰階
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            primary: '#9CA3AF',        // wireframe 灰階（mockup 階段改為 #00C896）
+            'primary-light': '#F3F4F6',
+            'primary-dark': '#6B7280',
+          },
+          borderRadius: {
+            'sm': '8px',
+            'md': '12px',
+            'lg': '16px',
+            'xl': '20px',
+          },
+          spacing: {
+            'xs': '4px',
+            'sm': '8px',
+            'md': '12px',
+            'lg': '16px',
+            'xl': '20px',
+            '2xl': '24px',
+          }
+        }
+      }
+    }
+  </script>
+  <style>
+    /* wireframe 階段自訂：虛線邊框標示佔位區塊 */
+    .placeholder-box { border: 1px dashed #D1D5DB; }
+  </style>
+</head>
+<body class="bg-gray-100 min-h-screen font-sans text-gray-700">
+
+  <!-- 說明：此為低保真 wireframe，用於傳達佈局與層級。實作以 01-6-UI_UX_Design.md 為權威。 -->
+
+  <div class="max-w-md mx-auto bg-white min-h-screen shadow-sm pb-32">
+
+    <!-- §3.1.1 Header -->
+    <header id="header" class="h-14 border-b border-gray-200 flex items-center justify-between px-2xl bg-white">
+      <div class="flex items-center gap-sm">
+        <div class="w-8 h-8 bg-gray-300 rounded-sm flex items-center justify-center text-white text-sm">💰</div>
+        <div>
+          <div class="text-base font-semibold text-gray-800">Vibe Money Book</div>
+          <div class="text-xs text-gray-500 tracking-widest">語音記帳教練</div>
+        </div>
+      </div>
+      <button class="w-6 h-6 text-gray-500" aria-label="設定">⚙️</button>
+    </header>
+
+    <main class="p-2xl space-y-lg">
+
+      <!-- §3.1.2 預算卡片 -->
+      <section id="budget-card" class="bg-white rounded-lg shadow-sm p-lg" aria-label="預算卡片">
+        <div class="flex justify-between items-start mb-sm">
+          <div>
+            <div class="text-xs text-gray-500">預算剩餘</div>
+            <div class="text-4xl font-bold text-gray-800 mt-1">99%</div>
+          </div>
+          <div class="text-right">
+            <div class="text-xs text-gray-500">本月支出</div>
+            <div class="text-2xl font-bold text-gray-700 mt-1">$250</div>
+          </div>
+        </div>
+        <!-- 進度條（wireframe：灰階；mockup 改為 --color-success/warning/danger） -->
+        <div class="h-2 bg-gray-200 rounded-full overflow-hidden">
+          <div class="h-full bg-gray-500 rounded-full" style="width: 99%"></div>
+        </div>
+        <div class="flex justify-between mt-xs text-xs text-gray-500">
+          <span>$0</span>
+          <span>目標：$20,000</span>
+        </div>
+      </section>
+
+      <!-- §3.1.3 AI 回饋卡片 -->
+      <section id="ai-feedback" class="bg-primary-light rounded-lg p-lg" aria-label="AI 回饋卡片">
+        <div class="flex items-start gap-md">
+          <div class="w-9 h-9 bg-gray-400 rounded-full flex items-center justify-center text-white text-sm shrink-0">💬</div>
+          <div class="flex-1 min-w-0">
+            <div class="text-xs text-gray-500 mb-1">溫柔管家 的即時回饋</div>
+            <div class="text-sm text-gray-700 leading-relaxed">
+              「享受美味是很重要的。預算目前仍很充裕，請繼續保持...」
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- §3.1.4 最近帳目列表 -->
+      <section id="recent-transactions" aria-label="最近帳目">
+        <div class="flex justify-between items-center mb-md">
+          <h2 class="text-base font-semibold text-gray-800">🕐 最近帳目</h2>
+        </div>
+        <div class="bg-white rounded-lg divide-y divide-gray-100">
+          <!-- 交易項目（template，實作時迭代渲染） -->
+          <div class="flex items-center gap-md p-md">
+            <div class="w-10 h-10 bg-gray-200 rounded-md flex items-center justify-center shrink-0">🍜</div>
+            <div class="flex-1 min-w-0">
+              <div class="text-sm font-semibold text-gray-800">拉麵</div>
+              <div class="text-xs text-gray-500">
+                <span class="inline-block bg-gray-100 rounded-sm px-2 py-0.5 mr-2">飲食</span>
+                <span>上午 01:07</span>
+              </div>
+            </div>
+            <div class="text-base font-semibold text-gray-700">-$250</div>
+          </div>
+          <div class="flex items-center gap-md p-md">
+            <div class="w-10 h-10 bg-gray-200 rounded-md flex items-center justify-center shrink-0">🚌</div>
+            <div class="flex-1 min-w-0">
+              <div class="text-sm font-semibold text-gray-800">捷運</div>
+              <div class="text-xs text-gray-500">
+                <span class="inline-block bg-gray-100 rounded-sm px-2 py-0.5 mr-2">交通</span>
+                <span>上午 08:30</span>
+              </div>
+            </div>
+            <div class="text-base font-semibold text-gray-700">-$35</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- §3.1.6 Footer -->
+      <footer id="footer" class="text-center py-sm">
+        <div class="text-xs text-gray-400 tracking-wider">POWERED BY AI · 精準記帳 · 情緒滿分</div>
+      </footer>
+    </main>
+
+    <!-- §3.1.5 輸入區（固定於 Tab Bar 上方） -->
+    <div id="input-bar" class="fixed bottom-14 left-0 right-0 max-w-md mx-auto bg-white border-t border-gray-200 p-md">
+      <div class="flex items-center gap-sm">
+        <input
+          type="text"
+          placeholder="例如：中午吃拉麵 280 元"
+          class="flex-1 h-11 rounded-xl bg-gray-100 border border-gray-200 px-lg text-sm placeholder:text-gray-400"
+          aria-label="記帳輸入"
+        >
+        <button class="w-9 h-9 text-gray-500" aria-label="語音輸入">🎤</button>
+        <button class="w-10 h-10 rounded-full bg-gray-500 text-white flex items-center justify-center" aria-label="送出">
+          ➤
+        </button>
+      </div>
+    </div>
+
+    <!-- §3.5 底部 Tab Bar -->
+    <nav id="tab-bar" class="fixed bottom-0 left-0 right-0 max-w-md mx-auto h-14 bg-white border-t border-gray-200 flex" aria-label="底部導覽">
+      <button class="flex-1 flex flex-col items-center justify-center text-xs text-gray-800" aria-current="page">
+        <span class="text-lg">🏠</span>
+        <span class="mt-0.5">首頁</span>
+        <div class="w-1 h-1 rounded-full bg-gray-800 mt-0.5"></div>
+      </button>
+      <button class="flex-1 flex flex-col items-center justify-center text-xs text-gray-400">
+        <span class="text-lg">📊</span>
+        <span class="mt-0.5">統計</span>
+      </button>
+      <button class="flex-1 flex flex-col items-center justify-center text-xs text-gray-400">
+        <span class="text-lg">📋</span>
+        <span class="mt-0.5">記錄</span>
+      </button>
+      <button class="flex-1 flex flex-col items-center justify-center text-xs text-gray-400">
+        <span class="text-lg">⚙️</span>
+        <span class="mt-0.5">設定</span>
+      </button>
+    </nav>
+
+  </div>
+
+</body>
+</html>

--- a/docs/ui/login.html
+++ b/docs/ui/login.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="fidelity" content="wireframe">
+  <meta name="spec-ref" content="../01-6-UI_UX_Design.md#36-登入頁-login-與註冊頁-register">
+  <title>登入 - Vibe Money Book Wireframe</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            primary: '#9CA3AF',
+            'primary-light': '#F3F4F6',
+            'primary-dark': '#6B7280',
+          },
+          borderRadius: { 'sm': '8px', 'md': '12px', 'lg': '16px', 'xl': '20px' },
+          spacing: { 'xs': '4px', 'sm': '8px', 'md': '12px', 'lg': '16px', 'xl': '20px', '2xl': '24px' }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="bg-gray-100 min-h-screen font-sans text-gray-700">
+
+  <!-- 此為低保真 wireframe。實作以 01-6-UI_UX_Design.md §3.6 為權威。 -->
+  <!-- 元件庫：shadcn/ui Input、Label、Button、Form -->
+
+  <div class="max-w-md mx-auto bg-white min-h-screen shadow-sm flex flex-col">
+
+    <!-- Logo 區 -->
+    <header id="logo" class="flex flex-col items-center pt-20 pb-lg">
+      <div class="w-16 h-16 bg-gray-300 rounded-lg flex items-center justify-center text-2xl mb-md">💰</div>
+      <h1 class="text-xl font-bold text-gray-800">Vibe Money Book</h1>
+      <p class="text-xs text-gray-500 tracking-widest mt-1">語音記帳教練</p>
+    </header>
+
+    <!-- 表單區 -->
+    <main id="auth-form" class="flex-1 px-2xl">
+      <form class="space-y-lg" aria-label="登入表單">
+
+        <!-- Email 欄位 -->
+        <div class="space-y-sm">
+          <label for="email" class="text-xs font-semibold text-gray-600">Email</label>
+          <input
+            id="email"
+            type="email"
+            placeholder="your@email.com"
+            class="w-full h-12 rounded-md border border-gray-200 px-lg text-sm placeholder:text-gray-400"
+            required
+            aria-required="true"
+          >
+        </div>
+
+        <!-- 密碼欄位 -->
+        <div class="space-y-sm">
+          <label for="password" class="text-xs font-semibold text-gray-600">密碼</label>
+          <input
+            id="password"
+            type="password"
+            placeholder="••••••••"
+            class="w-full h-12 rounded-md border border-gray-200 px-lg text-sm placeholder:text-gray-400"
+            required
+            aria-required="true"
+          >
+        </div>
+
+        <!-- 主按鈕 -->
+        <button
+          type="submit"
+          class="w-full h-12 rounded-md bg-gray-500 text-white text-sm font-semibold"
+        >
+          登入
+        </button>
+
+      </form>
+
+      <!-- 模式切換連結 -->
+      <div class="text-center mt-lg">
+        <a href="./register.html" class="text-xs text-gray-500 underline">還沒有帳號？立即註冊</a>
+      </div>
+    </main>
+
+    <footer class="text-center py-lg">
+      <div class="text-xs text-gray-400 tracking-wider">POWERED BY AI · 精準記帳 · 情緒滿分</div>
+    </footer>
+
+  </div>
+
+</body>
+</html>

--- a/docs/ui/register.html
+++ b/docs/ui/register.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="fidelity" content="wireframe">
+  <meta name="spec-ref" content="../01-6-UI_UX_Design.md#36-登入頁-login-與註冊頁-register">
+  <title>註冊 - Vibe Money Book Wireframe</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            primary: '#9CA3AF',
+            'primary-light': '#F3F4F6',
+            'primary-dark': '#6B7280',
+          },
+          borderRadius: { 'sm': '8px', 'md': '12px', 'lg': '16px', 'xl': '20px' },
+          spacing: { 'xs': '4px', 'sm': '8px', 'md': '12px', 'lg': '16px', 'xl': '20px', '2xl': '24px' }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="bg-gray-100 min-h-screen font-sans text-gray-700">
+
+  <!-- 此為低保真 wireframe。實作以 01-6-UI_UX_Design.md §3.6 為權威。 -->
+  <!-- 元件庫：shadcn/ui Input、Label、Button、Form -->
+
+  <div class="max-w-md mx-auto bg-white min-h-screen shadow-sm flex flex-col">
+
+    <!-- Logo 區 -->
+    <header id="logo" class="flex flex-col items-center pt-16 pb-lg">
+      <div class="w-16 h-16 bg-gray-300 rounded-lg flex items-center justify-center text-2xl mb-md">💰</div>
+      <h1 class="text-xl font-bold text-gray-800">Vibe Money Book</h1>
+      <p class="text-xs text-gray-500 tracking-widest mt-1">語音記帳教練</p>
+    </header>
+
+    <!-- 表單區 -->
+    <main id="auth-form" class="flex-1 px-2xl">
+      <form class="space-y-lg" aria-label="註冊表單">
+
+        <!-- Email 欄位 -->
+        <div class="space-y-sm">
+          <label for="email" class="text-xs font-semibold text-gray-600">Email</label>
+          <input
+            id="email"
+            type="email"
+            placeholder="your@email.com"
+            class="w-full h-12 rounded-md border border-gray-200 px-lg text-sm placeholder:text-gray-400"
+            required
+            aria-required="true"
+          >
+        </div>
+
+        <!-- 密碼欄位（含規則提示） -->
+        <div class="space-y-sm">
+          <label for="password" class="text-xs font-semibold text-gray-600">密碼</label>
+          <input
+            id="password"
+            type="password"
+            placeholder="••••••••"
+            class="w-full h-12 rounded-md border border-gray-200 px-lg text-sm placeholder:text-gray-400"
+            required
+            aria-required="true"
+            aria-describedby="password-hint"
+          >
+          <p id="password-hint" class="text-xs text-gray-500">需 8 碼以上並包含英文字母與數字</p>
+        </div>
+
+        <!-- 確認密碼欄位（僅註冊頁顯示） -->
+        <div class="space-y-sm">
+          <label for="confirm-password" class="text-xs font-semibold text-gray-600">確認密碼</label>
+          <input
+            id="confirm-password"
+            type="password"
+            placeholder="••••••••"
+            class="w-full h-12 rounded-md border border-gray-200 px-lg text-sm placeholder:text-gray-400"
+            required
+            aria-required="true"
+          >
+        </div>
+
+        <!-- 主按鈕 -->
+        <button
+          type="submit"
+          class="w-full h-12 rounded-md bg-gray-500 text-white text-sm font-semibold"
+        >
+          註冊
+        </button>
+
+      </form>
+
+      <!-- 模式切換連結 -->
+      <div class="text-center mt-lg">
+        <a href="./login.html" class="text-xs text-gray-500 underline">已有帳號？返回登入</a>
+      </div>
+    </main>
+
+    <footer class="text-center py-lg">
+      <div class="text-xs text-gray-400 tracking-wider">POWERED BY AI · 精準記帳 · 情緒滿分</div>
+    </footer>
+
+  </div>
+
+</body>
+</html>

--- a/docs/ui/settings.html
+++ b/docs/ui/settings.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="fidelity" content="wireframe">
+  <meta name="spec-ref" content="../01-6-UI_UX_Design.md#34-設定頁-settings">
+  <title>設定 - Vibe Money Book Wireframe</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            primary: '#9CA3AF',
+            'primary-light': '#F3F4F6',
+            'primary-dark': '#6B7280',
+          },
+          borderRadius: { 'sm': '8px', 'md': '12px', 'lg': '16px', 'xl': '20px' },
+          spacing: { 'xs': '4px', 'sm': '8px', 'md': '12px', 'lg': '16px', 'xl': '20px', '2xl': '24px' }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="bg-gray-100 min-h-screen font-sans text-gray-700">
+
+  <!-- 此為低保真 wireframe。實作以 01-6-UI_UX_Design.md §3.4 為權威。 -->
+
+  <div class="max-w-md mx-auto bg-white min-h-screen shadow-sm pb-20">
+
+    <!-- Header -->
+    <header id="header" class="h-14 border-b border-gray-200 flex items-center px-2xl bg-white">
+      <h1 class="text-base font-semibold text-gray-800">設定</h1>
+    </header>
+
+    <main class="divide-y divide-gray-100">
+
+      <!-- 使用者資訊區 -->
+      <section id="user-info" class="p-lg px-2xl flex items-center gap-md" aria-label="使用者資訊">
+        <div class="w-12 h-12 bg-gray-200 rounded-full flex items-center justify-center text-xl">👤</div>
+        <div class="flex-1 min-w-0">
+          <div class="text-sm font-semibold text-gray-800">使用者名稱</div>
+          <div class="text-xs text-gray-500">user@email.com</div>
+        </div>
+      </section>
+
+      <!-- AI 人設選擇 -->
+      <section id="persona-select" class="p-lg px-2xl" aria-label="AI 人設選擇">
+        <div class="text-xs font-semibold text-gray-500 mb-md uppercase tracking-wider">AI 人設</div>
+        <div class="grid grid-cols-3 gap-md">
+          <button class="aspect-square rounded-lg border border-gray-200 bg-white flex flex-col items-center justify-center gap-1">
+            <span class="text-2xl">🔥</span>
+            <span class="text-xs text-gray-500">毒舌</span>
+          </button>
+          <button class="aspect-square rounded-lg border-2 border-gray-500 bg-gray-100 flex flex-col items-center justify-center gap-1 relative" aria-pressed="true">
+            <span class="absolute top-1 right-1 text-xs text-gray-700">✓</span>
+            <span class="text-2xl">💖</span>
+            <span class="text-xs font-semibold text-gray-800">溫柔</span>
+          </button>
+          <button class="aspect-square rounded-lg border border-gray-200 bg-white flex flex-col items-center justify-center gap-1">
+            <span class="text-2xl">🥺</span>
+            <span class="text-xs text-gray-500">情勒</span>
+          </button>
+        </div>
+      </section>
+
+      <!-- 月預算設定 -->
+      <section id="monthly-budget" class="p-lg px-2xl" aria-label="月預算設定">
+        <div class="text-xs font-semibold text-gray-500 mb-md uppercase tracking-wider">月預算</div>
+        <div class="flex items-center justify-between">
+          <label for="monthly-budget-input" class="text-sm text-gray-700">每月預算</label>
+          <div class="relative">
+            <span class="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-gray-500">$</span>
+            <input id="monthly-budget-input" type="text" value="20,000" class="w-32 h-9 rounded-md border border-gray-200 pl-7 pr-3 text-right text-sm">
+          </div>
+        </div>
+      </section>
+
+      <!-- 類別預算管理 -->
+      <section id="category-budget" class="p-lg px-2xl" aria-label="類別預算管理">
+        <div class="text-xs font-semibold text-gray-500 mb-md uppercase tracking-wider">類別預算</div>
+        <div class="space-y-md">
+          <div class="flex items-center justify-between gap-md">
+            <div class="flex items-center gap-sm flex-1">
+              <span class="text-sm text-gray-700">飲食</span>
+              <span class="text-xs bg-gray-100 text-gray-500 rounded-sm px-2 py-0.5">預設</span>
+            </div>
+            <div class="relative">
+              <span class="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-gray-500">$</span>
+              <input type="text" value="5,000" class="w-28 h-9 rounded-md border border-gray-200 pl-7 pr-3 text-right text-sm">
+            </div>
+          </div>
+          <div class="flex items-center justify-between gap-md">
+            <div class="flex items-center gap-sm flex-1">
+              <span class="text-sm text-gray-700">交通</span>
+              <span class="text-xs bg-gray-100 text-gray-500 rounded-sm px-2 py-0.5">預設</span>
+            </div>
+            <div class="relative">
+              <span class="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-gray-500">$</span>
+              <input type="text" value="2,000" class="w-28 h-9 rounded-md border border-gray-200 pl-7 pr-3 text-right text-sm">
+            </div>
+          </div>
+          <div class="flex items-center justify-between gap-md">
+            <div class="flex items-center gap-sm flex-1">
+              <span class="text-sm text-gray-700">寵物</span>
+              <span class="text-xs bg-gray-200 text-gray-700 rounded-sm px-2 py-0.5">自訂</span>
+            </div>
+            <div class="flex items-center gap-sm">
+              <div class="relative">
+                <span class="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-gray-500">$</span>
+                <input type="text" value="1,000" class="w-28 h-9 rounded-md border border-gray-200 pl-7 pr-3 text-right text-sm">
+              </div>
+              <button class="w-8 h-8 flex items-center justify-center text-gray-400" aria-label="刪除寵物類別">🗑️</button>
+            </div>
+          </div>
+          <button class="w-full h-10 rounded-md border border-dashed border-gray-300 text-xs text-gray-500">+ 新增類別</button>
+        </div>
+      </section>
+
+      <!-- AI 引擎設定（PRD-F-013） -->
+      <section id="ai-engine" class="p-lg px-2xl" aria-label="AI 引擎設定">
+        <div class="text-xs font-semibold text-gray-500 mb-md uppercase tracking-wider">AI 引擎（PRD-F-013）</div>
+        <div class="grid grid-cols-2 gap-md mb-md">
+          <button class="h-14 rounded-lg border-2 border-gray-500 bg-gray-100 flex items-center justify-center gap-1 relative" aria-pressed="true">
+            <span class="absolute top-1 right-1 text-xs text-gray-700">✓</span>
+            <span class="text-sm">✨</span>
+            <span class="text-xs font-semibold text-gray-800">Gemini</span>
+          </button>
+          <button class="h-14 rounded-lg border border-gray-200 bg-white flex items-center justify-center gap-1">
+            <span class="text-sm">🤖</span>
+            <span class="text-xs text-gray-500">OpenAI</span>
+          </button>
+        </div>
+        <div class="space-y-sm">
+          <label for="api-key" class="text-xs text-gray-500">API Key</label>
+          <div class="relative">
+            <input id="api-key" type="password" value="••••••••••••••••" class="w-full h-10 rounded-md border border-gray-200 px-lg pr-10 text-sm">
+            <button class="absolute right-2 top-1/2 -translate-y-1/2 w-6 h-6 flex items-center justify-center text-gray-400" aria-label="顯示/隱藏 API Key">👁️</button>
+          </div>
+          <div class="text-xs text-gray-500">狀態：<span class="text-gray-700">✅ 金鑰有效</span></div>
+        </div>
+      </section>
+
+      <!-- 其他設定 -->
+      <section id="other-settings" class="p-lg px-2xl" aria-label="其他設定">
+        <div class="text-xs font-semibold text-gray-500 mb-md uppercase tracking-wider">其他</div>
+        <div class="space-y-md">
+          <div class="flex items-center justify-between">
+            <span class="text-sm text-gray-700">幣別</span>
+            <span class="text-xs text-gray-500">TWD（新台幣）</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- 登出 -->
+      <section id="logout" class="p-lg px-2xl">
+        <button class="w-full h-11 rounded-md border border-gray-300 text-sm font-semibold text-gray-600">登出</button>
+      </section>
+
+    </main>
+
+    <!-- 底部 Tab Bar -->
+    <nav id="tab-bar" class="fixed bottom-0 left-0 right-0 max-w-md mx-auto h-14 bg-white border-t border-gray-200 flex" aria-label="底部導覽">
+      <button class="flex-1 flex flex-col items-center justify-center text-xs text-gray-400">
+        <span class="text-lg">🏠</span><span class="mt-0.5">首頁</span>
+      </button>
+      <button class="flex-1 flex flex-col items-center justify-center text-xs text-gray-400">
+        <span class="text-lg">📊</span><span class="mt-0.5">統計</span>
+      </button>
+      <button class="flex-1 flex flex-col items-center justify-center text-xs text-gray-400">
+        <span class="text-lg">📋</span><span class="mt-0.5">記錄</span>
+      </button>
+      <button class="flex-1 flex flex-col items-center justify-center text-xs text-gray-800" aria-current="page">
+        <span class="text-lg">⚙️</span><span class="mt-0.5">設定</span>
+        <div class="w-1 h-1 rounded-full bg-gray-800 mt-0.5"></div>
+      </button>
+    </nav>
+
+  </div>
+
+</body>
+</html>

--- a/docs/ui/stats.html
+++ b/docs/ui/stats.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="fidelity" content="wireframe">
+  <meta name="spec-ref" content="../01-6-UI_UX_Design.md#32-統計頁-stats">
+  <title>統計 - Vibe Money Book Wireframe</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            primary: '#9CA3AF',
+            'primary-light': '#F3F4F6',
+            'primary-dark': '#6B7280',
+          },
+          borderRadius: { 'sm': '8px', 'md': '12px', 'lg': '16px', 'xl': '20px' },
+          spacing: { 'xs': '4px', 'sm': '8px', 'md': '12px', 'lg': '16px', 'xl': '20px', '2xl': '24px' }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="bg-gray-100 min-h-screen font-sans text-gray-700">
+
+  <!-- 此為低保真 wireframe。實作以 01-6-UI_UX_Design.md §3.2 為權威。 -->
+
+  <div class="max-w-md mx-auto bg-white min-h-screen shadow-sm pb-20">
+
+    <!-- Header -->
+    <header id="header" class="h-14 border-b border-gray-200 flex items-center px-2xl bg-white">
+      <button class="w-8 h-8 flex items-center justify-center text-gray-500" aria-label="返回">←</button>
+      <h1 class="flex-1 text-center text-base font-semibold text-gray-800">統計</h1>
+      <div class="w-8"></div>
+    </header>
+
+    <main class="p-2xl space-y-lg">
+
+      <!-- 時間篩選列（Segmented Control） -->
+      <div id="time-filter" class="flex bg-gray-100 rounded-full p-1" role="tablist" aria-label="時間篩選">
+        <button class="flex-1 h-9 rounded-full text-xs text-gray-500" role="tab">本週</button>
+        <button class="flex-1 h-9 rounded-full bg-white shadow-sm text-xs font-semibold text-gray-800" role="tab" aria-selected="true">本月</button>
+        <button class="flex-1 h-9 rounded-full text-xs text-gray-500" role="tab">自訂</button>
+      </div>
+
+      <!-- 總支出摘要卡片 -->
+      <section id="summary-card" class="bg-white rounded-lg shadow-sm p-lg" aria-label="總支出摘要">
+        <div class="text-xs text-gray-500">本月總支出</div>
+        <div class="flex items-baseline justify-between mt-xs">
+          <div class="text-4xl font-bold text-gray-800">$12,580</div>
+          <div class="text-xs text-gray-500">/ $20,000</div>
+        </div>
+        <div class="h-2 bg-gray-200 rounded-full overflow-hidden mt-md">
+          <div class="h-full bg-gray-500 rounded-full" style="width: 63%"></div>
+        </div>
+      </section>
+
+      <!-- 消費分佈圓餅圖（wireframe 占位） -->
+      <section id="pie-chart" class="bg-white rounded-lg shadow-sm p-lg" aria-label="消費分佈">
+        <div class="text-sm font-semibold text-gray-800 mb-md">消費分佈</div>
+        <div class="flex flex-col items-center py-md">
+          <!-- Recharts PieChart 占位：wireframe 用虛線圓圈 -->
+          <div class="w-48 h-48 rounded-full border-4 border-dashed border-gray-300 flex items-center justify-center">
+            <div class="text-center">
+              <div class="text-xs text-gray-400">總金額</div>
+              <div class="text-xl font-bold text-gray-700 mt-1">$12,580</div>
+            </div>
+          </div>
+        </div>
+        <!-- 圖例 -->
+        <div class="flex flex-wrap gap-sm mt-md text-xs">
+          <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-gray-400"></span>飲食 40%</span>
+          <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-gray-500"></span>交通 15%</span>
+          <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-gray-600"></span>娛樂 20%</span>
+          <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-gray-300"></span>其他 25%</span>
+        </div>
+      </section>
+
+      <!-- 類別排行列表 -->
+      <section id="category-ranking" aria-label="類別排行">
+        <h2 class="text-sm font-semibold text-gray-800 mb-md">類別排行</h2>
+        <div class="bg-white rounded-lg divide-y divide-gray-100">
+          <div class="flex items-center gap-md p-md">
+            <div class="w-6 text-xs font-semibold text-gray-500">1</div>
+            <div class="flex-1 min-w-0">
+              <div class="flex justify-between items-baseline mb-1">
+                <span class="text-sm font-semibold text-gray-800">飲食</span>
+                <span class="text-sm text-gray-700">$5,032</span>
+              </div>
+              <div class="h-1.5 bg-gray-200 rounded-full overflow-hidden">
+                <div class="h-full bg-gray-500 rounded-full" style="width: 80%"></div>
+              </div>
+            </div>
+          </div>
+          <div class="flex items-center gap-md p-md">
+            <div class="w-6 text-xs font-semibold text-gray-500">2</div>
+            <div class="flex-1 min-w-0">
+              <div class="flex justify-between items-baseline mb-1">
+                <span class="text-sm font-semibold text-gray-800">娛樂</span>
+                <span class="text-sm text-gray-700">$2,516</span>
+              </div>
+              <div class="h-1.5 bg-gray-200 rounded-full overflow-hidden">
+                <div class="h-full bg-gray-500 rounded-full" style="width: 40%"></div>
+              </div>
+            </div>
+          </div>
+          <div class="flex items-center gap-md p-md">
+            <div class="w-6 text-xs font-semibold text-gray-500">3</div>
+            <div class="flex-1 min-w-0">
+              <div class="flex justify-between items-baseline mb-1">
+                <span class="text-sm font-semibold text-gray-800">交通</span>
+                <span class="text-sm text-gray-700">$1,887</span>
+              </div>
+              <div class="h-1.5 bg-gray-200 rounded-full overflow-hidden">
+                <div class="h-full bg-gray-500 rounded-full" style="width: 30%"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+    </main>
+
+    <!-- 底部 Tab Bar -->
+    <nav id="tab-bar" class="fixed bottom-0 left-0 right-0 max-w-md mx-auto h-14 bg-white border-t border-gray-200 flex" aria-label="底部導覽">
+      <button class="flex-1 flex flex-col items-center justify-center text-xs text-gray-400">
+        <span class="text-lg">🏠</span><span class="mt-0.5">首頁</span>
+      </button>
+      <button class="flex-1 flex flex-col items-center justify-center text-xs text-gray-800" aria-current="page">
+        <span class="text-lg">📊</span><span class="mt-0.5">統計</span>
+        <div class="w-1 h-1 rounded-full bg-gray-800 mt-0.5"></div>
+      </button>
+      <button class="flex-1 flex flex-col items-center justify-center text-xs text-gray-400">
+        <span class="text-lg">📋</span><span class="mt-0.5">記錄</span>
+      </button>
+      <button class="flex-1 flex flex-col items-center justify-center text-xs text-gray-400">
+        <span class="text-lg">⚙️</span><span class="mt-0.5">設定</span>
+      </button>
+    </nav>
+
+  </div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

補齊 `docs/` 以符合新版 `vibe-sdlc-spec` 技能規範：

- **新增 `docs/01-3-SDD.md` v1.0（首版）**
  - 從 SRD 抽離系統設計章節，內容涵蓋 M1–M7
  - 架構總覽（含 M7 四引擎架構圖：OpenAI/Gemini/Anthropic/xAI）
  - 技術棧選型決策、前後端目錄結構（含 `anthropicProvider` / `xaiProvider`）
  - 數據模型 ER 圖與索引（`users.ai_engine` 擴展為 4 供應商、新增 `ai_model` 欄位）
  - LLM 多引擎抽象層（PRD-F-013、F-017）含動態模型路由
  - i18n 架構、4 項 ADR、錯誤處理、快取、安全設計

- **新增 `docs/ui/` 6 個 HTML + Tailwind wireframes**
  - `home.html`、`stats.html`、`history.html`、`settings.html`、`login.html`、`register.html`
  - 每個含 `<meta name="fidelity">` 與 `<meta name="spec-ref">`、section 元素含 `id` 供 anchor link

- **`docs/01-6-UI_UX_Design.md` v1.1 → v1.2**
  - 為 §3.1 – §3.6 每個頁面章節補上視覺參考 link 與元件層級 anchor
  - 對齊 `vibe-sdlc-spec` UI/UX Writing Guidelines §9

## 相關 Issue

- Closes #209（UI wireframe 補完，完整達成驗收條件）
- Refs #208（SDD 首版已建立；SRD 內重複章節（§2 技術架構指導、§3 數據模型、§4 LLM 整合、§5 i18n）的清理重構將於後續獨立 PR 處理，避免此 PR 過大）

## Test plan

- [ ] 確認 `docs/01-3-SDD.md` 章節完整（§1-§10 + 版本修訂說明）
- [ ] 確認 `docs/ui/*.html` 共 6 檔且可於瀏覽器開啟（Tailwind CDN 正常載入）
- [ ] 確認 `docs/01-6-UI_UX_Design.md` §3.1-§3.6 視覺參考 link 可正確跳轉
- [ ] 確認 SDD 與 SRD 的 M7 引擎內容一致（ai_engine enum、ai_model 欄位、Provider 列表）