### PR TITLE
docs(skills): 禁止儀表板顯示 dev/main-agent 的 ahead/behind 差距

### DIFF
--- a/.claude/skills/vibe-sdlc/skill.md
+++ b/.claude/skills/vibe-sdlc/skill.md
@@ -181,6 +181,8 @@ Vibe-SDLC 的 Phase 1 skill (/vibe-sdlc-spec) 具備空專案初始化能力，
 - **工作目錄乾淨**：執行 `git fetch origin && git reset --hard origin/dev/main-agent` 對齊遠端快照（**不要 rebase**）。儀表板僅讀取資料，不修改此分支歷史
 - **工作目錄有未提交變更**（⚠️ 異常：快照分支不該有未提交變更）：提示使用者並建議將變更搬移至 `chore/main-agent/<date>-*` 短命分支後再執行儀表板流程
 
+> **⛔ 禁止顯示 ahead/behind**：不得在儀表板或任何輸出中顯示 `dev/main-agent` 相對於 `main` 的 `ahead/behind` commit 數量。原因：快照分支每次 `main` 合入新 PR 後都會自動「落後」，這是設計上的預期行為，不是需要同步的警告；歷次實測中使用者會把 `behind: N` 誤讀為警告並反覆追問。若需要表達快照時效，**唯一允許**的方式是相對時間字串（如「2 小時前」），取得方式：`git log -1 --format='%cr' dev/main-agent`。詳見步驟 3 的「快照分支顯示規則」。
+
 #### 情境 B：當前在 `{main}` 分支（應避免）
 
 - **工作目錄乾淨**：執行 `git pull origin {main}` 後切回快照分支：`git checkout dev/main-agent && git reset --hard origin/dev/main-agent`
@@ -428,6 +430,26 @@ Tunnel 狀態獨立判定：
 - 「上次部署 commit」：比對目前正在運行的容器 image 與本地最新 commit，若無法取得容器資訊則顯示最近一次與部署相關的 commit（搜尋關鍵字：`deploy`, `部署`, `release`, `docker`, `tunnel`）
 - 公網端點：從 `docker-compose.yml` 的環境變數（如 `CORS_ORIGIN`、`VITE_API_BASE_URL`）或啟動腳本中解析；若無公網端點則省略該行
 - 健康檢查逾時設為 5 秒（`curl --max-time 5`）
+
+**快照分支顯示規則**（非常重要，違反會造成使用者困擾）：
+
+| 顯示類型 | 允許 | 原因 |
+|----------|:----:|------|
+| `dev/main-agent` vs `main` 的 `ahead/behind` commit 數量 | ❌ | 快照分支在 main 合入新 PR 後天生會「落後」，這是預期行為；顯示數字會被誤讀為「需要同步的警告」 |
+| 「dev/main-agent 落後 main N 個 commit」「需要 rebase」類語句 | ❌ | 誤導使用者，與 `/vibe-sdlc-status` 的設計合約衝突 |
+| `git rev-list --left-right --count origin/main...HEAD` 的原始輸出 | ❌ | 同上；這類數據對快照分支無意義 |
+| 相對時間字串的快照時效（如「2 小時前」「昨天」） | ✅ | 語意直觀，沒有「需要動作」的暗示 |
+| 最新的快照 commit hash + 時效 | ✅ | 作為「A-Main 上次工作的時間點」參考 |
+
+若需要在儀表板顯示快照時效，**在「Agent 活動」區塊底部**加一行（而非獨立區塊）：
+
+```
+│ 📸 A-Main 快照時效：{相對時間}（{short_hash}）
+```
+
+取得方式：`git log -1 --format='%cr %h' dev/main-agent`（範例輸出：`2 hours ago 7f7f32c`）。若快照時效超過 24 小時，可在 `建議下一步` 加一句「建議呼叫 `/vibe-sdlc-status` 刷新快照」，但**不得**呈現為警告。
+
+> 此規則同時適用於 Claude 在儀表板以外的自由輸出 —— 不要在任何地方把快照分支的 git ahead/behind 當成需要處理的狀態來報告。
 
 **同步 Dev Plan 狀態**
 


### PR DESCRIPTION
## Summary

/vibe-sdlc 儀表板**禁止**顯示 `dev/main-agent` 相對於 `main` 的 `ahead/behind` commit 數量，改用相對時間字串（如「2 小時前」）表達快照時效。

### Why

#211 已將 `dev/main-agent` 重構為 **A-Main 快照分支**（不承接工作 commit、歷史不保證線性）。此後該分支在 `main` 合入新 PR 時會**自動落後**，這是設計上的預期行為，不是需要同步的警告。

但儀表板輸出會把 `git rev-list --left-right --count origin/main...HEAD` 的結果直接顯示成：

```
📍 分支狀態
Main 關係：1 ahead / 3 behind
```

使用者會反覆把 `behind: N` 誤讀為警告，並追問「怎麼解決掉」。即使附上解釋文字，每次新 PR 合併後數字就會跳動，感覺像一個永遠修不完的錯誤。

## 變更內容

修改 `.claude/skills/vibe-sdlc/skill.md` 兩處：

### 1. 步驟 0 情境 A — 新增禁令註解

在 \`情境 A：當前在 dev/main-agent（快照分支，正常狀態）\` 的兩個 bullet 之後加上 \`⛔ 禁止顯示 ahead/behind\` 註解，說明原因與唯一允許的替代方案。

### 2. 步驟 3 — 新增「快照分支顯示規則」表格

在「部署現況區塊規則」後加入新子章節，列出 ❌ 禁止顯示 / ✅ 允許顯示的類型：

| 顯示類型 | 允許 | 原因 |
|----------|:----:|------|
| ahead/behind commit 數量 | ❌ | 會被誤讀為警告 |
| 「落後」「需要 rebase」類語句 | ❌ | 與 \`/vibe-sdlc-status\` 設計合約衝突 |
| \`git rev-list\` 原始輸出 | ❌ | 對快照分支無意義 |
| 相對時間字串（「2 小時前」） | ✅ | 語意直觀 |
| 快照 commit hash + 時效 | ✅ | 作為「A-Main 上次工作時間點」參考 |

並提供可選的儀表板顯示格式：

\`\`\`
│ 📸 A-Main 快照時效：{相對時間}（{short_hash}）
\`\`\`

取得方式：\`git log -1 --format='%cr %h' dev/main-agent\`

### 明確聲明

新規則**同時適用於 Claude 在儀表板以外的自由輸出** — 不要在任何地方把快照分支的 git ahead/behind 當成需要處理的狀態來報告。

## Test plan

- [ ] 本 PR 本身只改 \`.claude/skills/**\`，屬 #212 \`paths-ignore\` 範圍，**CI 應自動跳過**（這也是 #212 的首次 dogfooding 驗證）
- [ ] 下個新 session 啟動後呼叫 /vibe-sdlc，確認輸出不再包含「1 ahead / N behind」類語句
- [ ] 若需要顯示快照時效，改用 \`📸 A-Main 快照時效：X 小時前\` 格式

---

🔖 這是 Vibe-SDLC skill 的 UX 精煉 — 把 #211 建立的快照分支設計合約落實到輸出層。