### PR TITLE
ci: 文件/技能類變更自動跳過 CI（paths-ignore）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,20 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '.claude/**'
+      - '**/*.md'
+      - '.gitignore'
+      - 'LICENSE'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '.claude/**'
+      - '**/*.md'
+      - '.gitignore'
+      - 'LICENSE'
 
 jobs:
   ci-backend:


### PR DESCRIPTION
## Summary

在 `.github/workflows/ci.yml` 的 `push` 與 `pull_request` trigger 加上 `paths-ignore`，當變更只涉及**純文件類路徑**時自動跳過整個 CI workflow。

### 跳過清單

| 路徑 | 用途 |
|------|------|
| `docs/**` | 規格文件（PRD、SRD、API Spec、Dev Plan、Docs Review Report 等） |
| `.claude/**` | Claude Code skills、agents、commands 設定 |
| `**/*.md` | 任意目錄下的 markdown 檔（README、CLAUDE.md、CHANGELOG 等） |
| `.gitignore` | Git 忽略設定 |
| `LICENSE` | 授權文件 |

### Why

現行 CI 包含 `ci-backend` + `ci-frontend` + `e2e`（docker-compose + Playwright），一次完整跑需 10~15 分鐘。純文件 PR 不會影響程式碼行為，跑 CI 純粹浪費 Actions 分鐘數與等待時間。

### 判斷規則（`paths-ignore` 語意）

- ✅ 只有當**所有**變更檔案都落在 `paths-ignore` 清單時才跳過
- ✅ 若 PR 同時包含文件與程式碼（例如 `docs/` + `backend/`），CI 仍會正常觸發
- ✅ 若 workflow 檔案本身被改（`.github/workflows/`），CI 會正常觸發（未列入 ignore）

### 安全性確認

- main 分支目前**無 branch protection** 設定 required status checks，因此直接用 `paths-ignore` **不會**造成 PR 卡在「永遠 pending」的問題
- 若未來加上 required checks，可改用 dummy success job 或 job-level `if` 條件保留綠勾

## Test plan

- [ ] 本 PR 本身改的是 `.github/workflows/ci.yml`，**不在** ignore 清單，CI 應正常觸發並通過
- [ ] 後續的純文件 PR（如 #211）若 rebase / 重推後應自動跳過 CI
- [ ] 如果發現漏掉哪些文件類路徑（例如 `/examples/**`），開追補 PR 修正

---

🔖 這是 #211 合併後的第二個 dogfooding：新的 `chore/main-agent/<date>-*` 短命分支模式。